### PR TITLE
small Makefile change to allow packaging

### DIFF
--- a/addons/Makefile.include.am
+++ b/addons/Makefile.include.am
@@ -36,8 +36,8 @@ zip: $(LIB)
 	cd @abs_top_srcdir@/addons/.build ; zip -9 -r @abs_top_srcdir@/addons/$(ADDONNAME)-@OS@-@ARCHITECTURE@.zip $(ADDONNAME)
 
 install: $(LIB)
-	mkdir -p $(prefix)
-	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon $(prefix)/$(ADDONNAME)
+	mkdir -p $(DESTDIR)$(prefix)
+	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon $(DESTDIR)$(prefix)/$(ADDONNAME)
 
 all: $(LIB)
 


### PR DESCRIPTION
this is needed to override the prefix when packaging e.g. in fakeroot.
manual building is not affected, as $DESTDIR will be empty. Tested on ubuntu and launchpad.
