### PR TITLE
install binaries in lib/

### DIFF
--- a/addons/Makefile.include.am
+++ b/addons/Makefile.include.am
@@ -6,8 +6,6 @@ INCLUDES        = -I. -I$(abs_top_srcdir)/xbmc -I$(abs_top_srcdir)/lib @HOST_INC
 WARNINGS        = -Wall -Wextra -Wno-missing-field-initializers -Woverloaded-virtual -Wno-parentheses
 DEFINES         = @ARCH_DEFINES@ -DUSE_DEMUX -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS
 AM_CXXFLAGS     = -g -O2 -fPIC $(WARNINGS) $(DEFINES) @HOST_CXXFLAGS@
-LIBDIR		= $(libdir)/xbmc/addons
-DATADIR		= $(prefix)/share/xbmc/addons
 LIB             = @abs_top_srcdir@/addons/$(ADDONNAME)/addon/$(ADDONBINNAME).pvr
 
 clean:
@@ -36,13 +34,10 @@ zip: $(LIB)
 	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon @abs_top_srcdir@/addons/.build/$(ADDONNAME)
 	cd @abs_top_srcdir@/addons/.build ; zip -9 -r @abs_top_srcdir@/addons/$(ADDONNAME)-@OS@-@ARCHITECTURE@.zip $(ADDONNAME)
 
-install: $(LIB)
-	mkdir -p $(DESTDIR)$(prefix)
-	mkdir -p $(DESTDIR)$(LIBDIR)/$(ADDONNAME)
-	mkdir -p $(DESTDIR)$(DATADIR)/$(ADDONNAME)
-	cp -f $(ADDONBINNAME).pvr $(DESTDIR)$(LIBDIR)/$(ADDONNAME)
-	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon/* $(DESTDIR)$(DATADIR)/$(ADDONNAME)
-	rm $(DESTDIR)$(DATADIR)/$(ADDONNAME)/$(ADDONBINNAME).pvr
+install: @BUILD_TYPE@
+	mkdir -m 755 -p $(DESTDIR)@LIBDIR@/$(ADDONNAME)
+	mkdir -m 755 -p $(DESTDIR)@DATADIR@/$(ADDONNAME)
+	cp -f $(ADDONBINNAME).pvr $(DESTDIR)@LIBDIR@/$(ADDONNAME) ; chmod 655 $(DESTDIR)@LIBDIR@/$(ADDONNAME)/$(ADDONBINNAME).pvr
+	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon/* $(DESTDIR)@DATADIR@/$(ADDONNAME) ; chmod -R o+rx $(DESTDIR)@DATADIR@/$(ADDONNAME)
 
-all: $(LIB)
-
+all: @BUILD_TYPE@

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,8 @@ AC_CANONICAL_TARGET
 
 AM_INIT_AUTOMAKE(AC_PACKAGE_NAME, AC_PACKAGE_VERSION, [http://www.xbmc.org])
 
-AC_PREFIX_DEFAULT(/usr)
+PREFIX_DEFAULT="/usr"
+AC_PREFIX_DEFAULT(PREFIX_DEFAULT)
 
 AC_PROG_CXX
 AC_PROG_CPP
@@ -93,6 +94,25 @@ if test "x$use_libcurl" = "xyes"; then
 else
   AM_CONDITIONAL(USE_CURL, false)
 fi
+
+if test "x${libdir}" != 'x${exec_prefix}/lib'; then
+  LIBDIR=${libdir}
+elif test "$prefix" = "NONE"; then
+  LIBDIR=$PREFIX_DEFAULT/lib/xbmc/addons
+else
+  LIBDIR=$prefix/lib/xbmc/addons
+fi
+AC_SUBST(LIBDIR)
+
+if test "x${datadir}" != 'x${datarootdir}' && test "x${datarootdir}" = 'x${prefix}/share'; then
+  DATADIR=${datadir}
+elif test "$prefix" = "NONE"; then
+  DATADIR=$PREFIX_DEFAULT/share/xbmc/addons
+else
+  DATADIR=$prefix/share/xbmc/addons 
+fi
+AC_SUBST(DATADIR)
+
 
 AC_OUTPUT([Makefile
            lib/Makefile


### PR DESCRIPTION
pvr addon binaries should go to $prefix/lib/xbmc/addons, like other .so files from normal addons.
addon data still goes to $prefix/share/xbmc/addons

This is needed for packaging, as $prefix/share/xbmc/addons goes in the arch independent package with the standard xbmc packaging scripts and therefore no binaries are allowed.

tested on ubuntu 

edit: updated to honor --libdir and --datadir configure options. 
