### PR TITLE
configure: developer convenience - copy addons to xbmcs addons dir if building in xbmc tree

### DIFF
--- a/addons/Makefile.include.am
+++ b/addons/Makefile.include.am
@@ -10,6 +10,9 @@ LIB             = @abs_top_srcdir@/addons/$(ADDONNAME)/addon/$(ADDONBINNAME).pvr
 
 clean:
 	-rm -r -f $(LIB) $(ADDONBINNAME).pvr @abs_top_srcdir@/addons/$(ADDONNAME).@OS@-@ARCHITECTURE@.zip @abs_top_srcdir@/addons/.build/$(ADDONNAME) *.so *.lo *.o *.la *.a *.P *~
+if IS_INTREE_BUILD
+	rm -rf ../../../addons/$(ADDONNAME)
+endif
 
 release: $(lib_LTLIBRARIES)
 if HOST_IS_OSX
@@ -34,10 +37,23 @@ zip: $(LIB)
 	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon @abs_top_srcdir@/addons/.build/$(ADDONNAME)
 	cd @abs_top_srcdir@/addons/.build ; zip -9 -r @abs_top_srcdir@/addons/$(ADDONNAME)-@OS@-@ARCHITECTURE@.zip $(ADDONNAME)
 
+if IS_INTREE_BUILD
+install:
+	@echo "PVR-ADDONS: Leaving make install to xbmc"
+else
 install: @BUILD_TYPE@
 	mkdir -m 755 -p $(DESTDIR)@LIBDIR@/$(ADDONNAME)
 	mkdir -m 755 -p $(DESTDIR)@DATADIR@/$(ADDONNAME)
 	cp -f $(ADDONBINNAME).pvr $(DESTDIR)@LIBDIR@/$(ADDONNAME) ; chmod 655 $(DESTDIR)@LIBDIR@/$(ADDONNAME)/$(ADDONBINNAME).pvr
 	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon/* $(DESTDIR)@DATADIR@/$(ADDONNAME) ; chmod -R o+rx $(DESTDIR)@DATADIR@/$(ADDONNAME)
+endif
 
+if IS_INTREE_BUILD
 all: @BUILD_TYPE@
+	@echo "copying pvr-addons to xbmc/addons"
+	rm -rf ../../../addons/$(ADDONNAME)
+	cp -r -p -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon ../../../addons/$(ADDONNAME)
+	cp -f -p $(ADDONBINNAME).pvr ../../../addons/$(ADDONNAME)
+else
+all: @BUILD_TYPE@
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -69,10 +69,18 @@ case "${host}" in
     ;;
 esac
 
+### External libraries checks
+# Curl
 use_libcurl="no"
 PKG_CHECK_MODULES([CURL],[libcurl],use_libcurl="yes",AC_MSG_WARN("CURL was not found, N7 add-on will not be available"))
 
+### Check for Intree building
+checkpath=".."
+AC_CHECK_FILE([$checkpath/xbmc/xbmc.h], [AM_CONDITIONAL(IS_INTREE_BUILD, true) intree=true], [AM_CONDITIONAL(IS_INTREE_BUILD, false) intree=false])
+echo "Intree build: $intree"
+
 HOST_CXXFLAGS="-Wall -Wextra -Wno-missing-field-initializers -Woverloaded-virtual -Wno-parentheses -fPIC $HOST_CXXFLAGS"
+
 
 AC_SUBST(ARCHITECTURE)
 AC_SUBST(BUILD_TYPE)


### PR DESCRIPTION
As requested by @FernetMenta and others on IRC

Configure checks if the parent dir is the xbmc source directory(by looking for ../xbmc/xbmc.h).
If yes:
- copies the compiled addons to the xbmc/addons folder when doing make from the xbmc source tree.
- make install is handled by xbmc's make install
- make clean removes the addons from ..xbmc/addons/ 

building outside of xbmc should still work as before.
