### PR TITLE
fortherecord: fix live tv/recording playback on Windows

### DIFF
--- a/addons/pvr.fortherecord.argus/project/VS2010Express/pvr.fortherecord.argus.vcxproj
+++ b/addons/pvr.fortherecord.argus/project/VS2010Express/pvr.fortherecord.argus.vcxproj
@@ -51,7 +51,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\..\..\..\xbmc;..\..\..\..\lib;..\..\..\..\lib\jsoncpp\include;..\..\..\..\lib\platform\windows;..\..\src;..\..\..\..\project\BuildDependencies\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_WINDLL;TARGET_WINDOWS;_WINSOCKAPI_;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;TARGET_WINDOWS;TSREADER;_WINSOCKAPI_;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
@@ -67,7 +67,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\..\..\..\xbmc;..\..\..\..\lib;..\..\..\..\lib\jsoncpp\include;..\..\..\..\lib\platform\windows;..\..\src;..\..\..\..\project\BuildDependencies\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_WINDLL;TARGET_WINDOWS;_WINSOCKAPI_;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDLL;TARGET_WINDOWS;TSREADER;_WINSOCKAPI_;_USE_32BIT_TIME_T;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>


### PR DESCRIPTION
A required define (TSREADER) was missing on Windows.
I missed this change with my previous pull request.
