### PR TITLE
Fix downloading dependencies if there are whitespaces in the path.

### DIFF
--- a/project/BuildDependencies/DownloadBuildDeps.bat
+++ b/project/BuildDependencies/DownloadBuildDeps.bat
@@ -2,8 +2,8 @@
 
 SETLOCAL
 
-SET CUR_PATH=%CD%
-SET TMP_PATH=%CD%\scripts\tmp
+SET CUR_PATH="%CD%"
+SET TMP_PATH="%CD%\scripts\tmp"
 
 rem can't run rmdir and md back to back. access denied error otherwise.
 IF EXIST lib rmdir lib /S /Q

--- a/project/BuildDependencies/scripts/dlextract.bat
+++ b/project/BuildDependencies/scripts/dlextract.bat
@@ -5,15 +5,14 @@ echo --------------
 
 cd %DL_PATH%
 
-FOR /F "eol=; tokens=1,2" %%f IN (%2) DO (
-echo %%f %%g
+FOR /F "eol=; tokens=1,2" %%f IN ('type %2') DO (
   IF NOT EXIST %%f (
     %WGET% "%%g/%%f"
   ) ELSE (
     echo Already have %%f
   )
 
-  copy /b "%%f" "%TMP_PATH%"
+  copy /b %%f %TMP_PATH%
 )
 
 echo Extracting...
@@ -21,10 +20,10 @@ echo -------------
 
 cd %TMP_PATH%
 
-FOR /F "eol=; tokens=1,2" %%f IN (%2) DO (
+FOR /F "eol=; tokens=1,2" %%f IN ('type %2') DO (
   %ZIP% x %%f
 )
 
 FOR /F "tokens=*" %%f IN ('dir /B "*.tar"') DO (
   %ZIP% x -y %%f
-)
+) 2>nul

--- a/project/BuildDependencies/scripts/libcurl_d.bat
+++ b/project/BuildDependencies/scripts/libcurl_d.bat
@@ -1,13 +1,13 @@
 @ECHO OFF
 
-SET LOC_PATH=%CD%
-SET FILES=%LOC_PATH%\libcurl_d.txt
+SET LOC_PATH="%CD%"
+SET FILES="%CD%\libcurl_d.txt"
 
 CALL dlextract.bat libcurl %FILES%
 
 cd %TMP_PATH%
 
-xcopy curl-7.21.6-devel-mingw32\include\curl "%CUR_PATH%\include\curl" /E /Q /I /Y
-xcopy curl-7.21.6-devel-mingw32\lib\*.a "%CUR_PATH%\lib" /Y
+xcopy curl-7.21.6-devel-mingw32\include\curl %CUR_PATH%\include\curl /E /Q /I /Y
+xcopy curl-7.21.6-devel-mingw32\lib\*.a %CUR_PATH%\lib /Y
 
 cd %LOC_PATH%


### PR DESCRIPTION
I cloned the repository to a path with whitespaces in it, and the script failed. This fixes the issue by correctly using "".
