### PR TITLE
Two fixes (crashes on windows & compatibility with DM8000)

### DIFF
--- a/addons/pvr.vuplus/addon/addon.xml
+++ b/addons/pvr.vuplus/addon/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="0.3.3"
+  version="0.3.4"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>

--- a/addons/pvr.vuplus/addon/changelog.txt
+++ b/addons/pvr.vuplus/addon/changelog.txt
@@ -1,3 +1,7 @@
+0.3.4:
+- fix: several crashes on win32 due to missing locks / invalid memory access
+- fix: do not report connection problems when there is an empty TV-channel bouquet
+
 0.3.3:
 - add: support for storing the last played positions for recordings. These will be stored in the file recordings.xml
 - fix: if the webinterface cannot be loaded, deactivate the addon

--- a/addons/pvr.vuplus/src/VuData.h
+++ b/addons/pvr.vuplus/src/VuData.h
@@ -176,6 +176,8 @@ private:
   PLATFORM::CMutex m_mutex;
   PLATFORM::CCondition<bool> m_started;
 
+  bool m_bUpdating;
+
   // functions
   void StoreChannelData();
   void LoadChannelData();
@@ -200,8 +202,7 @@ private:
   bool CheckForGroupUpdate();
   bool CheckForChannelUpdate();
   std::string& Escape(std::string &s, std::string from, std::string to);
-  char toHex(const char& code);
-  CStdString URLEncodeInline(const CStdString&);
+  CStdString URLEncodeInline(const CStdString& sSrc);
 
 protected:
   virtual void *Process(void);


### PR DESCRIPTION
Hi Lars,

I know we are in feature freeze, so no new features anymore. Sorry for yesterday's PR.

Anyways, these two commits fix two problems that were reported to me:
1. There were several crashes on windows due to missing locks. I tested the fix myself and also one user on the xbmc forum tested it and confirmed that it works.
2. There is a difference in how VU+ Settop-Boxes and Dreambox handle TV Bouquets - which showed a logical error in the implementation. Before the fix, when the user had an empty bouquet configured on the box, the addon would report that the connection could not be established - the second commit fixes this.

Cheers,

Joerg
