### PR TITLE
vnsi: having no signal quality is no error

### DIFF
--- a/addons/pvr.vdr.vnsi/src/VNSIDemux.cpp
+++ b/addons/pvr.vdr.vnsi/src/VNSIDemux.cpp
@@ -181,7 +181,7 @@ bool cVNSIDemux::SwitchChannel(const PVR_CHANNEL &channelinfo)
 bool cVNSIDemux::GetSignalStatus(PVR_SIGNAL_STATUS &qualityinfo)
 {
   if (m_Quality.fe_name.empty())
-    return false;
+    return true;
 
   strncpy(qualityinfo.strAdapterName, m_Quality.fe_name.c_str(), sizeof(qualityinfo.strAdapterName));
   strncpy(qualityinfo.strAdapterStatus, m_Quality.fe_status.c_str(), sizeof(qualityinfo.strAdapterStatus));


### PR DESCRIPTION
finally those error logs have bothered me too much :)
Is it ok to change it here or do you want to change the API and make GetSignalStatus a void?
