### PR TITLE
[mythtv-cmyth] Release 0.5

### DIFF
--- a/addons/pvr.mythtv.cmyth/addon/addon.xml
+++ b/addons/pvr.mythtv.cmyth/addon/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv.cmyth"
-  version="0.4.0"
+  version="0.5.0"
   name="MythTV cmyth PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière, Tonny Petersen">
   <requires>
@@ -15,7 +15,7 @@
     library_windx="XBMC_MythTV_cmyth_win32.pvr"/>
   <extension point="xbmc.addon.metadata">
     <summary>XBMC frontend for MythTV (using libcmyth)</summary>
-    <description>MythTV frontend (up to MythTV 0.25). Supports streaming of Live TV &amp; Recordings, listening to Radio channels, EPG and Timers.</description>
+    <description>MythTV frontend (up to MythTV 0.26). Supports streaming of Live TV &amp; Recordings, listening to Radio channels, EPG and Timers.</description>
     <disclaimer>This is unstable software! The authors are in no way responsible for failed recordings, incorrect timers, wasted hours, or any other undesirable effects.</disclaimer>
     <platform>all</platform>
   </extension>

--- a/addons/pvr.mythtv.cmyth/addon/changelog.txt
+++ b/addons/pvr.mythtv.cmyth/addon/changelog.txt
@@ -1,8 +1,21 @@
+v0.5.0
+- Support MythTV 0.26 backends
+- Allow Timer Deletion
+- Support reconnecting to backend
+- Reworked LiveTV (no more stops at show end, fixed USB tuner support)
+- Performance improvements (adapted socket buffer sizes, removed unnecessary locks)
+- Stability improvements
+    - Fixed crash on SetRecordingPlayCount and SetRecordingLastPlayedPosition
+    - Fixed crash when addon was restarted
+    - Fixed crash when backend connection was lost
+    - Fixed memory leaks in libcmyth
+- Show correct start/end time in recordings- and timer view
+
 v0.4.0
 - OSX support
 
 v0.3.0
-- Transifex localizations (https://www.transifex.com/projects/p/pvrmythtvcmyth)
+- Transifex localizations
 - Support for recording images (icon, thumbnail, fanart)
 - Fixed: Preview images of new recordings were not cached
 

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.h
@@ -86,13 +86,12 @@ public:
 
   // Bookmarks
   long long GetBookmark(MythProgramInfo &recording);
-  int SetBookmark(MythProgramInfo &recording, long long bookmark);
+  bool SetBookmark(MythProgramInfo &recording, long long bookmark);
 
 private:
   boost::shared_ptr<MythPointerThreadSafe<cmyth_conn_t> > m_conn_t;
   CStdString m_server;
   unsigned short m_port;
-  int m_retryCount;
 
   MythEventHandler *m_pEventHandler;
 };

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythFile.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythFile.cpp
@@ -21,22 +21,6 @@
 #include "MythFile.h"
 #include "MythPointer.h"
 
-/* Call 'call', then if 'cond' condition is true see if we're still
- * connected to the control socket and try to re-connect if not.
- * If reconnection is ok, call 'call' again. */
-#define CMYTH_FILE_CALL(var, cond, call) m_conn.Lock(); \
-                                         var = call; \
-                                         m_conn.Unlock(); \
-                                         if (cond) \
-                                         { \
-                                           if (!m_conn.IsConnected() && m_conn.TryReconnect()) \
-                                           { \
-                                             m_conn.Lock(); \
-                                             var = call; \
-                                             m_conn.Unlock(); \
-                                           } \
-                                         } \
-
 MythFile::MythFile()
   : m_file_t(new MythPointer<cmyth_file_t>())
   , m_conn(MythConnection())
@@ -60,33 +44,34 @@ bool MythFile::IsNull() const
 unsigned long long MythFile::Length()
 {
   unsigned long long retval = 0;
-  CMYTH_FILE_CALL(retval, (long long)retval < 0, cmyth_file_length(*m_file_t));
+  retval = cmyth_file_length(*m_file_t);
   return retval;
 }
 
 void MythFile::UpdateLength(unsigned long long length)
 {
   int retval = 0;
-  CMYTH_FILE_CALL(retval, retval < 0, cmyth_update_file_length(*m_file_t, length));
+  retval = cmyth_update_file_length(*m_file_t, length);
+  (void)retval;
 }
 
 int MythFile::Read(void *buffer, unsigned long length)
 {
   int bytesRead;
-  CMYTH_FILE_CALL(bytesRead, bytesRead < 0, cmyth_file_read(*m_file_t, static_cast< char * >(buffer), length));
+  bytesRead = cmyth_file_read(*m_file_t, static_cast< char * >(buffer), length);
   return bytesRead;
 }
 
 long long MythFile::Seek(long long offset, int whence)
 {
   long long retval = 0;
-  CMYTH_FILE_CALL(retval, retval < 0, cmyth_file_seek(*m_file_t, offset, whence));
+  retval = cmyth_file_seek(*m_file_t, offset, whence);
   return retval;
 }
 
 unsigned long long MythFile::Position()
 {
   unsigned long long retval = 0;
-  CMYTH_FILE_CALL( retval, (long long)retval < 0, cmyth_file_position(*m_file_t));
+  retval = cmyth_file_position(*m_file_t);
   return retval;
 }

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythProgramInfo.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythProgramInfo.cpp
@@ -45,14 +45,14 @@ CStdString MythProgramInfo::StrUID()
   // Creates unique IDs from ChannelID, RecordID and StartTime like "100_200_2011-12-10T12:00:00"
   char buf[40] = "";
   sprintf(buf, "%d_%ld_", ChannelID(), RecordID());
-  time_t starttime = StartTime();
+  time_t starttime = RecordingStartTime();
   strftime(buf + strlen(buf), 20, "%Y-%m-%dT%H:%M:%S", localtime(&starttime));
   return CStdString(buf);
 }
 
 long long MythProgramInfo::UID()
 {
-  long long retval = RecStart();
+  long long retval = RecordingStartTime();
   retval <<= 32;
   retval += ChannelID();
   if (retval > 0)
@@ -180,9 +180,16 @@ unsigned long MythProgramInfo::RecordID()
   return cmyth_proginfo_recordid(*m_proginfo_t);
 }
 
-time_t MythProgramInfo::RecStart()
+time_t MythProgramInfo::RecordingStartTime()
 {
   MythTimestamp time = cmyth_proginfo_rec_start(*m_proginfo_t);
+  time_t retval(time.UnixTime());
+  return retval;
+}
+
+time_t MythProgramInfo::RecordingEndTime()
+{
+  MythTimestamp time = cmyth_proginfo_rec_end(*m_proginfo_t);
   time_t retval(time.UnixTime());
   return retval;
 }

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythProgramInfo.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythProgramInfo.h
@@ -61,7 +61,8 @@ public:
   RecordStatus Status();
   CStdString RecordingGroup();
   unsigned long RecordID();
-  time_t RecStart();
+  time_t RecordingStartTime();
+  time_t RecordingEndTime();
   int Priority();
 
 private:

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.h
@@ -41,6 +41,9 @@ public:
   MythRecorder(cmyth_recorder_t cmyth_recorder, const MythConnection &conn);
 
   bool IsNull() const;
+  void Lock();
+  void Unlock();
+
   int ID();
   MythProgramInfo GetCurrentProgram();
 

--- a/addons/pvr.mythtv.cmyth/src/fileOps.cpp
+++ b/addons/pvr.mythtv.cmyth/src/fileOps.cpp
@@ -226,7 +226,6 @@ void* FileOps::Process()
 
       if (g_bExtraDebug)
         XBMC->Log(LOG_DEBUG,"%s Job fetched: local: %s, remote: %s, storagegroup: %s", __FUNCTION__, job.m_localFilename.c_str(), job.m_remoteFilename.c_str(), job.m_storageGroup.c_str());
-      m_con.Lock();
 
       MythFile file = m_con.ConnectPath(job.m_remoteFilename, job.m_storageGroup);
       if (file.Length() > 0)
@@ -252,7 +251,6 @@ void* FileOps::Process()
         jobQueueDelayed.push_back(job);
       }
 
-      m_con.Unlock();
     }
 
     // Try to recache the currently empty files
@@ -316,7 +314,7 @@ bool FileOps::CacheFile(const CStdString &localFilename, MythFile &source)
   unsigned long long totalRead = 0;
   unsigned long long totalWrite = 0;
 
-  const long buffersize = 4096;
+  const long buffersize = 32768;
   char* buffer = new char[buffersize];
 
   while (totalRead < totalLength)

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -421,6 +421,15 @@ extern char* cmyth_conn_get_backend_hostname(cmyth_conn_t conn);
  * \retval ref counted string with client hostname
  */
 extern char* cmyth_conn_get_client_hostname(cmyth_conn_t conn);
+
+/**
+ * Issues a run of the re-scheduler
+ * \param conn connection handle
+ * \param recordid or -1 performs a full run
+ * \retval <0 for failure
+ */
+extern int cmyth_conn_reschedule_recordings(cmyth_conn_t conn, int recordid);
+
 /*
  * -----------------------------------------------------------------
  * Event Operations
@@ -605,12 +614,9 @@ extern long long cmyth_livetv_chain_duration(cmyth_recorder_t rec);
 
 extern int cmyth_livetv_chain_switch(cmyth_recorder_t rec, int dir);
 
-extern int cmyth_livetv_chain_switch_unlocked(cmyth_recorder_t rec, int dir);
-
 extern int cmyth_livetv_chain_switch_last(cmyth_recorder_t rec);
 
-extern int cmyth_livetv_chain_update(cmyth_recorder_t rec, char * chainid,
-						int tcp_rcvbuf);
+extern int cmyth_livetv_chain_update(cmyth_recorder_t rec, char * chainid);
 
 /* JLB: Manage program breaks */
 extern int cmyth_livetv_watch(cmyth_recorder_t rec, char * msg);
@@ -663,6 +669,8 @@ extern int cmyth_database_set_pass(cmyth_database_t db, char *pass);
 extern int cmyth_database_set_name(cmyth_database_t db, char *name);
 
 extern int cmyth_set_watched_status_mysql(cmyth_database_t db, cmyth_proginfo_t prog, int watchedStat);
+
+extern int cmyth_database_setup(cmyth_database_t db);
 
 /*
  * -----------------------------------------------------------------
@@ -1119,7 +1127,9 @@ extern int cmyth_file_read(cmyth_file_t file,
 			   char *buf,
 			   unsigned long len);
 
-extern int cmyth_file_data_conn_fd(cmyth_file_t file);
+extern int cmyth_file_is_open(cmyth_file_t file);
+
+extern int cmyth_file_set_timeout(cmyth_file_t file, int fast);
 
 /*
  * -----------------------------------------------------------------
@@ -1158,7 +1168,7 @@ extern cmyth_freespace_t cmyth_freespace_create(void);
  * -------
  */
 extern long long cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog);
-extern int cmyth_get_bookmark_offset(cmyth_database_t db, long chanid, long long mark, char *starttime, int mode);
+extern int cmyth_get_bookmark_offset(cmyth_database_t db, long chanid, long long mark, time_t starttime, int mode);
 extern int cmyth_update_bookmark_setting(cmyth_database_t, cmyth_proginfo_t);
 extern long long cmyth_get_bookmark_mark(cmyth_database_t, cmyth_proginfo_t, long long, int);
 extern int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog,
@@ -1212,7 +1222,17 @@ typedef struct cmyth_recgrougs {
 }cmyth_recgroups_t;
 
 extern int cmyth_mysql_get_recgroups(cmyth_database_t, cmyth_recgroups_t **);
+
+/**
+ * Run SQL query from param (backdoor)
+ * \deprecated alternative: cmyth_mysql_delete_timer
+ */
 extern int cmyth_mysql_delete_scheduled_recording(cmyth_database_t db, char * query);
+
+/**
+ * Run SQL query from param (backdoor)
+ * \deprecated alternative: cmyth_mysql_add_timer
+ */
 extern int cmyth_mysql_insert_into_record(cmyth_database_t db, char * query, char * query1, char * query2, char *title, char * subtitle, char * description, char * callsign);
 
 extern char* cmyth_get_recordid_mysql(cmyth_database_t, int, char *, char *, char *, char *, char *);
@@ -1222,9 +1242,15 @@ extern int cmyth_mysql_get_prog_finder_char_title(cmyth_database_t db, cmyth_pro
 extern int cmyth_mysql_get_prog_finder_time(cmyth_database_t db, cmyth_program_t **prog,  time_t starttime, char *program_name);
 extern int cmyth_mysql_get_guide(cmyth_database_t db, cmyth_program_t **prog, time_t starttime, time_t endtime);
 extern int cmyth_mysql_testdb_connection(cmyth_database_t db,char **message);
+
+/**
+ * Send control message from param (backdoor)
+ * \deprecated alternative: cmyth_conn_reschedule_recordings
+ */
 extern int cmyth_schedule_recording(cmyth_conn_t conn, char * msg);
+
 extern char * cmyth_mysql_escape_chars(cmyth_database_t db, char * string);
-extern int cmyth_mysql_get_commbreak_list(cmyth_database_t db, int chanid, char * start_ts_dt, cmyth_commbreaklist_t breaklist, int conn_version);
+extern int cmyth_mysql_get_commbreak_list(cmyth_database_t db, int chanid, time_t start_ts_dt, cmyth_commbreaklist_t breaklist, int conn_version);
 
 extern int cmyth_mysql_get_prev_recorded(cmyth_database_t db, cmyth_program_t **prog);
 

--- a/lib/cmyth/include/refmem/atomic.h
+++ b/lib/cmyth/include/refmem/atomic.h
@@ -24,20 +24,35 @@
 #pragma GCC optimization_level 0
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 #include <windows.h>
+#define inline __inline
 #endif
+
+#if defined __mips__
+#include <atomic.h>
+#endif
+
+#if defined(__APPLE__)
+#include <libkern/OSAtomic.h>
+
+typedef	volatile int32_t mvp_atomic_t;
+
+#define __mvp_atomic_increment(x)	OSAtomicIncrement32(x)
+#define __mvp_atomic_decrement(x)	OSAtomicDecrement32(x)
+#else
+typedef	volatile unsigned int mvp_atomic_t;
+
 /**
  * Atomically incremente a reference count variable.
  * \param valp address of atomic variable
  * \return incremented reference count
  */
-typedef	unsigned mvp_atomic_t;
 static inline unsigned
 __mvp_atomic_increment(mvp_atomic_t *valp)
 {
 	mvp_atomic_t __val;
-#if defined __i486__ || defined __i586__ || defined __i686__ || defined __x86_64__
+#if defined __i486__ || defined __i586__ || defined __i686__
 	__asm__ __volatile__(
 		"lock xaddl %0, (%1);"
 		"     inc   %0;"
@@ -45,8 +60,8 @@ __mvp_atomic_increment(mvp_atomic_t *valp)
 		: "r" (valp), "0" (0x1)
 		: "cc", "memory"
 		);
-#elif defined __i386__
-	asm volatile (".byte 0xf0, 0x0f, 0xc1, 0x02" /*lock; xaddl %eax, (%edx) */
+#elif defined __i386__ || defined __x86_64__
+	__asm__ volatile (".byte 0xf0, 0x0f, 0xc1, 0x02" /*lock; xaddl %eax, (%edx) */
 		      : "=a" (__val)
 		      : "0" (1), "m" (*valp), "d" (valp)
 		      : "memory");
@@ -63,17 +78,34 @@ __mvp_atomic_increment(mvp_atomic_t *valp)
 		      : "r" (valp)
 		      : "cc", "memory");
 #elif defined _MSC_VER
-  __val = InterlockedIncrement(valp);
-#else
+	__val = InterlockedIncrement(valp);
+#elif defined ANDROID
+	__val = __atomic_inc(valp) + 1;
+#elif defined __arm__ && !defined __thumb__
+	int tmp1, tmp2;
+	int inc = 1;
+	__asm__ __volatile__ (
+		"\n"
+		"0:"
+		"ldr     %0, [%3]\n"
+		"add     %1, %0, %4\n"
+		"swp     %2, %1, [%3]\n"
+		"cmp     %0, %2\n"
+		"swpne   %0, %2, [%3]\n"
+		"bne     0b\n"
+		: "=&r"(tmp1), "=&r"(__val), "=&r"(tmp2)
+		: "r" (valp), "r"(inc)
+		: "cc", "memory");
+#elif defined __mips__
+	__val = atomic_increment_val(valp);
+#elif defined __GNUC__
 	/*
 	 * Don't know how to atomic increment for a generic architecture
-	 * so punt and just increment the value.
+	 * so try to use GCC builtin
 	 */
-#ifdef _WIN32
-  #pragma message("unknown architecture, atomic increment is not...");
+	__val = __sync_add_and_fetch(valp,1);
 #else
-  #warning unknown architecture, atomic increment is not...
-#endif
+#warning unknown architecture, atomic increment is not...
 	__val = ++(*valp);
 #endif
 	return __val;
@@ -88,7 +120,7 @@ static inline unsigned
 __mvp_atomic_decrement(mvp_atomic_t *valp)
 {
 	mvp_atomic_t __val;
-#if defined __i486__ || defined __i586__ || defined __i686__ || defined __x86_64__
+#if defined __i486__ || defined __i586__ || defined __i686__
 	__asm__ __volatile__(
 		"lock xaddl %0, (%1);"
 		"     dec   %0;"
@@ -96,8 +128,8 @@ __mvp_atomic_decrement(mvp_atomic_t *valp)
 		: "r" (valp), "0" (-0x1)
 		: "cc", "memory"
 		);
-#elif defined __i386__
-	asm volatile (".byte 0xf0, 0x0f, 0xc1, 0x02" /*lock; xaddl %eax, (%edx) */
+#elif defined __i386__ || defined __x86_64__
+	__asm__ volatile (".byte 0xf0, 0x0f, 0xc1, 0x02" /*lock; xaddl %eax, (%edx) */
 		      : "=a" (__val)
 		      : "0" (-1), "m" (*valp), "d" (valp)
 		      : "memory");
@@ -113,6 +145,25 @@ __mvp_atomic_decrement(mvp_atomic_t *valp)
 		      : "=&r" (__val)
 		      : "r" (valp)
 		      : "cc", "memory");
+#elif defined ANDROID
+	__val = __atomic_dec(valp) - 1;
+#elif defined __arm__ && !defined __thumb__
+	int tmp1, tmp2;
+	int inc = -1;
+	__asm__ __volatile__ (
+		"\n"
+		"0:"
+		"ldr     %0, [%3]\n"
+		"add     %1, %0, %4\n"
+		"swp     %2, %1, [%3]\n"
+		"cmp     %0, %2\n"
+		"swpne   %0, %2, [%3]\n"
+		"bne     0b\n"
+		: "=&r"(tmp1), "=&r"(__val), "=&r"(tmp2)
+		: "r" (valp), "r"(inc)
+		: "cc", "memory");
+#elif defined __mips__
+	__val = atomic_decrement_val(valp);
 #elif defined __sparcv9__
 	mvp_atomic_t __newval, __oldval = (*valp);
 	do
@@ -126,21 +177,21 @@ __mvp_atomic_decrement(mvp_atomic_t *valp)
 	/*  The value for __val is in '__oldval' */
 	__val = __oldval;
 #elif defined _MSC_VER
-  __val = InterlockedDecrement(valp);
-#else
+	__val = InterlockedDecrement(valp);
+#elif defined __GNUC__
 	/*
 	 * Don't know how to atomic decrement for a generic architecture
-	 * so punt and just decrement the value.
+	 * so use GCC builtin
 	 */
-#ifdef _WIN32
-  #pragma message("unknown architecture, atomic decrement is not...");
+	__val = __sync_sub_and_fetch(valp,1);
 #else
-  #warning unknown architecture, atomic decrement is not...
-#endif
+#warning unknown architecture, atomic deccrement is not...
 	__val = --(*valp);
 #endif
 	return __val;
 }
+#endif
+
 #define mvp_atomic_inc __mvp_atomic_inc
 static inline int mvp_atomic_inc(mvp_atomic_t *a) {
 	return __mvp_atomic_increment(a);
@@ -159,6 +210,11 @@ static inline int mvp_atomic_dec_and_test(mvp_atomic_t *a) {
 #define mvp_atomic_set __mvp_atomic_set
 static inline void mvp_atomic_set(mvp_atomic_t *a, unsigned val) {
 	*a = val;
+};
+
+#define mvp_atomic_val __mvp_atomic_val
+static inline int mvp_atomic_val(mvp_atomic_t *a) {
+	return *a;
 };
 
 #ifdef __APPLE__

--- a/lib/cmyth/include/refmem/refmem.h
+++ b/lib/cmyth/include/refmem/refmem.h
@@ -24,11 +24,16 @@
 #ifndef __REFMEM_H
 #define __REFMEM_H
 
+#include "atomic.h"
+
 /*
  * -----------------------------------------------------------------
  * Types
  * -----------------------------------------------------------------
  */
+
+/* Return current number of references outstanding for everything */
+extern int ref_get_refcount();
 
 /**
  * Release a reference to allocated memory.
@@ -94,5 +99,32 @@ extern void ref_set_destroy(void *block, ref_destroy_t func);
  * Print allocation information to stdout.
  */
 extern void ref_alloc_show(void);
+
+/*
+ * Debug level constants used to determine the level of debug tracing
+ * to be done and the debug level of any given message.
+ */
+
+#define REF_DBG_NONE    -1
+#define REF_DBG_ERRORS   0
+#define REF_DBG_COUNTERS 1
+#define REF_DBG_DEBUG    2
+#define REF_DBG_ALL      3
+
+/**
+ * Set librefmem debug level.
+ * \param l debugging level (-1 for none, 3 for all)
+ */
+void refmem_dbg_level(int l);
+
+/**
+ * Enable all librefmem debugging.
+ */
+void refmem_dbg_all();
+
+/**
+ * Disable all librefmem debugging.
+ */
+void refmem_dbg_none();
 
 #endif /* __REFMEM_H */

--- a/lib/cmyth/libcmyth/bookmark.c
+++ b/lib/cmyth/libcmyth/bookmark.c
@@ -76,10 +76,7 @@ int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog, long long bookm
 {
 	char *buf;
 	unsigned int len = CMYTH_TIMESTAMP_LEN + CMYTH_LONGLONG_LEN * 2 + 18 + 2;
-	char resultstr[3];
-	int r,err;
 	int ret;
-	int count;
 	char start_ts_dt[CMYTH_TIMESTAMP_LEN + 1];
 	cmyth_datetime_to_string(start_ts_dt, prog->proginfo_rec_start_ts);
 	buf = alloca(len);
@@ -100,22 +97,16 @@ int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog, long long bookm
 				start_ts_dt, (int32_t)(bookmark >> 32), (int32_t)(bookmark & 0xffffffff));
 	}
 	pthread_mutex_lock(&mutex);
-	if ((err = cmyth_send_message(conn,buf)) < 0) {
+	if ((ret = cmyth_send_message(conn,buf)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_send_message() failed (%d)\n",
-			__FUNCTION__, err);
-		ret = err;
+			__FUNCTION__, ret);
 		goto out;
 	}
-	count = cmyth_rcv_length(conn);
-	if ((r=cmyth_rcv_string(conn,&err,resultstr,sizeof(resultstr),count)) < 0) {
-		cmyth_dbg(CMYTH_DBG_ERROR,
-			"%s: cmyth_rcv_string() failed (%d)\n",
-			__FUNCTION__, count);
-		ret = count;
-		goto out;
+	if ((ret = cmyth_rcv_okay(conn)) < 0) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: cmyth_rcv_okay() failed\n",
+			  __FUNCTION__);
 	}
-	ret = (strncmp(resultstr,"OK",2) == 0);
    out:
 	pthread_mutex_unlock(&mutex);
 	return ret;

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -281,10 +281,10 @@ cmyth_commbreaklist_t
 cmyth_mysql_get_commbreaklist(cmyth_database_t db, cmyth_conn_t conn, cmyth_proginfo_t prog)
 {
 	cmyth_commbreaklist_t breaklist = cmyth_commbreaklist_create();
-	char start_ts_dt[CMYTH_TIMESTAMP_LEN + 1];
+	time_t start_ts_dt;
 	int r;
 
-	cmyth_timestamp_to_display_string(start_ts_dt, prog->proginfo_rec_start_ts, 0);
+	start_ts_dt = cmyth_timestamp_to_unixtime(prog->proginfo_rec_start_ts);
 	pthread_mutex_lock(&mutex);
 	if ((r=cmyth_mysql_get_commbreak_list(db, prog->proginfo_chanId, start_ts_dt, breaklist, conn->conn_version)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,

--- a/lib/cmyth/libcmyth/mysql_query.c
+++ b/lib/cmyth/libcmyth/mysql_query.c
@@ -303,21 +303,29 @@ cmyth_mysql_query_param_uint(cmyth_mysql_query_t * query,int param)
  * Add, and convert a unixtime to mysql date/timestamp
  * \param query the query object
  * \param param the time to add
+ * \param tz_utc flag to convert local time to UTC time ( 1 = true | 0 = false )
  */
 int
-cmyth_mysql_query_param_unixtime(cmyth_mysql_query_t * query, time_t param)
+cmyth_mysql_query_param_unixtime(cmyth_mysql_query_t * query, time_t param, int tz_utc)
 {
     int ret;
     ret = query_begin_next_param(query);
     if(ret < 0)
 	return ret;
-    ret = query_buffer_add_str(query,"FROM_UNIXTIME(");
+    if (tz_utc == 1)
+        ret = query_buffer_add_str(query, "CONVERT_TZ(FROM_UNIXTIME(");
+    else
+        ret = query_buffer_add_str(query, "FROM_UNIXTIME(");
     if(ret < 0)
 	return ret;
     ret = query_buffer_add_long(query,(long)param);
     if(ret < 0)
 	return ret;
-    return query_buffer_add_str(query,")");
+    if (tz_utc == 1)
+
+        return query_buffer_add_str(query, "),'SYSTEM','UTC')");
+    else
+        return query_buffer_add_str(query, ")");
 }
 
 

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -1535,8 +1535,6 @@ cmyth_proginfo_fill(cmyth_conn_t control, cmyth_proginfo_t prog)
 	 */
 	if (prog->proginfo_Length == 0) {
 		prog->proginfo_Length = length;
-		ret = -1;
-		goto out;
 	}
 
 	ret = 0;

--- a/lib/cmyth/libcmyth/proglist.c
+++ b/lib/cmyth/libcmyth/proglist.c
@@ -321,7 +321,7 @@ cmyth_storagegroup_get_filelist(cmyth_conn_t control,char* storagegroup, char* h
 		cmyth_storagegroup_update_fileinfo(control,ret->storagegroup_filelist_list[i]);
 	}
 
-	cmyth_dbg(CMYTH_DBG_ERROR, "%s: results= %d\n", __FUNCTION__, res);
+	cmyth_dbg(CMYTH_DBG_DEBUG, "%s: results= %d\n", __FUNCTION__, res);
 
     out:
 	pthread_mutex_unlock(&mutex);

--- a/lib/cmyth/libcmyth/recorder.c
+++ b/lib/cmyth/libcmyth/recorder.c
@@ -497,7 +497,7 @@ cmyth_recorder_pause(cmyth_recorder_t rec)
 		goto err;
 	}
 
-	if ((ret=cmyth_rcv_okay(rec->rec_conn, "ok")) < 0) {
+	if ((ret=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: cmyth_rcv_okay() failed\n",
 			  __FUNCTION__);
 		goto err;
@@ -614,7 +614,7 @@ cmyth_recorder_change_channel(cmyth_recorder_t rec,
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "ok")) < 0) {
+	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -688,7 +688,7 @@ cmyth_recorder_set_channel(cmyth_recorder_t rec, char *channame)
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "ok")) < 0) {
+	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -884,9 +884,9 @@ cmyth_recorder_check_channel(cmyth_recorder_t rec,
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "1")) < 0) {
+	if ((err=cmyth_rcv_feedback(rec->rec_conn, "1")) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
-			  "%s: cmyth_rcv_okay() failed (%d)\n",
+			  "%s: cmyth_rcv_feedback() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto fail;
 	}
@@ -1355,7 +1355,7 @@ cmyth_recorder_spawn_livetv(cmyth_recorder_t rec)
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "ok")) < 0) {
+	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1414,7 +1414,7 @@ cmyth_recorder_spawn_chain_livetv(cmyth_recorder_t rec, char* channame)
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "ok")) < 0) {
+	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1458,7 +1458,7 @@ cmyth_recorder_stop_livetv(cmyth_recorder_t rec)
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "ok")) < 0) {
+	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1501,7 +1501,7 @@ cmyth_recorder_done_ringbuf(cmyth_recorder_t rec)
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn, "OK")) < 0) {
+	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);

--- a/lib/cmyth/libcmyth/timestamp.c
+++ b/lib/cmyth/libcmyth/timestamp.c
@@ -440,18 +440,9 @@ cmyth_datetime_to_string(char *str, cmyth_timestamp_t ts)
 	tm_datetime.tm_sec = ts->timestamp_second;
 	tm_datetime.tm_isdst = ts->timestamp_isdst;
 	t_datetime = mktime(&tm_datetime);
-	sprintf(str,
-		"%4.4ld-%2.2ld-%2.2ldT%2.2ld:%2.2ld:%2.2ld",
-		ts->timestamp_year,
-		ts->timestamp_month,
-		ts->timestamp_day,
-		ts->timestamp_hour,
-		ts->timestamp_minute,
-		ts->timestamp_second);
-	//cmyth_dbg(CMYTH_DBG_ERROR, "original timestamp string: %s \n",str);
+
 	sprintf(str,"%lu",(unsigned long) t_datetime);
-	//cmyth_dbg(CMYTH_DBG_ERROR, "time in seconds: %s \n",str);
-	
+
 	return 0;
 }
 

--- a/lib/cmyth/librefmem/refmem_local.h
+++ b/lib/cmyth/librefmem/refmem_local.h
@@ -1,20 +1,25 @@
+/*
+ *  Copyright (C) 2004-2012, Eric Lund, Jon Gettler
+ *  http://www.mvpmc.org/
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
 #ifndef __REFMEM_LOCAL_H
 #define __REFMEM_LOCAL_H
 
-/*
- * Debug level constants used to determine the level of debug tracing
- * to be done and the debug level of any given message.
- */
-
-#define REF_DBG_NONE  -1
-#define REF_DBG_DEBUG  0
-#define REF_DBG_ALL    0
-
-void refmem_dbg_level(int l);
-
-void refmem_dbg_all();
-
-void refmem_dbg_none();
-
 void refmem_dbg(int level, char *fmt, ...);
+
 #endif /* __REFMEM_LOCAL_H */


### PR DESCRIPTION
Hi Lars,

this PR updates the MythTV addon to version 0.5 - the version we'd like to have in Frodo.

This is mostly a bugfix release we've been hardworking to make the addon stable and less resource consuming. The biggest part is the rework of LiveTV in libcmyth where we had lots of problems. (now it's pretty close to MythFrontend)

The only 'new' thing is support for MythTV 0.26. This is only a minor change (MythTV database changed from localtime to UTC). It would be great to have it for Frodo because 0.26 was released in October and by the time Frodo is out it will probably be the version that is shipped with most distros.

The bugfixes and especially MythTV 0.26 support has been tested a lot during the last days and weeks by the devs and forum users. We also took the opportunity to test DST after October 30th.

Changelog:
- Support MythTV 0.26 backends
- Fixed Timer Deletion
- Support reconnecting to backend
- Reworked LiveTV (no more stops at show end, fixed USB tuner support)
- Performance improvements (adapted socket buffer sizes, removed unnecessary locks)
- Stability improvements
  - Fixed crash on SetRecordingPlayCount and SetRecordingLastPlayedPosition
  - Fixed crash when addon was restarted
  - Fixed crash when backend connection was lost
  - Fixed memory leaks in libcmyth
- Show correct start/end time in recordings- and timer view

Thanks,
Christian
