### PR TITLE
TVH recordings additions

### DIFF
--- a/addons/pvr.hts/Makefile.am
+++ b/addons/pvr.hts/Makefile.am
@@ -17,6 +17,7 @@ include ../Makefile.include.am
 libtvheadend_addon_la_SOURCES = src/client.cpp \
                                 src/HTSPConnection.cpp \
                                 src/HTSPData.cpp \
-                                src/HTSPDemux.cpp
+                                src/HTSPDemux.cpp \
+                                src/CircBuffer.cpp
 libtvheadend_addon_la_LDFLAGS = @TARGET_LDFLAGS@
 

--- a/addons/pvr.hts/src/CircBuffer.cpp
+++ b/addons/pvr.hts/src/CircBuffer.cpp
@@ -1,0 +1,128 @@
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "CircBuffer.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+CCircBuffer::CCircBuffer(void)
+  : m_buffer(NULL), m_alloc(0), m_size(0), m_count(0), m_pin(0), m_pout(0)
+{
+}
+
+CCircBuffer::~CCircBuffer(void)
+{
+  unalloc();
+}
+
+void CCircBuffer::alloc(size_t size)
+{
+  if (size > m_alloc) {
+    m_alloc  = size;
+    m_buffer = realloc(m_buffer, size);
+  }
+  m_size = size;
+  reset();
+}
+
+void CCircBuffer::unalloc(void)
+{
+  if(m_buffer)
+    ::free(m_buffer);
+
+  m_buffer = NULL;
+  m_alloc  = 0;
+  m_size   = 0;
+  reset();
+}
+
+void CCircBuffer::reset(void)
+{
+  m_pin   = 0;
+  m_pout  = 0;
+  m_count = 0;
+}
+
+size_t CCircBuffer::size(void) const
+{
+  return m_size;
+}
+
+size_t CCircBuffer::avail(void) const
+{
+  return m_count;
+}
+
+size_t CCircBuffer::free(void) const
+{
+  return m_size - m_count - 1;
+}
+
+ssize_t CCircBuffer::write(const void *data, size_t len)
+{
+  size_t pt1, pt2;
+  if (m_size < 2)
+    return -1;
+  if (len > free())
+    len = free();
+  if (m_pin < m_pout)
+    memcpy(m_buffer+m_pin, data, len);
+  else {
+    pt1 = m_size - m_pin;
+    if (len < pt1) {
+      pt1 = len;
+      pt2 = 0;
+    } else {
+      pt2 = len - pt1;
+    }
+    memcpy(m_buffer+m_pin, data, pt1);
+    memcpy(m_buffer, data+pt1, pt2);
+  }
+  m_pin    = (m_pin + len) % m_size;
+  m_count += len;
+  return len;
+}
+
+ssize_t CCircBuffer::read(void *data, size_t len)
+{
+  size_t pt1, pt2;
+  if (m_size < 2)
+    return -1;
+  if (len > avail())
+    len = avail();
+  if (m_pout < m_pin)
+    memcpy(data, m_buffer+m_pout, len);
+  else {
+    pt1 = m_size - m_pout;
+    if (len < pt1) {
+      pt1 = len;
+      pt2 = 0;
+    } else {
+      pt2 = len - pt1;
+    }
+    memcpy(data, m_buffer+m_pout, pt1);
+    memcpy(data+pt1, m_buffer, pt2);
+  }
+  m_pout   = ((m_pout + m_size) + len) % m_size;
+  m_count -= len;
+  return len;
+}

--- a/addons/pvr.hts/src/CircBuffer.h
+++ b/addons/pvr.hts/src/CircBuffer.h
@@ -1,0 +1,51 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2005-2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <sys/types.h>
+
+class CCircBuffer
+{
+public:
+  CCircBuffer    (void);
+  ~CCircBuffer   (void);
+
+  void    alloc   (size_t);
+  void    unalloc (void);
+  void    reset   (void);
+
+  size_t  size   (void) const;
+  size_t  avail  (void) const;
+  size_t  free   (void) const;
+
+  ssize_t write  (const void *data, size_t len);
+  ssize_t read   (void *data, size_t len);
+
+protected:
+  void*  m_buffer;
+  size_t m_alloc;
+  size_t m_size;
+  size_t m_count;
+  size_t m_pin;
+  size_t m_pout;
+
+};

--- a/addons/pvr.hts/src/HTSPConnection.cpp
+++ b/addons/pvr.hts/src/HTSPConnection.cpp
@@ -289,7 +289,7 @@ bool CHTSPConnection::SendGreeting(void)
   m = htsmsg_create_map();
   htsmsg_add_str(m, "method", "hello");
   htsmsg_add_str(m, "clientname", "XBMC Media Center");
-  htsmsg_add_u32(m, "htspversion", 6);
+  htsmsg_add_u32(m, "htspversion", 7);
 
   /* read welcome */
   if((m = ReadResult(m)) == NULL)

--- a/addons/pvr.hts/src/HTSPData.h
+++ b/addons/pvr.hts/src/HTSPData.h
@@ -24,6 +24,7 @@
 #include "client.h"
 #include "platform/threads/threads.h"
 #include "HTSPConnection.h"
+#include "CircBuffer.h"
 
 class CHTSResult
 {
@@ -127,5 +128,6 @@ private:
   bool                       m_bDisconnectWarningDisplayed;
   uint32_t                   m_recordingId;
   int64_t                    m_recordingOff;
+  CCircBuffer                m_recordingBuf;
 };
 

--- a/addons/pvr.hts/src/HTSPTypes.h
+++ b/addons/pvr.hts/src/HTSPTypes.h
@@ -174,6 +174,7 @@ struct SRecording
   uint32_t         start;
   uint32_t         stop;
   std::string      title;
+  std::string      path;
   std::string      description;
   ERecordingState  state;
   std::string      error;

--- a/addons/pvr.hts/src/client.cpp
+++ b/addons/pvr.hts/src/client.cpp
@@ -312,14 +312,15 @@ const char* GetMininumPVRAPIVersion(void)
 
 PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
 {
-  pCapabilities->bSupportsEPG             = true;
-  pCapabilities->bSupportsTV              = true;
-  pCapabilities->bSupportsRadio           = true;
-  pCapabilities->bSupportsRecordings      = true;
-  pCapabilities->bSupportsTimers          = true;
-  pCapabilities->bSupportsChannelGroups   = true;
-  pCapabilities->bHandlesInputStream      = true;
-  pCapabilities->bHandlesDemuxing         = true;
+  pCapabilities->bSupportsEPG              = true;
+  pCapabilities->bSupportsTV               = true;
+  pCapabilities->bSupportsRadio            = true;
+  pCapabilities->bSupportsRecordings       = true;
+  pCapabilities->bSupportsTimers           = true;
+  pCapabilities->bSupportsChannelGroups    = true;
+  pCapabilities->bHandlesInputStream       = true;
+  pCapabilities->bHandlesDemuxing          = true;
+  pCapabilities->bSupportsRecordingFolders = true;
   return PVR_ERROR_NO_ERROR;
 }
 


### PR DESCRIPTION
Added support for recordings being retrieved via HTSP (requires v7 server) rather than HTTP. This overcomes some of the limitations of HTTP in relation to in-progress recordings etc...

Added support for recordings folders (requires HTSP v7 capable server).

HTSP v7 is still WIP, but if anything changes I'll update.
