### PR TITLE
[pvr.hts] add timeshift period config to ensure tvh provides buffer.

### DIFF
--- a/addons/pvr.hts/src/HTSPDemux.cpp
+++ b/addons/pvr.hts/src/HTSPDemux.cpp
@@ -438,9 +438,10 @@ bool CHTSPDemux::SendUnsubscribe(int subscription)
 bool CHTSPDemux::SendSubscribe(int subscription, int channel)
 {
   htsmsg_t *m = htsmsg_create_map();
-  htsmsg_add_str(m, "method"        , "subscribe");
-  htsmsg_add_s32(m, "channelId"     , channel);
-  htsmsg_add_s32(m, "subscriptionId", subscription);
+  htsmsg_add_str(m, "method"         , "subscribe");
+  htsmsg_add_s32(m, "channelId"      , channel);
+  htsmsg_add_s32(m, "subscriptionId" , subscription);
+  htsmsg_add_u32(m, "timeshiftPeriod", (uint32_t)~0);
   return m_session->ReadSuccess(m, true, "subscribe to channel");
 }
 


### PR DESCRIPTION
This is a minor addition following our discussion on IRC. I have decided it will be even more confusing to put a config option in the addon settings since most people will not have access to the feature but this definitely will make it look like its there.

So I simply set the buffer period to unlimited (~0) and defer the limits to TVH.
