### PR TITLE
[droid] fix pvr.mythtv when linking against static mysql

### DIFF
--- a/addons/pvr.mythtv.cmyth/Makefile.am
+++ b/addons/pvr.mythtv.cmyth/Makefile.am
@@ -15,6 +15,7 @@ LIBS            = @abs_top_srcdir@/lib/cmyth/libcmyth.la
 AM_CPPFLAGS = -I$(abs_top_srcdir)/lib/cmyth/include
 
 include ../Makefile.include.am
+libmythtvcmyth_addon_la_LDFLAGS = $(MYSQL_LIBS) @TARGET_LDFLAGS@
 
 libmythtvcmyth_addon_la_SOURCES = src/client.cpp \
                                   src/fileOps.cpp \

--- a/lib/cmyth/libcmyth/Makefile.am
+++ b/lib/cmyth/libcmyth/Makefile.am
@@ -24,8 +24,6 @@ libcmyth_la_SOURCES = bookmark.c \
 
 INCLUDES=-I../include/ $(MYSQL_INCLUDES)
 
-AM_LDFLAGS = $(MYSQL_LIBS)
-
 $(LIB): libcmyth.la
 	cp -f .libs/libcmyth.a .
 	cp -f .libs/libcmyth.la $(LIB)


### PR DESCRIPTION
Fixes android build.

If all is static, the addon needs to link against mysql rather than libcmyth,
otherwise some symbols remain unresolved.

This should be more correct for dynamic linking as well.
