### PR TITLE
[vuplus]: Fix URL-Enconding when adding timers

### DIFF
--- a/addons/pvr.vuplus/addon/addon.xml.in
+++ b/addons/pvr.vuplus/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="1.6.3.4"
+  version="1.6.3.5"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>

--- a/addons/pvr.vuplus/addon/changelog.txt
+++ b/addons/pvr.vuplus/addon/changelog.txt
@@ -1,3 +1,6 @@
+0.3.5:
+- fix: URL encoding in timer-add operations
+
 0.3.4:
 - fix: several crashes on win32 due to missing locks / invalid memory access
 - fix: do not report connection problems when there is an empty TV-channel bouquet

--- a/addons/pvr.vuplus/src/VuData.cpp
+++ b/addons/pvr.vuplus/src/VuData.cpp
@@ -1407,9 +1407,9 @@ PVR_ERROR Vu::AddTimer(const PVR_TIMER &timer)
   CStdString strServiceReference = m_channels.at(timer.iClientChannelUid-1).strServiceReference.c_str();
 
   if (!g_strRecordingPath.compare(""))
-    strTmp.Format("web/timeradd?sRef=%s&repeated=%d&begin=%d&end=%d&name=%s&description=%s&eit=%d&dirname=&s", strServiceReference, timer.iWeekdays, timer.startTime, timer.endTime, URLEncodeInline(timer.strTitle), URLEncodeInline(timer.strSummary),timer.iEpgUid, URLEncodeInline(g_strRecordingPath));
+    strTmp.Format("web/timeradd?sRef=%s&repeated=%d&begin=%d&end=%d&name=%s&description=%s&eit=%d&dirname=&s", URLEncodeInline(strServiceReference), timer.iWeekdays, timer.startTime, timer.endTime, URLEncodeInline(timer.strTitle), URLEncodeInline(timer.strSummary),timer.iEpgUid, URLEncodeInline(g_strRecordingPath));
   else
-    strTmp.Format("web/timeradd?sRef=%s&repeated=%d&begin=%d&end=%d&name=%s&description=%s&eit=%d", strServiceReference, timer.iWeekdays, timer.startTime, timer.endTime, URLEncodeInline(timer.strTitle), URLEncodeInline(timer.strSummary),timer.iEpgUid);
+    strTmp.Format("web/timeradd?sRef=%s&repeated=%d&begin=%d&end=%d&name=%s&description=%s&eit=%d", URLEncodeInline(strServiceReference), timer.iWeekdays, timer.startTime, timer.endTime, URLEncodeInline(timer.strTitle), URLEncodeInline(timer.strSummary),timer.iEpgUid);
 
   CStdString strResult;
   if(!SendSimpleCommand(strTmp, strResult)) 


### PR DESCRIPTION
Hi Lars,

this one fixes a bug in the vuplus addon.

If a user wants to create a timer on a channel with special characters, then this will currently fail as this part is not properly URL encoded. This fix adds the url encoding to this part of the URL...
