### PR TITLE
[dvbviewer] Version 0.1.8

### DIFF
--- a/addons/pvr.dvbviewer/addon/addon.xml.in
+++ b/addons/pvr.dvbviewer/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.6.1.7"
+  version="1.6.1.8"
   name="DVBViewer Client"
   provider-name="jdembski, A600">
   <requires>

--- a/addons/pvr.dvbviewer/addon/changelog.txt
+++ b/addons/pvr.dvbviewer/addon/changelog.txt
@@ -1,3 +1,10 @@
+0.1.8
+
+[fixed] Changed the way timers are calculated. This should fix problems with scheduled and instant recordings on some machines.
+[fixed] Favourites didn't show channels if the audio track wasn't the first one.
+[fixed] Channel settings weren't saved/restored after a channel switch with the channels OSD.
+[fixed] XBMC could hang after a channel switch with the channels OSD.
+
 0.1.7
 
 [added] The Recording Service version 1.21 or higher is now required. Download the latest version from the DVBViewer members area and install it.

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -9,7 +9,6 @@
 #define ENCRYPTED_FLAG               (1 << 0)
 #define VIDEO_FLAG                   (1 << 3)
 #define ADDITIONAL_AUDIO_TRACK_FLAG  (1 << 7)
-#define DAY_MINS                     (24 * 60)
 #define DAY_SECS                     (24 * 60 * 60)
 #define DELPHI_DATE                  (25569)
 #define RECORDING_THUMB_POS          (143)
@@ -242,7 +241,8 @@ private:
   static bool GetBoolean(XMLNode xRootNode, const char* strTag, bool& bBoolValue);
   static bool GetString(XMLNode xRootNode, const char* strTag, CStdString& strStringValue);
   bool GetStringLng(XMLNode xRootNode, const char* strTag, CStdString& strStringValue);
-  CStdString GetPreferredLanguage();
+  void GetPreferredLanguage();
+  void GetTimeZone();
   void RemoveNullChars(CStdString &String);
   bool GetDeviceInfo();
 

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -275,7 +275,7 @@ PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES* pCapabilities)
   pCapabilities->bSupportsTimers          = true;
   pCapabilities->bSupportsChannelGroups   = true;
   pCapabilities->bSupportsChannelScan     = false;
-  pCapabilities->bHandlesInputStream      = true;
+  pCapabilities->bHandlesInputStream      = false;
   pCapabilities->bHandlesDemuxing         = false;
   pCapabilities->bSupportsLastPlayedPosition = false;
 


### PR DESCRIPTION
A couple of bug fixes:
- Use localtime instead of gmtime + timezone to generate the timers.
- Favourites didn't show channels if the audio track wasn't the first one.
- Changed bHandlesInputStream to false.
