### PR TITLE
Fix server plugin compilation against vdr-1.7.33

### DIFF
--- a/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/receiver.c
+++ b/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/receiver.c
@@ -592,7 +592,11 @@ void cLiveStreamer::Action(void)
       {
         patPmtParser.ParsePat(buf, TS_SIZE);
       }
+#if APIVERSNUM >= 10733
+      else if (patPmtParser.IsPmtPid(ts_pid))
+#else
       else if (ts_pid == patPmtParser.PmtPid())
+#endif
       {
         int patVersion, pmtVersion;
         patPmtParser.ParsePmt(buf, TS_SIZE);


### PR DESCRIPTION
As discussed on IRC, this fixes compilation against vdr-1.7.33 (from upstream changelog: "In order to be able to play TS recordings from other sources, in which there is more than one PMT PID in the PAT, 'int cPatPmtParser:atPmt(void)' has been changed to 'bool cPatPmtParser::IsPatPmt(int Pid)'.)
