### PR TITLE
[argustv-fix] Fixes the availability of pvr backend cannel numbers inside XBMC

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.6.150.144"
+  version="1.6.160.145"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,9 @@
+v1.6.160.145 (11-12-2012)
+- Support ARGUS TV channel numbers on XBMC, switch on:
+  Settings / Live-TV / General / 
+    "Use backend channels..." and 
+    "Always use the channel order..."
+- New version number by Team XBMC
 v1.0.150.144 (18-11-2012)
 - First ARGUS TV implementation
 - Support XBMC play count

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -374,7 +374,7 @@ PVR_ERROR cPVRClientArgusTV::GetEpg(ADDON_HANDLE handle, const PVR_CHANNEL &chan
             m_epg_id_offset++;
             broadcast.iUniqueBroadcastId  = m_epg_id_offset;
             broadcast.strTitle            = epg.Title();
-            broadcast.iChannelNumber      = channel.iChannelNumber;
+            broadcast.iChannelNumber      = channel.iUniqueId;
             broadcast.startTime           = epg.StartTime();
             broadcast.endTime             = epg.EndTime();
             broadcast.strPlotOutline      = epg.Subtitle();
@@ -492,14 +492,13 @@ PVR_ERROR cPVRClientArgusTV::GetChannels(ADDON_HANDLE handle, bool bRadio)
         //      But only if it isn't cached yet!
         if (FetchChannel(channel.Guid(), false) == NULL)
         {
-          tag.iChannelNumber =  m_channel_id_offset + 1;
+          tag.iUniqueId =  m_channel_id_offset + 1;
           m_channel_id_offset++;
         }
         else
         {
-          tag.iChannelNumber = FetchChannel(channel.Guid())->ID();
+          tag.iUniqueId = FetchChannel(channel.Guid())->ID();
         }
-        tag.iUniqueId = tag.iChannelNumber;
         strncpy(tag.strChannelName, channel.Name(), sizeof(tag.strChannelName));
         std::string logopath = ArgusTV::GetChannelLogo(channel.Guid()).c_str();
         strncpy(tag.strIconPath, logopath.c_str(), sizeof(tag.strIconPath));
@@ -509,14 +508,15 @@ PVR_ERROR cPVRClientArgusTV::GetChannels(ADDON_HANDLE handle, bool bRadio)
         //Use OpenLiveStream to read from the timeshift .ts file or an rtsp stream
         memset(tag.strStreamURL, 0, sizeof(tag.strStreamURL));
         strncpy(tag.strInputFormat, "video/x-mpegts", sizeof(tag.strInputFormat));
+        tag.iChannelNumber = channel.LCN();
 
         if (!tag.bIsRadio)
         {
-          XBMC->Log(LOG_DEBUG, "Found TV channel: %s\n", channel.Name());
+          XBMC->Log(LOG_DEBUG, "Found TV channel: %s, Unique id: %d, Backend channel: %d\n", channel.Name(), tag.iUniqueId, tag.iChannelNumber);
         }
         else
         {
-          XBMC->Log(LOG_DEBUG, "Found Radio channel: %s\n", channel.Name());
+          XBMC->Log(LOG_DEBUG, "Found Radio channel: %s, Unique id: %d, Backend channel: %d\n", channel.Name(), tag.iUniqueId, tag.iChannelNumber);
         }
         channel.SetID(tag.iUniqueId);
         if (FetchChannel(channel.Guid(), false) == NULL)
@@ -658,7 +658,7 @@ PVR_ERROR cPVRClientArgusTV::GetChannelGroupMembers(ADDON_HANDLE handle, const P
 
     strncpy(tag.strGroupName, group.strGroupName, sizeof(tag.strGroupName));
     tag.iChannelUniqueId = pChannel->ID();
-    tag.iChannelNumber   = index+1;
+    tag.iChannelNumber   = pChannel->LCN();
 
     XBMC->Log(LOG_DEBUG, "%s - add channel %s (%d) to group '%s' channel number %d",
       __FUNCTION__, pChannel->Name(), tag.iChannelUniqueId, tag.strGroupName, tag.iChannelNumber);


### PR DESCRIPTION
Finally fixes the availability of the backend channel numbers (LCN) within XBMC
