### PR TITLE
A couple of bug fixes

### DIFF
--- a/addons/pvr.dvbviewer/addon/addon.xml.in
+++ b/addons/pvr.dvbviewer/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.6.3"
+  version="1.6.4"
   name="DVBViewer Client"
   provider-name="jdembski, A600">
   <requires>

--- a/addons/pvr.dvbviewer/addon/changelog.txt
+++ b/addons/pvr.dvbviewer/addon/changelog.txt
@@ -1,3 +1,8 @@
+1.6.4
+
+[fixed] Use utf-8 encoding to get and set the timers.
+[fixed] Channel names with more than 25 chars could crash the add-on.
+
 1.6.3
 
 [updated] Language files from Transifex
@@ -23,7 +28,6 @@ New version number by Team XBMC
 [fixed] Channel names with ansi chars are converted to utf8 so they can be displayed properly (a reset of the PVR database may be required).
 [fixed] Channel names with more than 25 chars.
 
-
 0.1.5
 
 [added] Timers support.
@@ -35,7 +39,6 @@ New version number by Team XBMC
 [added] Receiving device name to the status info.
 [fixed] The preferred language is loaded from the DVBViewer config and used to get the correct EPG in case it supports multi language entries.
 [fixed] When the EPG is missing the description entry, the event entry is used instead.
-
 
 0.1.0
 

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -229,10 +229,12 @@ bool Dvb::LoadChannels()
     else
       channel_pos++;
 
-    if (strcmp(channel_group, channel->Category))
+    char channel_group_dat[26] = "";
+    strncpy(channel_group_dat, channel->Category, channel->Category_len);
+    if (strcmp(channel_group, channel_group_dat))
     {
       memset(channel_group, 0, sizeof(channel_group));
-      strncpy(channel_group, channel->Category, channel->Category_len);
+      strncpy(channel_group, channel_group_dat, channel->Category_len);
       char* strGroupNameUtf8 = XBMC->UnknownToUTF8(channel_group);
       datGroup.strGroupName = strGroupNameUtf8;
       groupsdat.push_back(datGroup);
@@ -258,12 +260,14 @@ bool Dvb::LoadChannels()
       {
         char channel_root[26] = "";
         CStdString strRoot = strncpy(channel_root, channel->Root, 25);
-        strChannelName.append(strRoot.substr(channel->Root_len + 1, channel->Root[channel->Root_len]));
+        if (channel->Root_len < 25)
+          strChannelName.append(strRoot.substr(channel->Root_len + 1, channel->Root[channel->Root_len]));
         if (channel->Category[channel->Category_len] > 0)
         {
           char channel_category[26] = "";
           CStdString strCategory = strncpy(channel_category, channel->Category, 25);
-          strChannelName.append(strCategory.substr(channel->Category_len + 1, channel->Category[channel->Category_len]));
+          if (channel->Category_len < 25)
+            strChannelName.append(strCategory.substr(channel->Category_len + 1, channel->Category[channel->Category_len]));
         }
       }
     }


### PR DESCRIPTION
- Use utf-8 encoding to get and set the timers.
- Channel names with more than 25 chars could crash the add-on.
