### PR TITLE
Add new setting for separate MySQL and MythTV backends

### DIFF
--- a/addons/pvr.mythtv.cmyth/addon/resources/language/English/strings.po
+++ b/addons/pvr.mythtv.cmyth/addon/resources/language/English/strings.po
@@ -49,3 +49,7 @@ msgstr ""
 msgctxt "#30007"
 msgid "Allow Live TV to move scheduled shows"
 msgstr ""
+
+msgctxt "#30008"
+msgid "MythTV MySql Database Hostname or IP"
+msgstr ""

--- a/addons/pvr.mythtv.cmyth/addon/resources/settings.xml
+++ b/addons/pvr.mythtv.cmyth/addon/resources/settings.xml
@@ -2,6 +2,7 @@
 <settings>
   <setting id="host" type="text" label="30000" default="127.0.0.1" />
   <setting id="port" type="number" label="30001" default="6543" />
+  <setting id="dbhost" type="text" label="30008" default="127.0.0.1" />
   <setting id="db_user" type="text" label="30002" default="mythtv" />
   <setting id="db_password" type="text" label="30003" default="mythtv" />
   <setting id="db_name" type="text" label="30004" default="mythconverg" />

--- a/addons/pvr.mythtv.cmyth/src/client.cpp
+++ b/addons/pvr.mythtv.cmyth/src/client.cpp
@@ -34,6 +34,7 @@ using namespace ADDON;
  * and exported to the other source files.
  */
 CStdString   g_szHostname             = DEFAULT_HOST;             ///< The Host name or IP of the mythtv server
+CStdString   g_szDBHostname           = DEFAULT_HOST;             ///< The Host name or IP of the mysql database server
 int          g_iMythPort              = DEFAULT_PORT;             ///< The mythtv Port (default is 6543)
 CStdString   g_szMythDBuser           = DEFAULT_DB_USER;          ///< The mythtv sql username (default is mythtv)
 CStdString   g_szMythDBpassword       = DEFAULT_DB_PASSWORD;      ///< The mythtv sql password (default is mythtv)
@@ -127,6 +128,17 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'host' setting, falling back to '%s' as default", DEFAULT_HOST);
     g_szHostname = DEFAULT_HOST;
+  }
+  buffer[0] = 0;
+  
+  /* Read setting "dbhost" from settings.xml */
+  if (XBMC->GetSetting("dbhost", buffer))
+    g_szDBHostname = buffer;
+  else
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'dbhost' setting, falling back to '%s' as default", DEFAULT_HOST);
+    g_szDBHostname = DEFAULT_HOST;
   }
   buffer[0] = 0;
 
@@ -279,6 +291,15 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     tmp_sHostname = g_szHostname;
     g_szHostname = (const char*)settingValue;
     if (tmp_sHostname != g_szHostname)
+      return ADDON_STATUS_NEED_RESTART;
+  }
+  else if (str == "dbhost")
+  {
+    string tmp_sHostname;
+    XBMC->Log(LOG_INFO, "Changed Setting 'host' from %s to %s", g_szDBHostname.c_str(), (const char*)settingValue);
+    tmp_sHostname = g_szDBHostname;
+    g_szDBHostname = (const char*)settingValue;
+    if (tmp_sHostname != g_szDBHostname)
       return ADDON_STATUS_NEED_RESTART;
   }
   else if (str == "port")

--- a/addons/pvr.mythtv.cmyth/src/client.h
+++ b/addons/pvr.mythtv.cmyth/src/client.h
@@ -62,6 +62,7 @@ extern CStdString   g_szClientPath;       ///< The Path where this driver is loc
 
 /* Client Settings */
 extern CStdString   g_szHostname;         ///< The Host name or IP of the mythtv server
+extern CStdString   g_szDBHostname;       ///< The Host name or IP of the mythtv mysql server
 extern int          g_iMythPort;          ///< The mythtv Port (default is 6543)
 extern CStdString   g_szMythDBuser;       ///< The mythtv sql username (default is mythtv)
 extern CStdString   g_szMythDBpassword;   ///< The mythtv sql password (default is mythtv)

--- a/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.cpp
+++ b/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.cpp
@@ -199,11 +199,11 @@ bool PVRClientMythTV::Connect()
 
   // Create database connection
   m_protocolVersion.Format("%i", m_con.GetProtocolVersion());
-  m_connectionString.Format("%s:%i", g_szHostname, g_iMythPort);
-  m_db = MythDatabase(g_szHostname, g_szMythDBname, g_szMythDBuser, g_szMythDBpassword);
+  m_connectionString.Format("%s:%i", g_szDBHostname, g_iMythPort);
+  m_db = MythDatabase(g_szDBHostname, g_szMythDBname, g_szMythDBuser, g_szMythDBpassword);
   if (m_db.IsNull())
   {
-    XBMC->QueueNotification(QUEUE_ERROR, "Failed to connect to MythTV MySQL database %s@%s %s/%s", g_szMythDBname.c_str(), g_szHostname.c_str(), g_szMythDBuser.c_str(), g_szMythDBpassword.c_str());
+    XBMC->QueueNotification(QUEUE_ERROR, "Failed to connect to MythTV MySQL database %s@%s %s/%s", g_szMythDBname.c_str(), g_szDBHostname.c_str(), g_szMythDBuser.c_str(), g_szMythDBpassword.c_str());
     return false;
   }
 
@@ -211,7 +211,7 @@ bool PVRClientMythTV::Connect()
   CStdString db_test;
   if (!m_db.TestConnection(&db_test))
   {
-    XBMC->QueueNotification(QUEUE_ERROR, "Failed to connect to MythTV MySQL database %s@%s %s/%s\n%s", g_szMythDBname.c_str(), g_szHostname.c_str(), g_szMythDBuser.c_str(), g_szMythDBpassword.c_str(), db_test.c_str());
+    XBMC->QueueNotification(QUEUE_ERROR, "Failed to connect to MythTV MySQL database %s@%s %s/%s\n%s", g_szMythDBname.c_str(), g_szDBHostname.c_str(), g_szMythDBuser.c_str(), g_szMythDBpassword.c_str(), db_test.c_str());
     return false;
   }
 


### PR DESCRIPTION
I have my MythTV database located on a separate machine, which is not a backend.
I am unable to connect to the MythTV backend because there is only a prompt for one IP address/hostname. The plugin assumes that they are both on the same machine, so the entered hostname is being used for both connections.

Here's a patch that adds a separate setting for the database connection. It needs translations still.
I'd like it in Frodo, but the backport is at your discretion.
