### PR TITLE
[tvheadend] make channel.radio to not reset to false during update if tvheadend not provided channel services

### DIFF
--- a/addons/pvr.hts/src/HTSPData.cpp
+++ b/addons/pvr.hts/src/HTSPData.cpp
@@ -912,7 +912,7 @@ void CHTSPData::ParseChannelUpdate(htsmsg_t* msg)
   }
 
   htsmsg_t *services;
-  bool bIsRadio(false);
+  bool bIsRadio = channel.radio;
   if((services = htsmsg_get_list(msg, "services")))
   {
     htsmsg_field_t *f;


### PR DESCRIPTION
According to https://www.lonelycoder.com/redmine/projects/tvheadend/wiki/Htsp

```
channelUpdate
Same as channelAdd, but all fields (except channelId) are optional.
```

This is per design, that on channel update, services can be not provided (I guess they will be provided only if changed).
In this case, without fix, all radio channels will become TV channels later or sooner.

My fix deals with that bug without altering overall logic we discussed in other PR.
