### PR TITLE
Image cache and webroot support

### DIFF
--- a/addons/pvr.hts/src/HTSPConnection.cpp
+++ b/addons/pvr.hts/src/HTSPConnection.cpp
@@ -47,7 +47,6 @@ CHTSResult::~CHTSResult(void)
     htsmsg_destroy(message);
 }
 
-
 string CHTSResult::GetErrorMessage(void)
 {
   if (m_strError.empty())
@@ -105,6 +104,32 @@ CHTSPConnection::~CHTSPConnection()
 
   delete m_socket;
   delete m_reconnect;
+}
+
+const CStdString CHTSPConnection::GetWebURL (const char *fmt, ...) const
+{
+  CStdString url;
+  CStdString auth;
+
+  /* Authentication */
+  if (!g_strUsername.empty()) {
+    auth = g_strUsername;
+    if (!g_strPassword.empty())
+      auth.AppendFormat(":%s", g_strPassword.c_str());
+    auth += "@";
+  } else {
+    auth = "";
+  }
+
+  /* URL root */
+  url.Format("http://%s%s:%i%s", auth.c_str(), g_strHostname.c_str(), g_iPortHTTP, m_strWebroot.c_str());
+
+  va_list args;
+  va_start(args, fmt);
+  url.AppendFormatV(fmt, args);
+  va_end(args);
+
+  return url;
 }
 
 void CHTSPConnection::SetReadTimeout(int iTimeout)

--- a/addons/pvr.hts/src/HTSPConnection.h
+++ b/addons/pvr.hts/src/HTSPConnection.h
@@ -101,6 +101,7 @@ public:
   const char *GetServerName() const { return m_strServerName.c_str(); }
   const char *GetVersion() const { return m_strVersion.c_str(); }
   const char *GetWebroot() const { return m_strWebroot.c_str(); }
+  const       CStdString GetWebURL(const char *fmt, ...) const;
 
   bool        TransmitMessage(htsmsg_t* m);
   void        ReadResult(htsmsg_t *m, CHTSResult &result, const char* strAction = NULL);

--- a/addons/pvr.hts/src/HTSPData.cpp
+++ b/addons/pvr.hts/src/HTSPData.cpp
@@ -306,7 +306,7 @@ PVR_ERROR CHTSPData::GetRecordings(ADDON_HANDLE handle)
   for(SRecordings::const_iterator it = recordings.begin(); it != recordings.end(); ++it)
   {
     SRecording recording = it->second;
-    CStdString strStreamURL = "http://";
+    CStdString strStreamURL;
     CStdString strRecordingId;
     CStdString strDirectory = "/";
     std::string strChannelName = "";
@@ -319,25 +319,12 @@ PVR_ERROR CHTSPData::GetRecordings(ADDON_HANDLE handle)
         strChannelName = itr->second.name.c_str();
 
       /* HTSPv7+ - use HTSP */
-      if (GetProtocol() >= 7) {
+      if (GetProtocol() >= 7)
         strStreamURL = "";
 
       /* HTSPv6- - use HTTP */
-      } else {
-        strStreamURL = "http://";
-
-        if (g_strUsername != "")
-        {
-          strStreamURL += g_strUsername;
-          if (g_strPassword != "")
-          {
-            strStreamURL += ":";
-            strStreamURL += g_strPassword;
-          }
-          strStreamURL += "@";
-        }
-        strStreamURL.Format("%s%s:%i%sdvrfile/%i", strStreamURL.c_str(), g_strHostname.c_str(), g_iPortHTTP, m_session->GetWebroot(), recording.id);
-      }
+      else
+        strStreamURL = m_session->GetWebURL("dvrfile/%i", recording.id);
     }
 
     strRecordingId.Format("%i", recording.id);
@@ -870,25 +857,10 @@ void CHTSPData::ParseChannelUpdate(htsmsg_t* msg)
     CStdString strIconURL;
 
     if (strIconPath[0] != '/' || strIconPath[0] == '\0')
-    {
       strIconURL = strIconPath;
-    }
     else
-    {
-      strIconURL = "http://";
+      strIconURL = m_session->GetWebURL("%s", strIconPath);
 
-      if (g_strUsername != "")
-      {
-        strIconURL += g_strUsername;
-        if (g_strPassword != "")
-        {
-          strIconURL += ":";
-          strIconURL += g_strPassword;
-        }
-        strIconURL += "@";
-      }
-      strIconURL.Format("%s%s:%i%s%s", strIconURL.c_str(), g_strHostname.c_str(), g_iPortHTTP, m_session->GetWebroot(), strIconPath);
-    }
     if (channel.icon != strIconURL)
     {
       bChannelChanged = true;


### PR DESCRIPTION
This adds support for a couple of new optional features in TVH:
1. Webroot - allows TVH to server web pages from an alternative context, useful for those setting up TVH behind a rev proxy under a diff path.
2. Image cache - images (channel logos etc..) can now be cached by TVH. To keep things clean and consistent (since these images can also be accessed directly via HTSP) the URIs provided a relative to server root (without webroot). So HTSPv8 clients must prepend the protocol and server details.
