### PR TITLE
[tvheadend] expand dvr directories to full hierarchy.

### DIFF
--- a/addons/pvr.hts/src/HTSPData.cpp
+++ b/addons/pvr.hts/src/HTSPData.cpp
@@ -335,10 +335,9 @@ PVR_ERROR CHTSPData::GetRecordings(ADDON_HANDLE handle)
       if (idx == 0 || idx == std::string::npos) {
         strDirectory = "/";
       } else {
-        i = recording.path[0] == '/' ? 1 : 0;
-        strDirectory = recording.path.substr(i, idx - i);
-        strDirectory.Replace("/", " - ");
-        strDirectory = "/" + strDirectory;
+        strDirectory = recording.path.substr(0, idx);
+        if (strDirectory[0] != '/')
+          strDirectory = "/" + strDirectory;
       }
     }
 


### PR DESCRIPTION
Simplification of DVR directory list processing as I was wrong (no idea where I got that from!) that you could only have 1 directory.
