### PR TITLE
[tvheadend] remove missing files from recordings list.

### DIFF
--- a/addons/pvr.hts/src/HTSPData.cpp
+++ b/addons/pvr.hts/src/HTSPData.cpp
@@ -1027,10 +1027,18 @@ void CHTSPData::ParseDVREntryUpdate(htsmsg_t* msg)
     recording.error.clear();
   }
 
+  // Missing file (hide)
+  else if (recording.error == "File missing")
+  {
+    recording.state = ST_INVALID;
+    recording.error.clear();
+  }
+
+
 #if HTSP_DEBUGGING
-  XBMC->Log(LOG_DEBUG, "%s - id:%u, state:'%s', title:'%s', description: '%s'"
+  XBMC->Log(LOG_DEBUG, "%s - id:%u, state:'%s', title:'%s', description: '%s', error:'%s'"
       , __FUNCTION__, recording.id, state, recording.title.c_str()
-      , recording.description.c_str());
+      , recording.description.c_str(), recording.error.c_str());
 #endif
 
   m_recordings[recording.id] = recording;


### PR DESCRIPTION
This is admittedly a bit of a hack until I redo the DVR code, but it will at least make use of the new error state/msg output when TVH detects files are missing. Which certainly helps for those of us that purge our recordings files but keep the log around for a while.
