### PR TITLE
[tvheadend] ensure channel count is not cleared after succesful sub

### DIFF
--- a/addons/pvr.hts/src/HTSPDemux.cpp
+++ b/addons/pvr.hts/src/HTSPDemux.cpp
@@ -49,9 +49,10 @@ CHTSPDemux::~CHTSPDemux()
 
 bool CHTSPDemux::Open(const PVR_CHANNEL &channelinfo)
 {
-  m_channel        = channelinfo.iUniqueId;
-  m_bIsRadio       = channelinfo.bIsRadio;
-  m_bIsOpen        = false;
+  m_channel              = channelinfo.iUniqueId;
+  m_bIsRadio             = channelinfo.bIsRadio;
+  m_bIsOpen              = false;
+  m_Streams.iStreamCount = 0;
 
   if(!m_session->CheckConnection(g_iConnectTimeout * 1000))
     return false;
@@ -59,7 +60,6 @@ bool CHTSPDemux::Open(const PVR_CHANNEL &channelinfo)
   if(!SendSubscribe(++m_subs, m_channel))
     return false;
 
-  m_Streams.iStreamCount = 0;
   m_bIsOpen              = true;
   return m_bIsOpen;
 }


### PR DESCRIPTION
This is particularly apparent for already subscribed multiplexes
where the subscriptionStart message comes back very quickly (possibly
even before the response to subscribe). Thus meaning the channel
count has been setup by the point SendSubscribe() exits and was
subsequently cleared.

This may explain some of the recent multi-client failures that have been reported.
