### PR TITLE
[argustv-fix] EPG data genre description now filled from ARGUS TV "Category"

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.6.163"
+  version="1.6.164"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.6.164 (18-01-2013)
+- EPG genre will contain the ARGUS TV "Category" string.
 v1.6.163 (01-01-2013)
 - Updated language files from Transifex
 v1.6.162 (15-12-2012)

--- a/addons/pvr.argustv/src/epg.cpp
+++ b/addons/pvr.argustv/src/epg.cpp
@@ -44,6 +44,7 @@ void cEpg::Reset()
   m_title.clear();
   m_subtitle.clear();
   m_description.clear();
+  m_genre.clear();
 
   m_starttime       = 0;
   m_endtime         = 0;
@@ -82,6 +83,7 @@ bool cEpg::Parse(const Json::Value& data)
       m_title = m_title + " (" + m_subtitle + ")";
     }
     m_description = data["Description"].asString();
+    m_genre = data["Category"].asString();
 
     // Dates are returned in a WCF compatible format ("/Date(9991231231+0100)/")
     std::string starttime = data["StartTime"].asString();

--- a/addons/pvr.argustv/src/epg.h
+++ b/addons/pvr.argustv/src/epg.h
@@ -34,6 +34,7 @@ private:
   std::string m_title;
   std::string m_subtitle;
   std::string m_description;
+  std::string m_genre;
   time_t m_starttime;
   time_t m_endtime;
   time_t m_utcdiff;
@@ -50,6 +51,7 @@ public:
   const char *Title(void) const { return m_title.c_str(); }
   const char *Subtitle(void) const { return m_subtitle.c_str(); }
   const char *Description(void) const { return m_description.c_str(); }
+  const char *Genre(void) const { return m_genre.c_str(); }
 };
 
 #endif //__EPG_H

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -380,9 +380,9 @@ PVR_ERROR cPVRClientArgusTV::GetEpg(ADDON_HANDLE handle, const PVR_CHANNEL &chan
             broadcast.strPlotOutline      = epg.Subtitle();
             broadcast.strPlot             = epg.Description();
             broadcast.strIconPath         = "";
-            broadcast.iGenreType          = 0;
+            broadcast.iGenreType          = EPG_GENRE_USE_STRING;
             broadcast.iGenreSubType       = 0;
-            broadcast.strGenreDescription = "";
+            broadcast.strGenreDescription = epg.Genre();
             broadcast.firstAired          = 0;
             broadcast.iParentalRating     = 0;
             broadcast.iStarRating         = 0;


### PR DESCRIPTION
This fixes the genre "Unknown/Other" displayed at the epg show details dialog.
