### PR TITLE
Prevent add-on from becoming disabled when connection fails

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.6.164"
+  version="1.6.165"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.6.165 (19-01-2013)
+- Do not disable the add-on when it can not connect to the ARGUS-TV server.
 v1.6.164 (18-01-2013)
 - EPG genre will contain the ARGUS TV "Category" string.
 v1.6.163 (01-01-2013)

--- a/addons/pvr.argustv/src/client.cpp
+++ b/addons/pvr.argustv/src/client.cpp
@@ -160,7 +160,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
     SAFE_DELETE(g_client);
     SAFE_DELETE(PVR);
     SAFE_DELETE(XBMC);
-    m_CurStatus = ADDON_STATUS_PERMANENT_FAILURE;
+    m_CurStatus = ADDON_STATUS_LOST_CONNECTION;
   }
   else
   {
@@ -186,14 +186,8 @@ void ADDON_Destroy()
     g_bCreated = false;
   }
 
-  if (PVR)
-  {
-    SAFE_DELETE(PVR);
-  }
-  if (XBMC)
-  {
-    SAFE_DELETE(XBMC);
-  }
+  SAFE_DELETE(PVR);
+  SAFE_DELETE(XBMC);
 
   m_CurStatus = ADDON_STATUS_UNKNOWN;
 }

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -116,9 +116,9 @@ bool cPVRClientArgusTV::Connect()
       default:
          XBMC->Log(LOG_ERROR, "Ping failed... No connection to Argus TV.\n");
          usleep(1000000);
-         if (attemps > 30)
+         if (attemps > 3)
          {
-           XBMC->QueueNotification(QUEUE_ERROR, "No connection to Argus TV");
+           XBMC->QueueNotification(QUEUE_ERROR, "No connection to Argus TV server");
            return false;
          }
     }


### PR DESCRIPTION
By request from da-anda.

[argustv-fix] If we can not connect to the pvr server at startup do not return ADDON_STATUS_PERMANENT_FAILURE as this causes the add-on to become disabled.
