### PR TITLE
[mythtv-cmyth] Release v1.6.9

### DIFF
--- a/addons/pvr.mythtv.cmyth/addon/addon.xml.in
+++ b/addons/pvr.mythtv.cmyth/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv.cmyth"
-  version="1.6.8"
+  version="1.6.9"
   name="MythTV cmyth PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière, Tonny Petersen">
   <requires>

--- a/addons/pvr.mythtv.cmyth/addon/changelog.txt
+++ b/addons/pvr.mythtv.cmyth/addon/changelog.txt
@@ -1,3 +1,8 @@
+v1.6.9
+- Added Live TV vs. recording conflict handling
+- Fixed recovering from backend connection loss on Windows
+- Fixed error when trying to set watched flag for recordings that already have been marked as watched
+
 v1.6.8
 - Performance improvements
     - Reduced startup time (Faster loading of EPG, channels, recordings and images)

--- a/addons/pvr.mythtv.cmyth/addon/resources/language/English/strings.po
+++ b/addons/pvr.mythtv.cmyth/addon/resources/language/English/strings.po
@@ -50,6 +50,22 @@ msgctxt "#30007"
 msgid "Allow Live TV to move scheduled shows"
 msgstr ""
 
+msgctxt "#30008"
+msgid "Conflict handling"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Prefer Live TV when recording has later slot"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Prefer recording and stop Live TV"
+msgstr ""
+
+msgctxt "#30011"
+msgid "Prefer Live TV and cancel conflicting recording"
+msgstr ""
+
 msgctxt "#30019"
 msgid "General"
 msgstr ""
@@ -142,4 +158,12 @@ msgstr ""
 
 msgctxt "#30306"
 msgid "Recorder unavailable"
+msgstr ""
+
+msgctxt "#30307"
+msgid "Canceling conflicting recording: %s"
+msgstr ""
+
+msgctxt "#30308"
+msgid "Stopping Live TV due to conflicting recording: %s"
 msgstr ""

--- a/addons/pvr.mythtv.cmyth/addon/resources/settings.xml
+++ b/addons/pvr.mythtv.cmyth/addon/resources/settings.xml
@@ -10,7 +10,8 @@
     <setting id="db_port" type="number" visible="false" default="3306" />
     <setting id="extradebug" type="bool" label="30005" default="false" />
     <setting id="livetv" type="bool" label="30006" default="true" />
-    <setting id="livetv_priority" type="bool" label="30007" default="false" />
+    <setting id="livetv_priority" type="bool" label="30007" default="true" />
+    <setting id="livetv_conflict_strategy" type="enum" label="30008" lvalues="30009|30010|30011" default="30009" />
   </category>
   <category label="30049">
     <setting id="rec_template_provider" type="enum" label="30020" lvalues="30021|30022" default="1" />

--- a/addons/pvr.mythtv.cmyth/src/client.cpp
+++ b/addons/pvr.mythtv.cmyth/src/client.cpp
@@ -31,34 +31,29 @@ using namespace ADDON;
  * Default values are defined inside client.h
  * and exported to the other source files.
  */
-CStdString   g_szMythHostname         = DEFAULT_HOST;             ///< The Host name or IP of the mythtv server
-int          g_iMythPort              = DEFAULT_PORT;             ///< The mythtv Port (default is 6543)
-CStdString   g_szDBUser               = DEFAULT_DB_USER;          ///< The mythtv sql username (default is mythtv)
-CStdString   g_szDBPassword           = DEFAULT_DB_PASSWORD;      ///< The mythtv sql password (default is mythtv)
-CStdString   g_szDBName               = DEFAULT_DB_NAME;          ///< The mythtv sql database name (default is mythconverg)
-CStdString   g_szDBHostname           = DEFAULT_HOST;             ///< The mythtv sql database host name or IP of the database server (default is same as mythtv backend hostname)
-int          g_iDBPort                = DEFAULT_DB_PORT;          ///< The mythtv sql database port (default is 3306)
-bool         g_bExtraDebug            = DEFAULT_EXTRA_DEBUG;      ///< Output extensive debug information to the log
-bool         g_bLiveTV                = DEFAULT_LIVETV;           ///< LiveTV support (or recordings only)
-bool         g_bLiveTVPriority        = DEFAULT_LIVETV_PRIORITY;  ///< MythTV Backend setting to allow live TV to move scheduled shows
-int          g_iRecTemplateType       = DEFAULT_RECORD_TEMPLATE;  ///< Template type for new record (0=Internal, 1=MythTV)
-bool         g_bRecAutoMetadata       = true;
-bool         g_bRecAutoCommFlag       = false;
-bool         g_bRecAutoTranscode      = false;
-bool         g_bRecAutoRunJob1        = false;
-bool         g_bRecAutoRunJob2        = false;
-bool         g_bRecAutoRunJob3        = false;
-bool         g_bRecAutoRunJob4        = false;
-bool         g_bRecAutoExpire         = false;
-int          g_iRecTranscoder         = 0;
+CStdString   g_szMythHostname          = DEFAULT_HOST;                     ///< The Host name or IP of the mythtv server
+int          g_iMythPort               = DEFAULT_PORT;                     ///< The mythtv Port (default is 6543)
+CStdString   g_szDBUser                = DEFAULT_DB_USER;                  ///< The mythtv sql username (default is mythtv)
+CStdString   g_szDBPassword            = DEFAULT_DB_PASSWORD;              ///< The mythtv sql password (default is mythtv)
+CStdString   g_szDBName                = DEFAULT_DB_NAME;                  ///< The mythtv sql database name (default is mythconverg)
+CStdString   g_szDBHostname            = DEFAULT_HOST;                     ///< The mythtv sql database host name or IP of the database server (default is same as mythtv backend hostname)
+int          g_iDBPort                 = DEFAULT_DB_PORT;                  ///< The mythtv sql database port (default is 3306)
+bool         g_bExtraDebug             = DEFAULT_EXTRA_DEBUG;              ///< Output extensive debug information to the log
+bool         g_bLiveTV                 = DEFAULT_LIVETV;                   ///< LiveTV support (or recordings only)
+bool         g_bLiveTVPriority         = DEFAULT_LIVETV_PRIORITY;          ///< MythTV Backend setting to allow live TV to move scheduled shows
+int          g_iLiveTVConflictStrategy = DEFAULT_LIVETV_CONFLICT_STRATEGY; ///< Conflict resolving strategy (0=
+int          g_iRecTemplateType        = DEFAULT_RECORD_TEMPLATE;          ///< Template type for new record (0=Internal, 1=MythTV)
+bool         g_bRecAutoMetadata        = true;
+bool         g_bRecAutoCommFlag        = false;
+bool         g_bRecAutoTranscode       = false;
+bool         g_bRecAutoRunJob1         = false;
+bool         g_bRecAutoRunJob2         = false;
+bool         g_bRecAutoRunJob3         = false;
+bool         g_bRecAutoRunJob4         = false;
+bool         g_bRecAutoExpire          = false;
+int          g_iRecTranscoder          = 0;
 
 ///* Client member variables */
-bool         m_recordingFirstRead;
-char         m_noSignalStreamData[6 + 0xffff];
-long         m_noSignalStreamSize     = 0;
-long         m_noSignalStreamReadPos  = 0;
-bool         m_bPlayingNoSignal       = false;
-int          m_iCurrentChannel        = 1;
 ADDON_STATUS m_CurStatus              = ADDON_STATUS_UNKNOWN;
 bool         g_bCreated               = false;
 int          g_iClientID              = -1;
@@ -218,6 +213,14 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     /* If setting is unknown fallback to defaults */
     XBMC->Log(LOG_ERROR, "Couldn't get 'livetv' setting, falling back to '%b' as default", DEFAULT_LIVETV);
     g_bLiveTV = DEFAULT_LIVETV;
+  }
+
+  /* Read settings "Record livetv_conflict_method" from settings.xml */
+  if (!XBMC->GetSetting("livetv_conflict_strategy", &g_iLiveTVConflictStrategy))
+  {
+    /* If setting is unknown fallback to defaults */
+    XBMC->Log(LOG_ERROR, "Couldn't get 'livetv_conflict_method' setting, falling back to '%i' as default", DEFAULT_RECORD_TEMPLATE);
+    g_iLiveTVConflictStrategy = DEFAULT_LIVETV_CONFLICT_STRATEGY;
   }
 
   /* Read settings "Record template" from settings.xml */

--- a/addons/pvr.mythtv.cmyth/src/client.h
+++ b/addons/pvr.mythtv.cmyth/src/client.h
@@ -36,16 +36,21 @@ extern "C" {
 #define strdup _strdup // # strdup is POSIX, _strdup should be used instead
 #endif
 
-#define DEFAULT_HOST            "127.0.0.1"
-#define DEFAULT_EXTRA_DEBUG     false
-#define DEFAULT_LIVETV_PRIORITY false
-#define DEFAULT_LIVETV          true
-#define DEFAULT_PORT            6543
-#define DEFAULT_DB_USER         "mythtv"
-#define DEFAULT_DB_PASSWORD     "mythtv"
-#define DEFAULT_DB_NAME         "mythconverg"
-#define DEFAULT_DB_PORT         3306
-#define DEFAULT_RECORD_TEMPLATE 1
+#define LIVETV_CONFLICT_STRATEGY_HASLATER  0
+#define LIVETV_CONFLICT_STRATEGY_STOPTV    1
+#define LIVETV_CONFLICT_STRATEGY_CANCELREC 2
+
+#define DEFAULT_HOST                       "127.0.0.1"
+#define DEFAULT_EXTRA_DEBUG                false
+#define DEFAULT_LIVETV_PRIORITY            true
+#define DEFAULT_LIVETV_CONFLICT_STRATEGY   LIVETV_CONFLICT_STRATEGY_HASLATER
+#define DEFAULT_LIVETV                     true
+#define DEFAULT_PORT                       6543
+#define DEFAULT_DB_USER                    "mythtv"
+#define DEFAULT_DB_PASSWORD                "mythtv"
+#define DEFAULT_DB_NAME                    "mythconverg"
+#define DEFAULT_DB_PORT                    3306
+#define DEFAULT_RECORD_TEMPLATE            1
 
 #define SUBTITLE_SEPARATOR " - "
 
@@ -59,23 +64,24 @@ extern "C" {
 #define SAFE_DELETE(p)       do { delete (p);     (p)=NULL; } while (0)
 #define SAFE_DELETE_ARRAY(p) do { delete[] (p);   (p)=NULL; } while (0)
 
-extern bool         g_bCreated;           ///< Shows that the Create function was successfully called
-extern int          g_iClientID;          ///< The PVR client ID used by XBMC for this driver
-extern CStdString   g_szUserPath;         ///< The Path to the user directory inside user profile
-extern CStdString   g_szClientPath;       ///< The Path where this driver is located
+extern bool         g_bCreated;                ///< Shows that the Create function was successfully called
+extern int          g_iClientID;               ///< The PVR client ID used by XBMC for this driver
+extern CStdString   g_szUserPath;              ///< The Path to the user directory inside user profile
+extern CStdString   g_szClientPath;            ///< The Path where this driver is located
 
 /* Client Settings */
-extern CStdString   g_szMythHostname;     ///< The Host name or IP of the mythtv server
-extern int          g_iMythPort;          ///< The mythtv Port (default is 6543)
-extern CStdString   g_szDBUser;           ///< The mythtv sql username (default is mythtv)
-extern CStdString   g_szDBPassword;       ///< The mythtv sql password (default is mythtv)
-extern CStdString   g_szDBName;           ///< The mythtv sql database name (default is mythconverg)
-extern CStdString   g_szDBHostname;       ///< The mythtv sql database host name or IP of the database server
-extern int          g_iDBPort;            ///< The mythtv sql database port (default is 3306)
-extern bool         g_bExtraDebug;        ///< Debug logging
-extern bool         g_bLiveTV;            ///< LiveTV support (or recordings only)
-extern bool         g_bLiveTVPriority;    ///< MythTV Backend setting to allow live TV to move scheduled shows
-extern int          g_iRecTemplateType;   ///< Template type for new record (0=Internal, 1=MythTV)
+extern CStdString   g_szMythHostname;          ///< The Host name or IP of the mythtv server
+extern int          g_iMythPort;               ///< The mythtv Port (default is 6543)
+extern CStdString   g_szDBUser;                ///< The mythtv sql username (default is mythtv)
+extern CStdString   g_szDBPassword;            ///< The mythtv sql password (default is mythtv)
+extern CStdString   g_szDBName;                ///< The mythtv sql database name (default is mythconverg)
+extern CStdString   g_szDBHostname;            ///< The mythtv sql database host name or IP of the database server
+extern int          g_iDBPort;                 ///< The mythtv sql database port (default is 3306)
+extern bool         g_bExtraDebug;             ///< Debug logging
+extern bool         g_bLiveTV;                 ///< LiveTV support (or recordings only)
+extern bool         g_bLiveTVPriority;         ///< MythTV Backend setting to allow live TV to move scheduled shows
+extern int          g_iLiveTVConflictStrategy; ///< Live TV conflict resolving strategy (0=Has later, 1=Stop TV, 2=Cancel recording)
+extern int          g_iRecTemplateType;        ///< Template type for new record (0=Internal, 1=MythTV)
 ///* Internal Record template */
 extern bool         g_bRecAutoMetadata;
 extern bool         g_bRecAutoCommFlag;

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.cpp
@@ -127,7 +127,7 @@ bool MythConnection::IsConnected()
 
 bool MythConnection::TryReconnect()
 {
-  int retval = false;
+  int retval;
   Lock();
   retval = cmyth_conn_reconnect_ctrl(*m_conn_t);
   Unlock();
@@ -222,8 +222,7 @@ ProgramInfoMap MythConnection::GetRecordedPrograms()
   int len = cmyth_proglist_get_count(proglist);
   for (int i = 0; i < len; i++)
   {
-    cmyth_proginfo_t cmprog = cmyth_proglist_get_item(proglist, i);
-    MythProgramInfo prog = cmyth_proginfo_get_detail(*m_conn_t, cmprog);
+    MythProgramInfo prog = cmyth_proglist_get_item(proglist, i);
     if (!prog.IsNull()) {
       retval.insert(std::pair<CStdString, MythProgramInfo>(prog.UID().c_str(), prog));
     }
@@ -297,8 +296,7 @@ ProgramInfoMap MythConnection::GetScheduledPrograms()
   int len = cmyth_proglist_get_count(proglist);
   for (int i = 0; i < len; i++)
   {
-    cmyth_proginfo_t cmprog = cmyth_proglist_get_item(proglist, i);
-    MythProgramInfo prog = cmyth_proginfo_get_detail(*m_conn_t, cmprog);
+    MythProgramInfo prog = cmyth_proglist_get_item(proglist, i);
     if (!prog.IsNull()) {
       retval.insert(std::pair<CStdString, MythProgramInfo>(prog.UID().c_str(), prog));
     }

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.cpp
@@ -66,6 +66,8 @@ public:
 
   virtual void* Process(void);
 
+  void HandleAskRecording(const CStdString &buffer, MythProgramInfo &programInfo);
+
   void HandleUpdateSignal(const CStdString &buffer);
 
   void SetRecordingEventListener(const CStdString &recordid, const MythFile &file);
@@ -80,6 +82,8 @@ public:
   unsigned short m_port;
 
   boost::shared_ptr<MythPointerThreadSafe<cmyth_conn_t> > m_conn_t;
+
+  MythEventObserver *m_observer;
 
   MythRecorder m_recorder;
   MythSignal m_signal;
@@ -98,6 +102,7 @@ MythEventHandler::MythEventHandlerPrivate::MythEventHandlerPrivate(const CStdStr
   , m_server(server)
   , m_port(port)
   , m_conn_t(new MythPointerThreadSafe<cmyth_conn_t>())
+  , m_observer(NULL)
   , m_recorder(MythRecorder())
   , m_signal()
   , m_playback(false)
@@ -218,6 +223,12 @@ void *MythEventHandler::MythEventHandlerPrivate::Process()
           if (g_bExtraDebug)
             XBMC->Log(LOG_NOTICE, "%s: Event DONE_RECORDING: No recorder", __FUNCTION__);
         Unlock();
+      }
+
+      else if (myth_event == CMYTH_EVENT_ASK_RECORDING)
+      {
+        MythProgramInfo prog(proginfo);
+        HandleAskRecording(databuf, prog);
       }
 
       else if (myth_event == CMYTH_EVENT_SIGNAL)
@@ -355,6 +366,44 @@ void MythEventHandler::MythEventHandlerPrivate::SetRecordingEventListener(const 
   m_currentRecordID = recordIDBuffer;
 }
 
+void MythEventHandler::MythEventHandlerPrivate::HandleAskRecording(const CStdString &databuf, MythProgramInfo &programInfo)
+{
+  // ASK_RECORDING <card id> <time until> <has rec> <has later>[]:[]<program info>
+  // Example: ASK_RECORDING 9 29 0 1[]:[]<program>
+
+  // The scheduled recording will hang in MythTV if ASK_RECORDING is just ignored.
+  // - Stop recorder (and blocked for time until seconds)
+  // - Skip the recording by sending CANCEL_NEXT_RECORDING(true)
+
+  unsigned int cardid;
+  int timeuntil, hasrec, haslater;
+  if (sscanf(databuf.c_str(), "%d %d %d %d", &cardid, &timeuntil, &hasrec, &haslater) == 4)
+    XBMC->Log(LOG_NOTICE, "%s: Event ASK_RECORDING: rec=%d timeuntil=%d hasrec=%d haslater=%d", __FUNCTION__, cardid, timeuntil, hasrec, haslater);
+  else
+    XBMC->Log(LOG_ERROR, "%s: Incorrect ASK_RECORDING event: rec=%d timeuntil=%d hasrec=%d haslater=%d", __FUNCTION__, cardid, timeuntil, hasrec, haslater);
+
+  CStdString title;
+  if (!programInfo.IsNull())
+    title = programInfo.Title();
+  XBMC->Log(LOG_NOTICE, "%s: Event ASK_RECORDING: title=%s", __FUNCTION__, title.c_str());
+
+  if (timeuntil >= 0 && !m_recorder.IsNull() && m_recorder.ID() == cardid)
+  {
+    if (g_iLiveTVConflictStrategy == LIVETV_CONFLICT_STRATEGY_CANCELREC ||
+      (g_iLiveTVConflictStrategy == LIVETV_CONFLICT_STRATEGY_HASLATER && haslater))
+    {
+      XBMC->QueueNotification(QUEUE_WARNING, XBMC->GetLocalizedString(30307), title.c_str()); // Canceling conflicting recording: %s
+      m_recorder.CancelNextRecording(true);
+    }
+    else // LIVETV_CONFLICT_STRATEGY_STOPTV
+    {
+      XBMC->QueueNotification(QUEUE_WARNING, XBMC->GetLocalizedString(30308), title.c_str()); // Stopping Live TV due to conflicting recording: %s
+      if (m_observer)
+        m_observer->CloseLiveStream();
+    }
+  }
+}
+
 void MythEventHandler::MythEventHandlerPrivate::HandleUpdateSignal(const CStdString &buffer)
 {
   // SIGNAL <card id> On known multiplex... or <tuner status list>
@@ -363,7 +412,7 @@ void MythEventHandler::MythEventHandlerPrivate::HandleUpdateSignal(const CStdStr
 
   std::vector<std::string> tokenList;
   tokenize<std::vector<std::string> >(buffer, tokenList, ";");
-  for (std::vector<std::string>::iterator it = tokenList.begin(); it != tokenList.end(); it++)
+  for (std::vector<std::string>::iterator it = tokenList.begin(); it != tokenList.end(); ++it)
   {
     std::vector<std::string> tokenList2;
     tokenize< std::vector<std::string> >(*it, tokenList2, " ");
@@ -448,15 +497,15 @@ void MythEventHandler::MythEventHandlerPrivate::RecordingListChange()
   PVR->TriggerRecordingUpdate();
 }
 
-MythEventHandler::MythEventHandler()
-  : m_imp()
-{
-}
-
 MythEventHandler::MythEventHandler(const CStdString &server, unsigned short port)
   : m_imp(new MythEventHandlerPrivate(server, port))
 {
   m_imp->CreateThread();
+}
+
+void MythEventHandler::RegisterObserver(MythEventObserver *observer)
+{
+  m_imp->m_observer = observer;
 }
 
 void MythEventHandler::PreventLiveChainUpdate()

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.h
@@ -38,11 +38,18 @@ class MythProgramInfo;
 
 template <class T> class MythPointer;
 
+class MythEventObserver
+{
+public:
+  // Request to stop Live TV
+  virtual void CloseLiveStream() = 0;
+};
+
 class MythEventHandler
 {
 public:
-  MythEventHandler();
   MythEventHandler(const CStdString &server, unsigned short port);
+  void RegisterObserver(MythEventObserver *observer);
 
   void PreventLiveChainUpdate();
   void AllowLiveChainUpdate();

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.cpp
@@ -91,6 +91,15 @@ bool MythRecorder::IsRecording()
   return retval == 1;
 }
 
+bool MythRecorder::CancelNextRecording(bool cancel)
+{
+  int retval = 0;
+  Lock();
+  retval = cmyth_recorder_cancel_next_recording(*m_recorder_t, cancel ? 1 : 0);
+  Unlock();
+  return retval == 1;
+}
+
 bool MythRecorder::IsTunable(MythChannel &channel)
 {
   Lock();

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.h
@@ -48,6 +48,7 @@ public:
   MythProgramInfo GetCurrentProgram();
 
   bool IsRecording();
+  bool CancelNextRecording(bool cancel);
   bool IsTunable(MythChannel &channel);
   bool CheckChannel(MythChannel &channel);
 

--- a/addons/pvr.mythtv.cmyth/src/fileOps.h
+++ b/addons/pvr.mythtv.cmyth/src/fileOps.h
@@ -82,7 +82,6 @@ public:
   }
 
   static const int c_timeoutProcess              = 10;       // Wake the thread every 10s
-  static const int c_timeoutCacheCleaning        = 60*60*24; // Clean the cache every 24h
   static const int c_maximumAttemptsOnReadError  = 3;        // Retry when reading file failed
 
   FileOps(MythConnection &mythConnection);
@@ -90,7 +89,7 @@ public:
 
   CStdString GetArtworkPath(const CStdString &remoteFilename, FileType fileType);
   CStdString GetChannelIconPath(const CStdString &remoteFilename);
-  CStdString GetPreviewIconPath(const CStdString &remoteFilename);
+  CStdString GetPreviewIconPath(const CStdString &remoteFilename, const CStdString &recordingGroup);
 
   void Suspend();
   void Resume();

--- a/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.cpp
+++ b/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.cpp
@@ -198,6 +198,7 @@ bool PVRClientMythTV::Connect()
     XBMC->QueueNotification(QUEUE_ERROR, XBMC->GetLocalizedString(30300));
     return false;
   }
+  m_pEventHandler->RegisterObserver(this);
 
   // Create database connection
   m_db = MythDatabase(g_szDBHostname, g_szDBName, g_szDBUser, g_szDBPassword, g_iDBPort);
@@ -467,7 +468,7 @@ int PVRClientMythTV::GetRecordingsAmount(void)
     XBMC->Log(LOG_DEBUG, "%s", __FUNCTION__);
 
   m_recordingsLock.Lock();
-  if (m_recordings.size() == 0)
+  if (m_recordings.empty())
     // Load recorings list
     res = FillRecordings();
   else
@@ -490,7 +491,7 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
     XBMC->Log(LOG_DEBUG, "%s", __FUNCTION__);
 
   m_recordingsLock.Lock();
-  if (m_recordings.size() == 0)
+  if (m_recordings.empty())
     // Load recorings list
     FillRecordings();
   else
@@ -533,7 +534,7 @@ PVR_ERROR PVRClientMythTV::GetRecordings(ADDON_HANDLE handle)
       if (!it->second.Coverart().IsEmpty())
         strIconPath = GetArtWork(FileOps::FileTypeCoverart, it->second.Coverart());
       else
-        strIconPath = m_fileOps->GetPreviewIconPath(it->second.IconPath());
+        strIconPath = m_fileOps->GetPreviewIconPath(it->second.IconPath(), it->second.RecordingGroup());
 
       CStdString strFanartPath;
       if (!it->second.Fanart().IsEmpty())
@@ -764,7 +765,6 @@ PVR_ERROR PVRClientMythTV::SetRecordingLastPlayedPosition(const PVR_RECORDING &r
 {
   // MythTV provides it's bookmarks as frame offsets whereas XBMC expects a time offset.
   // The frame offset is calculated by: frameOffset = bookmark * frameRate.
-  long long frameOffset = 0;
 
   if (g_bExtraDebug)
   {
@@ -779,7 +779,7 @@ PVR_ERROR PVRClientMythTV::SetRecordingLastPlayedPosition(const PVR_RECORDING &r
     if (it->second.Framterate() < 0)
       it->second.SetFramerate(m_db.GetRecordingFrameRate(it->second));
     // Calculate the frame offset
-    frameOffset = (long long)(lastplayedposition * it->second.Framterate() / 1000.0f);
+    long long frameOffset = (long long)(lastplayedposition * it->second.Framterate() / 1000.0f);
     if (frameOffset < 0) frameOffset = 0;
     if (g_bExtraDebug)
     {
@@ -878,13 +878,13 @@ PVR_ERROR PVRClientMythTV::GetTimers(ADDON_HANDLE handle)
   RecordingRuleMap rules = m_db.GetRecordingRules();
   m_recordingRules.clear();
 
-  for (RecordingRuleMap::iterator it = rules.begin(); it != rules.end(); it++)
+  for (RecordingRuleMap::iterator it = rules.begin(); it != rules.end(); ++it)
     m_recordingRules.push_back(it->second);
 
   //Search for modifiers and add links to them
-  for (RecordingRuleList::iterator it = m_recordingRules.begin(); it != m_recordingRules.end(); it++)
+  for (RecordingRuleList::iterator it = m_recordingRules.begin(); it != m_recordingRules.end(); ++it)
     if (it->Type() == MythRecordingRule::DontRecord || it->Type() == MythRecordingRule::OverrideRecord)
-      for (RecordingRuleList::iterator it2 = m_recordingRules.begin(); it2 != m_recordingRules.end(); it2++)
+      for (RecordingRuleList::iterator it2 = m_recordingRules.begin(); it2 != m_recordingRules.end(); ++it2)
         if (it2->Type() != MythRecordingRule::DontRecord && it2->Type() != MythRecordingRule::OverrideRecord)
           if (it->SameTimeslot(*it2) && !it->GetParent())
           {
@@ -893,7 +893,7 @@ PVR_ERROR PVRClientMythTV::GetTimers(ADDON_HANDLE handle)
           }
 
   ProgramInfoMap upcomingRecordings = m_con.GetPendingPrograms();
-  for (ProgramInfoMap::iterator it = upcomingRecordings.begin(); it != upcomingRecordings.end(); it++)
+  for (ProgramInfoMap::iterator it = upcomingRecordings.begin(); it != upcomingRecordings.end(); ++it)
   {
     // When deleting a timer from mythweb, it might happen that it's removed from database
     // but it's still present over mythprotocol. Skip those timers, because timers.at would crash.
@@ -1171,7 +1171,6 @@ PVR_ERROR PVRClientMythTV::UpdateTimer(const PVR_TIMER &timer)
     if (oldTimer.iClientChannelUid != timer.iClientChannelUid ||
       oldTimer.endTime != timer.endTime ||
       oldTimer.startTime != timer.startTime ||
-      oldTimer.startTime != timer.startTime ||
       strcmp(oldTimer.strTitle, timer.strTitle) ||
       timer.bIsRepeating
       )
@@ -1401,7 +1400,7 @@ bool PVRClientMythTV::SwitchChannel(const PVR_CHANNEL &channelinfo)
   if (g_bExtraDebug)
     XBMC->Log(LOG_DEBUG, "%s - chanID: %u", __FUNCTION__, channelinfo.iUniqueId);
 
-  bool retval = false;
+  bool retval;
 
   //Close current live stream for reopening
   //Keep playback mode enabled

--- a/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.h
+++ b/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.h
@@ -53,11 +53,11 @@ private:
 
 typedef std::vector<RecordingRule> RecordingRuleList;
 
-class PVRClientMythTV
+class PVRClientMythTV : public MythEventObserver
 {
 public:
   PVRClientMythTV();
-  ~PVRClientMythTV();
+  virtual ~PVRClientMythTV();
 
   // Server
   bool Connect();

--- a/lib/cmyth/Win32/libcmyth.vcxproj
+++ b/lib/cmyth/Win32/libcmyth.vcxproj
@@ -41,6 +41,7 @@
   <ItemGroup>
     <ClInclude Include="..\include\cmyth\cmyth.h" />
     <ClInclude Include="..\libcmyth\cmyth_local.h" />
+    <ClInclude Include="..\libcmyth\cmyth_msc.h" />
     <ClInclude Include="..\libcmyth\safe_string.h" />
     <ClInclude Include="..\librefmem\refmem_local.h" />
   </ItemGroup>

--- a/lib/cmyth/Win32/libcmyth.vcxproj.filters
+++ b/lib/cmyth/Win32/libcmyth.vcxproj.filters
@@ -102,5 +102,8 @@
     <ClInclude Include="..\librefmem\refmem_local.h">
       <Filter>refmem</Filter>
     </ClInclude>
+    <ClInclude Include="..\libcmyth\cmyth_msc.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -500,7 +500,13 @@ extern int cmyth_recorder_stop_playing(cmyth_recorder_t rec);
 
 extern int cmyth_recorder_frontend_ready(cmyth_recorder_t rec);
 
-extern int cmyth_recorder_cancel_next_recording(cmyth_recorder_t rec);
+/**
+ * Cancel the next pending recording.
+ * \param rec recorder handle
+ * \return success: 0
+ * \return failure: -(errno)
+ */
+extern int cmyth_recorder_cancel_next_recording(cmyth_recorder_t rec, int cancel);
 
 /**
  * Request that the recorder stop transmitting data.

--- a/lib/cmyth/libcmyth/cmyth_msc.h
+++ b/lib/cmyth/libcmyth/cmyth_msc.h
@@ -36,22 +36,12 @@
 #pragma warning(disable:4267)
 #pragma warning(disable:4996)
 
-//#define pthread_mutex_lock(a)
-//#define pthread_mutex_unlock(a)
 #define pthread_mutex_lock(a) EnterCriticalSection(a)
 #define pthread_mutex_unlock(a) LeaveCriticalSection(a)
-//#define PTHREAD_MUTEX_INITIALIZER NULL;
 #define PTHREAD_MUTEX_INITIALIZER InitializeCriticalSection(&mutex);
-//typedef void* pthread_mutex_t;
 typedef CRITICAL_SECTION pthread_mutex_t;
 extern pthread_mutex_t mutex;
-//#define mutex __cmyth_mutex
 
-#undef ECANCELED
-#undef ETIMEDOUT
-
-#define ECANCELED -1
-#define ETIMEDOUT -1
 #define SHUT_RDWR SD_BOTH
 
 typedef SOCKET cmyth_socket_t;

--- a/lib/cmyth/libcmyth/event.c
+++ b/lib/cmyth/libcmyth/event.c
@@ -122,14 +122,15 @@ cmyth_event_get_message(cmyth_conn_t conn, char * data, int32_t len, cmyth_progi
 		}
 	} else if (strncmp(tmp, "ASK_RECORDING", 13) == 0) {
 		event = CMYTH_EVENT_ASK_RECORDING;
+		strncpy(data, tmp + 14, len);
 		if (cmyth_conn_get_protocol_version(conn) < 37) {
 			/* receive 4 string - do nothing with them */
+			/* title, chanstr, chansign, channame */
 			for (i = 0; i < 4; i++) {
 				consumed = cmyth_rcv_string(conn, &err, tmp, sizeof(tmp) -1, count);
 				count -= consumed;
 			}
 		} else {
-			/* receive a proginfo structure - do nothing with it (yet?)*/
 			proginfo = cmyth_proginfo_create();
 			if (!proginfo) {
 				cmyth_dbg(CMYTH_DBG_ERROR,
@@ -138,9 +139,8 @@ cmyth_event_get_message(cmyth_conn_t conn, char * data, int32_t len, cmyth_progi
 				goto fail;
 			}
 			consumed = cmyth_rcv_proginfo(conn, &err, proginfo, count);
-			ref_release(proginfo);
-			proginfo = NULL;
 			count -= consumed;
+			*prog = proginfo;
 		}
 	} else if (strncmp(tmp, "CLEAR_SETTINGS_CACHE", 20) == 0) {
 		event = CMYTH_EVENT_CLEAR_SETTINGS_CACHE;

--- a/lib/cmyth/libcmyth/mythtv_mysql.c
+++ b/lib/cmyth/libcmyth/mythtv_mysql.c
@@ -219,7 +219,7 @@ cmyth_db_check_connection(cmyth_database_t db)
 			cmyth_dbg(CMYTH_DBG_ERROR, "%s: mysql_init() failed, insufficient memory?\n", __FUNCTION__);
 			return -1;
 		}
-		if (NULL == mysql_real_connect(db->mysql, db->db_host, db->db_user, db->db_pass, db->db_name, db->db_port, NULL, 0)) {
+		if (NULL == mysql_real_connect(db->mysql, db->db_host, db->db_user, db->db_pass, db->db_name, db->db_port, NULL, CLIENT_FOUND_ROWS)) {
 			cmyth_dbg(CMYTH_DBG_ERROR, "%s: mysql_connect() failed: %s\n", __FUNCTION__, mysql_error(db->mysql));
 			cmyth_database_close(db);
 			mysql_close(db->mysql);
@@ -956,7 +956,7 @@ cmyth_mysql_testdb_connection(cmyth_database_t db, char **message)
 			*message = buf;
 			return -1;
 		}
-		if (NULL == mysql_real_connect(db->mysql, db->db_host, db->db_user, db->db_pass, db->db_name, db->db_port, NULL, 0)) {
+		if (NULL == mysql_real_connect(db->mysql, db->db_host, db->db_user, db->db_pass, db->db_name, db->db_port, NULL, CLIENT_FOUND_ROWS)) {
 			cmyth_dbg(CMYTH_DBG_ERROR, "%s: mysql_connect() failed: %s\n", __FUNCTION__, mysql_error(db->mysql));
 			snprintf(buf, 1000, "%s", mysql_error(db->mysql));
 			*message = buf;


### PR DESCRIPTION
Hi Lars,

this updates the MythTV addon to version 1.6.9.

It fixes 2 small issues and brings a user configurable conflict handling when Live TV blocks an upcoming recording. Simply ignoring those cases unfortunately often leads into a blocked tuner on the backend. Therefore it would be nice if this could be also back ported to Frodo.

Thanks,
Christian

---

Changelog:
- Added Live TV vs. recording conflict handling
- Fixed recovering from backend connection loss on Windows
- Fixed error when trying to set watched flag for recordings that already have been marked as watched
