### PR TITLE
[vuplus] fix typo in langugage file

### DIFF
--- a/addons/pvr.vuplus/addon/resources/language/English/strings.po
+++ b/addons/pvr.vuplus/addon/resources/language/English/strings.po
@@ -118,7 +118,7 @@ msgid "TV-Bouquet"
 msgstr ""
 
 msgctxt "#30027"
-imsgid "Fetch picons from webinterface"
+msgid "Fetch picons from webinterface"
 msgstr ""
 
 #empty strings from id 30028 to 30499

--- a/addons/pvr.vuplus/addon/resources/language/German/strings.po
+++ b/addons/pvr.vuplus/addon/resources/language/German/strings.po
@@ -110,7 +110,7 @@ msgid "TV-Bouquet"
 msgstr "TV-Bouquet"
 
 msgctxt "#30027"
-imsgid "Fetch picons from webinterface"
+msgid "Fetch picons from webinterface"
 msgstr "Lade Picons vom Web-Interface"
 
 #empty strings from id 30028 to 30499


### PR DESCRIPTION
This just fixes two typos in the language files. Due to this a setting label wouldn't show up in the addon settings.
