### PR TITLE
vuplus: Fix deviceinfo call for current openwebif versions

### DIFF
--- a/addons/pvr.vuplus/addon/addon.xml.in
+++ b/addons/pvr.vuplus/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="1.7.7"
+  version="1.7.8"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>

--- a/addons/pvr.vuplus/addon/changelog.txt
+++ b/addons/pvr.vuplus/addon/changelog.txt
@@ -1,3 +1,8 @@
+1.7.8
+- fix: typos in language files 
+- fix: typo in settings.xml
+- fix: (temporarily) disable the deviceinfo API call to openwebif as it is currently broken in openwebif
+
 1.7.7
 - Bump after PVR API version bump
 

--- a/addons/pvr.vuplus/addon/resources/settings.xml
+++ b/addons/pvr.vuplus/addon/resources/settings.xml
@@ -4,7 +4,7 @@
   <category label="30018">
     <setting id="host" type="text" label="30000" default="127.0.0.1" />
     <setting id="onlinepicons" type="bool" default="true" label="30027" />
-    <setting id="iconpath" type="folder" label="30008" enable="e1(-1, false)" default="" />
+    <setting id="iconpath" type="folder" label="30008" enable="eq(-1,false)" default="" />
     <setting id="updateint" type="number" label="30010" default="2" />
   </category>
 

--- a/addons/pvr.vuplus/src/VuData.cpp
+++ b/addons/pvr.vuplus/src/VuData.cpp
@@ -1895,6 +1895,7 @@ void Vu::SendPowerstate()
 
 bool Vu::GetDeviceInfo()
 {
+  return true; //disable deviceinfo check because openwebif is currently broken
   CStdString url; 
   url.Format("%s%s", m_strURL.c_str(), "web/deviceinfo"); 
 


### PR DESCRIPTION
Hi,

recent versions of openwebif break an api call that is being used to get information about the enigma2 firmware. This commit disables this check so that current enigma2 firmware images can be used again.
