### PR TITLE
Fixed pvr.hts ReadMessage data timeout to user settings timeout. 

### DIFF
--- a/lib/platform/posix/os-socket.h
+++ b/lib/platform/posix/os-socket.h
@@ -224,7 +224,7 @@ namespace PLATFORM
         if (iPollResult == 0)
         {
           *iError = ETIMEDOUT;
-          return -ETIMEDOUT;
+          return (iBytesRead > 0) ? iBytesRead : -ETIMEDOUT;
         }
       }
 
@@ -236,12 +236,12 @@ namespace PLATFORM
         if (errno == EAGAIN && iTimeoutMs > 0)
           continue;
         *iError = errno;
-        return -errno;
+        return (iBytesRead > 0) ? iBytesRead : -errno;
       }
-      else if (iReadResult == 0 || (iReadResult != (ssize_t)len && iTimeoutMs == 0))
+      else if (iReadResult == 0)
       {
         *iError = ECONNRESET;
-        return -ECONNRESET;
+        return (iBytesRead > 0) ? iBytesRead : -ECONNRESET;
       }
 
       iBytesRead += iReadResult;


### PR DESCRIPTION
Hi, I use Your great tools TVHeadend + XBMC PVR.HTS add-on. Thumbs up.

I have two RPIs running, one is my TVHeadend-Server, works like a charm. I use this with XBMC + PVR.HTS on Mac and Windows. Works perfect. 

The second RPI runs a self compiled HEAD XBMC, with self compiled HEAD PVR-Addons. PVR playback of recordings worked sometimes, it kept dropping the TVHeadend HTSP connection, so I had a closer look into source code.

When You do the ReadMessage in the thread-loop, You use the default timeout for data to be read which is one second. When my TVHeadend Raspberry is under heavy load, which it always is ;-), it will not respond within time, so i patched this and now it works great.

I wonder, why the OSX and Windows versions (FRODO, not self compiled) do not have this problem.

I also have problems playing back the live streams. I will do some more research here. One symptom is, when Live-Stream plays, it has 1:1 aspect ratio. Most stream cannot be played at all.  

Cheers
Dezi
