### PR TITLE
vuplus: fixups for settings.xml

### DIFF
--- a/addons/pvr.vuplus/addon/addon.xml.in
+++ b/addons/pvr.vuplus/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vuplus"
-  version="1.7.7"
+  version="1.7.8"
   name="VU+ / Enigma2 Client"
   provider-name="Joerg Dembski">
   <requires>

--- a/addons/pvr.vuplus/addon/changelog.txt
+++ b/addons/pvr.vuplus/addon/changelog.txt
@@ -1,3 +1,6 @@
+1.7.8
+- fix: typo in settings.xml
+
 1.7.7
 - Bump after PVR API version bump
 

--- a/addons/pvr.vuplus/addon/resources/settings.xml
+++ b/addons/pvr.vuplus/addon/resources/settings.xml
@@ -4,7 +4,7 @@
   <category label="30018">
     <setting id="host" type="text" label="30000" default="127.0.0.1" />
     <setting id="onlinepicons" type="bool" default="true" label="30027" />
-    <setting id="iconpath" type="folder" label="30008" enable="e1(-1, false)" default="" />
+    <setting id="iconpath" type="folder" label="30008" enable="eq(-1,false)" default="" />
     <setting id="updateint" type="number" label="30010" default="2" />
   </category>
 


### PR DESCRIPTION
Due to a typo in the settings.xml, the users cannot set the picon path.
