### PR TITLE
Fixed several bugs:

### DIFF
--- a/addons/pvr.nextpvr/addon/addon.xml.in
+++ b/addons/pvr.nextpvr/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="1.6.4"
+  version="1.6.5"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>

--- a/addons/pvr.nextpvr/addon/changelog.txt
+++ b/addons/pvr.nextpvr/addon/changelog.txt
@@ -1,5 +1,9 @@
-v1.6.4
+v1.6.5
+- reducing logging during live tv and playback of recordings
+- now explicitly telling backend when live tv viewing ends, rather than relying on detection of the socket closing. This solves a problem some users were having with live tv buffer files left on the disk.
+- fixed broken genre
 
+v1.6.4
 - small change to improve the performance of radio channels
 
 v1.6.3

--- a/addons/pvr.nextpvr/src/liveshift.cpp
+++ b/addons/pvr.nextpvr/src/liveshift.cpp
@@ -87,6 +87,17 @@ LiveShiftSource::~LiveShiftSource(void)
   }
 }
 
+void LiveShiftSource::Close()
+{
+  if (m_pSocket != NULL)
+  {
+    char request[48];
+    memset(request, 0, sizeof(request));
+    snprintf(request, sizeof(request), "Close");
+    m_pSocket->send(request, sizeof(request));
+  }
+}
+
 void LiveShiftSource::LOG(char const *fmt, ... )
 {
   if (m_log != NULL)

--- a/addons/pvr.nextpvr/src/liveshift.h
+++ b/addons/pvr.nextpvr/src/liveshift.h
@@ -41,6 +41,8 @@ public:
   long long GetPosition();
   void Seek(long long offset);
 
+  void Close();
+
 private:
   void LOG(char const *fmt, ... );
 


### PR DESCRIPTION
- Reducing logging during live tv and playback of recordings.
- Now explicitly telling backend when live tv viewing ends, rather than relying on detection of the socket closing. This solves a problem some users were having with live tv buffer files left on the disk.
- Fixed broken genre.
