### PR TITLE
Fixed a bug with EPG events with no description 

### DIFF
--- a/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
+++ b/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
@@ -347,6 +347,10 @@ PVR_ERROR cPVRClientNextPVR::GetEpg(ADDON_HANDLE handle, const PVR_CHANNEL &chan
         {
           PVR_STRCPY(description, pListingNode->FirstChildElement("description")->FirstChild()->Value());
         }
+        else
+        {
+          description[0] = '\0';
+        }
 
         char start[32];
         strncpy(start, pListingNode->FirstChildElement("start")->FirstChild()->Value(), sizeof start);


### PR DESCRIPTION
Fixed a bug that could cause an EPG event with no description to have a copy of last show's description, or cause a crash if the user was unlucky.
