### PR TITLE
[mythtv-cmyth] Release v1.7.11

### DIFF
--- a/addons/pvr.mythtv.cmyth/addon/addon.xml.in
+++ b/addons/pvr.mythtv.cmyth/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv.cmyth"
-  version="1.7.10"
+  version="1.7.11"
   name="MythTV cmyth PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière, Tonny Petersen">
   <requires>

--- a/addons/pvr.mythtv.cmyth/addon/changelog.txt
+++ b/addons/pvr.mythtv.cmyth/addon/changelog.txt
@@ -1,3 +1,10 @@
+v1.7.11
+- Fixed crash when setting up Live TV (in rare cases)
+- Fixed issue with not updated recording list (Daylight Saving Time)
+- Fixed issue with empty recording list (caused by '[' character)
+- Fixed playback of recordings made by a slave backend
+- Removed 'Failed to connect to MythTV Backend' notification
+
 v1.7.10
 - Get last played position for recordings from the server
 

--- a/addons/pvr.mythtv.cmyth/src/client.h
+++ b/addons/pvr.mythtv.cmyth/src/client.h
@@ -36,6 +36,12 @@ extern "C" {
 #define strdup _strdup // # strdup is POSIX, _strdup should be used instead
 #endif
 
+#define TCP_RCV_BUF_CONTROL_SIZE           128000 // Inherited from MythTV's MythSocket class
+#define RCV_BUF_CONTROL_SIZE               32000  // Buffer size to parse backend response from control connection
+#define TCP_RCV_BUF_DATA_SIZE              65536  // TCP buffer for video stream (best performance)
+#define RCV_BUF_DATA_SIZE                  64     // Buffer size to parse backend response from data control connection
+#define RCV_BUF_IMAGE_SIZE                 32000  // Buffer size to download artworks
+
 #define LIVETV_CONFLICT_STRATEGY_HASLATER  0
 #define LIVETV_CONFLICT_STRATEGY_STOPTV    1
 #define LIVETV_CONFLICT_STRATEGY_CANCELREC 2

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.cpp
@@ -77,7 +77,7 @@ MythConnection::MythConnection(const CStdString &server, unsigned short port)
   , m_port(port)
   , m_pEventHandler(NULL)
 {
-  cmyth_conn_t connection = cmyth_conn_connect_ctrl(const_cast<char*>(server.c_str()), port, 64 * 1024, 16 * 1024);
+  cmyth_conn_t connection = cmyth_conn_connect_ctrl(const_cast<char*>(server.c_str()), port, RCV_BUF_CONTROL_SIZE, TCP_RCV_BUF_CONTROL_SIZE);
   *m_conn_t = connection;
 }
 
@@ -249,13 +249,13 @@ MythProgramInfo MythConnection::GetRecordedProgram(const CStdString &basename)
   return retval;
 }
 
-MythProgramInfo MythConnection::GetRecordedProgram(int chanid, time_t recstartts)
+MythProgramInfo MythConnection::GetRecordedProgram(int chanid, const MythTimestamp &recstartts)
 {
   MythProgramInfo retval;
   cmyth_proginfo_t prog = NULL;
-  if (chanid > 0 && recstartts > 0)
+  if (chanid > 0 && !recstartts.IsNull())
   {
-    CMYTH_CONN_CALL_REF(prog, prog == NULL, cmyth_proginfo_get_from_timeslot(*m_conn_t, chanid, recstartts));
+    CMYTH_CONN_CALL_REF(prog, prog == NULL, cmyth_proginfo_get_from_timeslot(*m_conn_t, chanid, *recstartts.m_timestamp_t));
     if (prog) {
       retval = MythProgramInfo(prog);
     }
@@ -334,7 +334,7 @@ MythFile MythConnection::ConnectFile(MythProgramInfo &recording)
   // When file is not NULL doesn't need to mean there is no more connection,
   // so always check after calling cmyth_conn_connect_file if still connected to control socket.
   cmyth_file_t file = NULL;
-  CMYTH_CONN_CALL_REF(file, true, cmyth_conn_connect_file(*recording.m_proginfo_t, *m_conn_t, 64 * 1024, 16 * 1024));
+  CMYTH_CONN_CALL_REF(file, true, cmyth_conn_connect_file(*recording.m_proginfo_t, *m_conn_t, RCV_BUF_DATA_SIZE, TCP_RCV_BUF_DATA_SIZE));
   MythFile retval = MythFile(file, *this);
   return retval;
 }
@@ -342,7 +342,7 @@ MythFile MythConnection::ConnectFile(MythProgramInfo &recording)
 MythFile MythConnection::ConnectPath(const CStdString &filename, const CStdString &storageGroup)
 {
   cmyth_file_t file = NULL;
-  CMYTH_CONN_CALL_REF(file, file == NULL, cmyth_conn_connect_path(const_cast<char*>(filename.c_str()), *m_conn_t, 64 * 1024, 64 * 1024, const_cast<char*>(storageGroup.c_str())));
+  CMYTH_CONN_CALL_REF(file, file == NULL, cmyth_conn_connect_path(const_cast<char*>(filename.c_str()), *m_conn_t, RCV_BUF_DATA_SIZE, TCP_RCV_BUF_DATA_SIZE, const_cast<char*>(storageGroup.c_str())));
   return MythFile(file, *this);
 }
 

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.h
@@ -35,6 +35,7 @@ class MythProgramInfo;
 class MythEventHandler;
 class MythRecordingRule;
 class MythStorageGroupFile;
+class MythTimestamp;
 
 template <class T> class MythPointer;
 template <class T> class MythPointerThreadSafe;
@@ -75,7 +76,7 @@ public:
   bool DeleteRecording(MythProgramInfo &recording);
   ProgramInfoMap GetRecordedPrograms();
   MythProgramInfo GetRecordedProgram(const CStdString &basename);
-  MythProgramInfo GetRecordedProgram(int chanid, time_t recstartts);
+  MythProgramInfo GetRecordedProgram(int chanid, const MythTimestamp &recstartts);
 
   // Timers
   ProgramInfoMap GetPendingPrograms();

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.cpp
@@ -109,7 +109,7 @@ MythEventHandler::MythEventHandlerPrivate::MythEventHandlerPrivate(const CStdStr
   , m_hang(false)
   , m_recordingChangeEventList()
 {
-  *m_conn_t = cmyth_conn_connect_event(const_cast<char*>(m_server.c_str()), port, 64 * 1024, 16 * 1024);
+  *m_conn_t = cmyth_conn_connect_event(const_cast<char*>(m_server.c_str()), port, RCV_BUF_CONTROL_SIZE, TCP_RCV_BUF_CONTROL_SIZE);
 }
 
 MythEventHandler::MythEventHandlerPrivate::~MythEventHandlerPrivate()
@@ -460,7 +460,7 @@ void MythEventHandler::MythEventHandlerPrivate::RetryConnect()
     usleep(999999);
     ref_release(*m_conn_t);
     *m_conn_t = NULL;
-    *m_conn_t = cmyth_conn_connect_event(const_cast<char*>(m_server.c_str()), m_port, 64 * 1024, 16 * 1024);
+    *m_conn_t = cmyth_conn_connect_event(const_cast<char*>(m_server.c_str()), m_port, RCV_BUF_CONTROL_SIZE, TCP_RCV_BUF_CONTROL_SIZE);
 
     if (*m_conn_t == NULL)
       XBMC->Log(LOG_NOTICE, "%s - Could not connect client to event socket", __FUNCTION__);

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.h
@@ -78,21 +78,16 @@ public:
   class RecordingChangeEvent
   {
   public:
-    RecordingChangeEvent(RecordingChangeType type, unsigned int chanid, char *recstartts)
+    RecordingChangeEvent(RecordingChangeType type, unsigned int chanid, const CStdString &recstartts)
       : m_type(type)
       , m_channelID(chanid)
-      , m_recordStartTimeSlot(0)
     {
-      if (recstartts) {
-        MythTimestamp time(recstartts, false);
-        m_recordStartTimeSlot = time.UnixTime();
-      }
+      m_recordingStartTimeSlot = MythTimestamp(recstartts, false);
     }
 
     RecordingChangeEvent(RecordingChangeType type, const MythProgramInfo &prog)
       : m_type(type)
       , m_channelID(0)
-      , m_recordStartTimeSlot(0)
       , m_prog(prog)
     {
     }
@@ -100,20 +95,19 @@ public:
     RecordingChangeEvent(RecordingChangeType type)
       : m_type(type)
       , m_channelID(0)
-      , m_recordStartTimeSlot(0)
     {
     }
 
     RecordingChangeType Type() const { return m_type; }
     unsigned int ChannelID() const { return m_channelID; };
-    time_t RecordingStartTimeslot() const { return m_recordStartTimeSlot; }
+    MythTimestamp RecordingStartTimeslot() const { return m_recordingStartTimeSlot; }
     MythProgramInfo Program() const { return m_prog; }
 
   private:
     RecordingChangeType m_type;
-    unsigned int m_channelID;     // ADD and DELETE
-    time_t m_recordStartTimeSlot; // ADD and DELETE
-    MythProgramInfo m_prog;       // UPDATE
+    unsigned int m_channelID;               // ADD and DELETE
+    MythTimestamp m_recordingStartTimeSlot; // ADD and DELETE
+    MythProgramInfo m_prog;                 // UPDATE
   };
 
   bool HasRecordingChangeEvent() const;

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.cpp
@@ -159,7 +159,7 @@ bool MythRecorder::SpawnLiveTV(MythChannel &channel)
   // Check channel
   *m_liveChainUpdated = 0;
   cmyth_recorder_t recorder = NULL;
-  recorder = cmyth_spawn_live_tv(*m_recorder_t, 64*1024, 64*1024, MythRecorder::prog_update_callback, &pErr, const_cast<char*>(channel.Number().c_str()));
+  recorder = cmyth_spawn_live_tv(*m_recorder_t, RCV_BUF_DATA_SIZE, TCP_RCV_BUF_DATA_SIZE, MythRecorder::prog_update_callback, &pErr, const_cast<char*>(channel.Number().c_str()));
 
   if (recorder && pErr == NULL) {
     *m_recorder_t = recorder;

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.cpp
@@ -94,3 +94,10 @@ CStdString MythTimestamp::DisplayString(bool use12hClock)
   bool succeded=cmyth_timestamp_to_display_string(time, *m_timestamp_t, use12hClock) == 0;
   return succeded ? CStdString(time) : CStdString("");
 }
+
+CStdString MythTimestamp::NumString()
+{
+  char time[15];
+  bool succeded = cmyth_timestamp_to_numstring(time, *m_timestamp_t) == 0;
+  return succeded ? CStdString(time) : CStdString("");
+}

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.h
@@ -32,6 +32,8 @@ template <class T> class MythPointer;
 class MythTimestamp
 {
 public:
+  friend class MythConnection;
+
   MythTimestamp();
   MythTimestamp(cmyth_timestamp_t cmyth_timestamp);
   MythTimestamp(CStdString time, bool datetime);
@@ -50,6 +52,7 @@ public:
   CStdString String();
   CStdString IsoString();
   CStdString DisplayString(bool use12hClock);
+  CStdString NumString();
 
 private:
   boost::shared_ptr<MythPointer<cmyth_timestamp_t> > m_timestamp_t;

--- a/addons/pvr.mythtv.cmyth/src/fileOps.cpp
+++ b/addons/pvr.mythtv.cmyth/src/fileOps.cpp
@@ -298,7 +298,7 @@ bool FileOps::CacheFile(const CStdString &localFilename, MythFile &source)
   unsigned long long totalLength = source.Length();
   unsigned long long totalRead = 0;
 
-  const long buffersize = 32768;
+  const long buffersize = RCV_BUF_IMAGE_SIZE;
   char* buffer = new char[buffersize];
 
   while (totalRead < totalLength)

--- a/lib/cmyth/include/cmyth/cmyth.h
+++ b/lib/cmyth/include/cmyth/cmyth.h
@@ -630,7 +630,7 @@ extern cmyth_recorder_t cmyth_spawn_live_tv(cmyth_recorder_t rec,
 				char ** err, char * channame);
 
 extern cmyth_recorder_t cmyth_livetv_chain_setup(cmyth_recorder_t old_rec,
-				int32_t tcp_rcvbuf,
+				uint32_t buflen, int32_t tcp_rcvbuf,
 				void (*prog_update_callback)(cmyth_proginfo_t));
 
 extern int32_t cmyth_livetv_get_block(cmyth_recorder_t rec, char *buf,
@@ -730,7 +730,7 @@ extern int cmyth_timestamp_to_display_string(char *str, cmyth_timestamp_t ts,
 
 extern int cmyth_datetime_to_string(char *str, cmyth_timestamp_t ts);
 
-extern cmyth_timestamp_t cmyth_datetime_from_string(char *str);
+extern int cmyth_timestamp_to_numstring(char *str, cmyth_timestamp_t ts);
 
 extern int cmyth_timestamp_compare(cmyth_timestamp_t ts1,
 				   cmyth_timestamp_t ts2);
@@ -837,7 +837,7 @@ extern cmyth_proginfo_t cmyth_proginfo_get_from_basename(cmyth_conn_t control,
  */
 extern cmyth_proginfo_t cmyth_proginfo_get_from_timeslot(cmyth_conn_t control,
 					   uint32_t chanid,
-					   time_t recstartts);
+					   const cmyth_timestamp_t recstartts);
 
 /**
  * Retrieve the title of a program.

--- a/lib/cmyth/libcmyth/bookmark.c
+++ b/lib/cmyth/libcmyth/bookmark.c
@@ -41,7 +41,7 @@ int64_t cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog)
 	}
 	sprintf(buf,"%s %"PRIu32" %s","QUERY_BOOKMARK",prog->proginfo_chanId,
 		start_ts_dt);
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);;
 	if ((err = cmyth_send_message(conn,buf)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_send_message() failed (%d)\n",
@@ -66,7 +66,7 @@ int64_t cmyth_get_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog)
 	}
 
    out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	return ret;
 }
 
@@ -94,7 +94,7 @@ int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog, int64_t bookmar
 		sprintf(buf, "SET_BOOKMARK %"PRIu32" %s %"PRId32" %"PRId32, prog->proginfo_chanId,
 				start_ts_dt, (int32_t)(bookmark >> 32), (int32_t)(bookmark & 0xffffffff));
 	}
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);;
 	if ((ret = cmyth_send_message(conn,buf)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_send_message() failed (%d)\n",
@@ -106,6 +106,6 @@ int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog, int64_t bookmar
 			  __FUNCTION__);
 	}
    out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	return ret;
 }

--- a/lib/cmyth/libcmyth/cmyth_msc.h
+++ b/lib/cmyth/libcmyth/cmyth_msc.h
@@ -36,11 +36,11 @@
 #pragma warning(disable:4267)
 #pragma warning(disable:4996)
 
+#define pthread_mutex_init(a, b) InitializeCriticalSection(a)
+#define pthread_mutex_destroy(a) DeleteCriticalSection(a)
 #define pthread_mutex_lock(a) EnterCriticalSection(a)
 #define pthread_mutex_unlock(a) LeaveCriticalSection(a)
-#define PTHREAD_MUTEX_INITIALIZER InitializeCriticalSection(&mutex);
 typedef CRITICAL_SECTION pthread_mutex_t;
-extern pthread_mutex_t mutex;
 
 #define SHUT_RDWR SD_BOTH
 

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -110,7 +110,7 @@ cmyth_get_commbreaklist(cmyth_conn_t conn, cmyth_proginfo_t prog)
 
 	sprintf(buf,"%s %"PRIu32" %ld", "QUERY_COMMBREAK", prog->proginfo_chanId,
 	        (long)cmyth_timestamp_to_unixtime(prog->proginfo_rec_start_ts));
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 	if ((err = cmyth_send_message(conn, buf)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_send_message() failed (%d)\n",
@@ -134,7 +134,7 @@ cmyth_get_commbreaklist(cmyth_conn_t conn, cmyth_proginfo_t prog)
 	}
 
 	out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	return breaklist;
 }
 
@@ -156,7 +156,7 @@ cmyth_get_cutlist(cmyth_conn_t conn, cmyth_proginfo_t prog)
 
 	sprintf(buf,"%s %"PRIu32" %ld", "QUERY_CUTLIST", prog->proginfo_chanId,
 	        (long)cmyth_timestamp_to_unixtime(prog->proginfo_rec_start_ts));
-
+	pthread_mutex_lock(&conn->conn_mutex);
 	if ((err = cmyth_send_message(conn, buf)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_send_message() failed (%d)\n",
@@ -180,7 +180,7 @@ cmyth_get_cutlist(cmyth_conn_t conn, cmyth_proginfo_t prog)
 	}
 
 	out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	return breaklist;
 }
 
@@ -287,7 +287,7 @@ cmyth_mysql_get_commbreaklist(cmyth_database_t db, cmyth_conn_t conn, cmyth_prog
 	int r;
 
 	start_ts_dt = cmyth_timestamp_to_unixtime(prog->proginfo_rec_start_ts);
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 	if ((r=cmyth_mysql_get_commbreak_list(db, prog->proginfo_chanId, start_ts_dt, breaklist, conn->conn_version)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_mysql_get_commbreak_list() failed (%d)\n",
@@ -302,6 +302,6 @@ cmyth_mysql_get_commbreaklist(cmyth_database_t db, cmyth_conn_t conn, cmyth_prog
 		breaklist->commbreak_count = 0;
 	}
 	out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	return breaklist;
 }

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -33,31 +33,6 @@
 static char * cmyth_conn_get_setting_unlocked(cmyth_conn_t conn, const char* hostname, const char* setting);
 static int cmyth_conn_set_setting_unlocked(cmyth_conn_t conn, const char* hostname, const char* setting, const char* value);
 
-#ifdef _MSC_VER
-CRITICAL_SECTION mutex;
-
-BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
-{
-	switch( ul_reason_for_call )
-	{
-	case DLL_PROCESS_ATTACH:
-		InitializeCriticalSection(&mutex);
-		break;
-	/*case DLL_THREAD_ATTACH:
-		...
-	case DLL_THREAD_DETACH:
-		...*/
-	case DLL_PROCESS_DETACH:
-		DeleteCriticalSection(&mutex);
-		break;
-	}
-	return TRUE;
-}
-
-#else
-pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-#endif
-
 typedef struct {
 	unsigned int version;
 	char token[14]; // up to 13 chars used in v74 + the terminating NULL character
@@ -106,7 +81,7 @@ cmyth_conn_done(cmyth_conn_t conn)
 		return;
 	}
 	if (!conn->conn_hang && conn->conn_ann != ANN_NONE) {
-		pthread_mutex_lock(&mutex);
+		pthread_mutex_lock(&conn->conn_mutex);
 
 		/*
 		 * Try to shut down the connection.  Can't do much
@@ -118,7 +93,7 @@ cmyth_conn_done(cmyth_conn_t conn)
 				  __FUNCTION__, err);
 		}
 
-		pthread_mutex_unlock(&mutex);
+		pthread_mutex_unlock(&conn->conn_mutex);
 	}
 }
 
@@ -146,6 +121,7 @@ cmyth_conn_destroy(cmyth_conn_t conn)
 	{
 		free( conn->server );
 	}
+	pthread_mutex_destroy(&conn->conn_mutex);
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s }\n", __FUNCTION__);
 }
 
@@ -186,6 +162,7 @@ cmyth_conn_create(void)
 	ret->server = NULL;
 	ret->port = 0;
 	ret->conn_ann = ANN_NONE;
+	pthread_mutex_init(&ret->conn_mutex, NULL);
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s }\n", __FUNCTION__);
 	return ret;
 }
@@ -258,13 +235,12 @@ cmyth_connect_addr(struct addrinfo* addr, uint32_t buflen,
 
 	temp = tcp_rcvbuf;
 	size = sizeof(temp);
+	cmyth_dbg(CMYTH_DBG_DEBUG, "%s: setting socket option SO_RCVBUF to %d", __FUNCTION__, tcp_rcvbuf);
 	setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (void*)&temp, size);
 	if(getsockopt(fd, SOL_SOCKET, SO_RCVBUF, (void*)&temp, &size)) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: could not get rcvbuf from socket(%d)\n",
 			  __FUNCTION__, errno);
-		temp = tcp_rcvbuf;
 	}
-	tcp_rcvbuf = temp;
 
 	if (getnameinfo(addr->ai_addr, addr->ai_addrlen, namebuf, sizeof(namebuf), portbuf, sizeof(portbuf), NI_NUMERICHOST)) {
 		strcpy(namebuf, "[unknown]");
@@ -376,13 +352,12 @@ cmyth_reconnect_addr(cmyth_conn_t conn, struct addrinfo* addr)
 
 	temp = conn->conn_tcp_rcvbuf;
 	size = sizeof(temp);
+	cmyth_dbg(CMYTH_DBG_DEBUG, "%s: setting socket option SO_RCVBUF to %d", __FUNCTION__, conn->conn_tcp_rcvbuf);
 	setsockopt(fd, SOL_SOCKET, SO_RCVBUF, (void*)&temp, size);
 	if (getsockopt(fd, SOL_SOCKET, SO_RCVBUF, (void*)&temp, &size)) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: could not get rcvbuf from socket(%d)\n",
 			  __FUNCTION__, errno);
-		temp = conn->conn_tcp_rcvbuf;
 	}
-	conn->conn_tcp_rcvbuf = temp;
 
 	if (getnameinfo(addr->ai_addr, addr->ai_addrlen, namebuf, sizeof(namebuf), portbuf, sizeof(portbuf), NI_NUMERICHOST)) {
 		strcpy(namebuf, "[unknown]");
@@ -881,7 +856,6 @@ cmyth_conn_connect_file(cmyth_proginfo_t prog,  cmyth_conn_t control,
 {
 	cmyth_conn_t conn = NULL;
 	char *announcement = NULL;
-	char *myth_host = NULL;
 	char reply[16];
 	int err = 0;
 	int count = 0;
@@ -905,33 +879,11 @@ cmyth_conn_connect_file(cmyth_proginfo_t prog,  cmyth_conn_t control,
 			  __FUNCTION__);
 		goto shut;
 	}
-	cmyth_dbg(CMYTH_DBG_PROTO, "%s: connecting data connection\n",
-		  __FUNCTION__);
-	if (control->conn_version >= 17) {
-		myth_host = cmyth_conn_get_setting(control, prog->proginfo_host,
-		                                   "BackendServerIP");
-		if (myth_host && (strcmp(myth_host, "-1") == 0)) {
-			ref_release(myth_host);
-			myth_host = NULL;
-		}
-	}
-	if (!myth_host) {
-		cmyth_dbg(CMYTH_DBG_PROTO,
-		          "%s: BackendServerIP setting not found. Using proginfo_host: %s\n",
-		          __FUNCTION__, prog->proginfo_host);
-		myth_host = ref_alloc(strlen(prog->proginfo_host) + 1);
-		strcpy(myth_host, prog->proginfo_host);
-	}
-	conn = cmyth_connect(myth_host, prog->proginfo_port,
-			     buflen, tcp_rcvbuf);
-	cmyth_dbg(CMYTH_DBG_PROTO,
-		  "%s: done connecting data connection, conn = %d\n",
-		  __FUNCTION__, conn);
+	cmyth_dbg(CMYTH_DBG_PROTO, "%s: connecting data connection\n", __FUNCTION__);
+	conn = cmyth_connect(control->server, control->port, buflen, tcp_rcvbuf);
+	cmyth_dbg(CMYTH_DBG_PROTO, "%s: done connecting data connection, conn = %d\n", __FUNCTION__, conn);
 	if (!conn) {
-		cmyth_dbg(CMYTH_DBG_ERROR,
-			  "%s: cmyth_connect(%s, %"PRIu16", %"PRIu32") failed\n",
-			  __FUNCTION__,
-			  myth_host, prog->proginfo_port, buflen);
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: cmyth_connect(%s, %"PRIu16", %"PRIu32") failed\n", __FUNCTION__, control->server, control->port, buflen);
 		goto shut;
 	}
 	/*
@@ -1016,12 +968,10 @@ cmyth_conn_connect_file(cmyth_proginfo_t prog,  cmyth_conn_t control,
 	ret->file_data = conn;
 	ret->file_id = file_id;
 	ret->file_length = file_length;
-	ref_release(myth_host);
 	return ret;
 
     shut:
 	ref_release(conn);
-	ref_release(myth_host);
 	return NULL;
 }
 
@@ -1390,7 +1340,7 @@ cmyth_conn_get_recorder_from_num(cmyth_conn_t conn, int32_t id)
 		return NULL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 
 	if ((rec=cmyth_recorder_create()) == NULL)
 		goto fail;
@@ -1436,7 +1386,7 @@ cmyth_conn_get_recorder_from_num(cmyth_conn_t conn, int32_t id)
 					conn->conn_tcp_rcvbuf) < 0)
 		goto fail;
 
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return rec;
 
@@ -1444,7 +1394,7 @@ cmyth_conn_get_recorder_from_num(cmyth_conn_t conn, int32_t id)
 	if (rec)
 		ref_release(rec);
 
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return NULL;
 }
@@ -1483,7 +1433,7 @@ cmyth_conn_get_free_recorder(cmyth_conn_t conn)
 		return NULL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 
 	if ((rec=cmyth_recorder_create()) == NULL)
 		goto fail;
@@ -1534,7 +1484,7 @@ cmyth_conn_get_free_recorder(cmyth_conn_t conn)
 					conn->conn_tcp_rcvbuf) < 0)
 		goto fail;
 
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return rec;
 
@@ -1542,7 +1492,7 @@ cmyth_conn_get_free_recorder(cmyth_conn_t conn)
 	if (rec)
 		ref_release(rec);
 
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return NULL;
 }
@@ -1563,7 +1513,7 @@ cmyth_conn_get_freespace(cmyth_conn_t control,
 	if ((total == NULL) || (used == NULL))
 		return -EINVAL;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&control->conn_mutex);
 
 	if (control->conn_version >= 32)
 		{ snprintf(msg, sizeof(msg), "QUERY_FREE_SPACE_SUMMARY"); }
@@ -1633,7 +1583,7 @@ cmyth_conn_get_freespace(cmyth_conn_t control,
 		}
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&control->conn_mutex);
 
 	return ret;
 }
@@ -1675,7 +1625,7 @@ cmyth_conn_get_free_recorder_count(cmyth_conn_t conn)
 		return -1;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "GET_FREE_RECORDER_COUNT");
 	if ((err = cmyth_send_message(conn, msg)) < 0) {
@@ -1704,7 +1654,7 @@ cmyth_conn_get_free_recorder_count(cmyth_conn_t conn)
 	ret = (int)c;
 
     err:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return ret;
 }
@@ -1715,7 +1665,7 @@ cmyth_conn_get_backend_hostname(cmyth_conn_t conn)
 	int count, err;
 	char* result = NULL;
 
-  pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 	if(conn->conn_version < 17) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: protocol version doesn't support QUERY_HOSTNAME\n",
 			  __FUNCTION__);
@@ -1758,7 +1708,7 @@ cmyth_conn_get_backend_hostname(cmyth_conn_t conn)
 		buffer[sizeof(buffer)-1] = 0;
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: odd left over data %s\n", __FUNCTION__, buffer);
 	}
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	if(!strcmp("-1",result))  {
 		cmyth_dbg(CMYTH_DBG_PROTO, "%s: Failed to retrieve backend hostname.\n",
@@ -1768,7 +1718,7 @@ cmyth_conn_get_backend_hostname(cmyth_conn_t conn)
 	return result;
 
 err:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	if(result)
 		ref_release(result);
 
@@ -1853,9 +1803,9 @@ cmyth_conn_get_setting(cmyth_conn_t conn, const char* hostname, const char* sett
 {
 	char* result = NULL;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 	result = cmyth_conn_get_setting_unlocked(conn, hostname, setting);
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return result;
 }
@@ -1900,9 +1850,9 @@ int cmyth_conn_set_setting(cmyth_conn_t conn,
 {
 	int result;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 	result = cmyth_conn_set_setting_unlocked(conn, hostname, setting, value);
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return result;
 }
@@ -1970,7 +1920,7 @@ cmyth_conn_reschedule_recordings(cmyth_conn_t conn, uint32_t recordid)
 		}
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 
 	if ((err = cmyth_send_message(conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
@@ -1987,6 +1937,6 @@ cmyth_conn_reschedule_recordings(cmyth_conn_t conn, uint32_t recordid)
 	}
 
 out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 	return err;
 }

--- a/lib/cmyth/libcmyth/input.c
+++ b/lib/cmyth/libcmyth/input.c
@@ -114,7 +114,7 @@ cmyth_get_free_inputlist(cmyth_recorder_t rec)
 	}
 
 	sprintf(buf,"QUERY_RECORDER %"PRIu32"[]:[]GET_FREE_INPUTS", rec->rec_id);
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 	if ((err = cmyth_send_message(rec->rec_conn, buf)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			"%s: cmyth_send_message() failed (%d)\n",
@@ -138,7 +138,7 @@ cmyth_get_free_inputlist(cmyth_recorder_t rec)
 	}
 
 	out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 	return inputlist;
 }
 

--- a/lib/cmyth/libcmyth/proglist.c
+++ b/lib/cmyth/libcmyth/proglist.c
@@ -62,6 +62,7 @@ cmyth_proglist_destroy(cmyth_proglist_t pl)
 	if (pl->proglist_list) {
 		free(pl->proglist_list);
 	}
+	pthread_mutex_destroy(&pl->proglist_mutex);
 }
 
 /*
@@ -93,6 +94,7 @@ cmyth_proglist_create(void)
 
 	ret->proglist_list = NULL;
 	ret->proglist_count = 0;
+	pthread_mutex_init(&ret->proglist_mutex, NULL);
 	return ret;
 }
 
@@ -154,7 +156,7 @@ cmyth_proglist_delete_item(cmyth_proglist_t pl, cmyth_proginfo_t prog)
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&pl->proglist_mutex);
 
 	for (i=0; i<pl->proglist_count; i++) {
 		if (cmyth_proginfo_compare(prog, pl->proglist_list[i]) == 0) {
@@ -170,7 +172,7 @@ cmyth_proglist_delete_item(cmyth_proglist_t pl, cmyth_proginfo_t prog)
 	}
 
  out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&pl->proglist_mutex);
 
 	return ret;
 }
@@ -237,7 +239,7 @@ cmyth_proglist_get_list(cmyth_conn_t conn,
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&conn->conn_mutex);
 
 	if ((err = cmyth_send_message(conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
@@ -282,7 +284,7 @@ cmyth_proglist_get_list(cmyth_conn_t conn,
 	ret = 0;
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&conn->conn_mutex);
 
 	return ret;
 }

--- a/lib/cmyth/libcmyth/recorder.c
+++ b/lib/cmyth/libcmyth/recorder.c
@@ -180,7 +180,7 @@ cmyth_recorder_is_recording(cmyth_recorder_t rec)
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]IS_RECORDING",
 		 rec->rec_id);
@@ -205,7 +205,7 @@ cmyth_recorder_is_recording(cmyth_recorder_t rec)
 	ret = c;
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -242,7 +242,7 @@ cmyth_recorder_get_framerate(cmyth_recorder_t rec,
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]GET_FRAMERATE",
 		 rec->rec_id);
@@ -269,7 +269,7 @@ cmyth_recorder_get_framerate(cmyth_recorder_t rec,
 	ret = 0;
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -458,7 +458,7 @@ cmyth_recorder_cancel_next_recording(cmyth_recorder_t rec, int cancel)
 		return -ENOSYS;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]CANCEL_NEXT_RECORDING[]:[]%"PRIu32 ,rec->rec_id, cancel == 1);
 
@@ -475,7 +475,7 @@ cmyth_recorder_cancel_next_recording(cmyth_recorder_t rec, int cancel)
 	ret = 0;
 
 fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -511,7 +511,7 @@ cmyth_recorder_pause(cmyth_recorder_t rec)
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	sprintf(Buffer, "QUERY_RECORDER %"PRIu32"[]:[]PAUSE", rec->rec_id);
 	if ((ret=cmyth_send_message(rec->rec_conn, Buffer)) < 0) {
@@ -530,7 +530,7 @@ cmyth_recorder_pause(cmyth_recorder_t rec)
 	ret = 0;
 
     err:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -624,7 +624,7 @@ cmyth_recorder_change_channel(cmyth_recorder_t rec,
 		return -ENOSYS;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg),
 		 "QUERY_RECORDER %"PRIu32"[]:[]CHANGE_CHANNEL[]:[]%d",
@@ -658,7 +658,7 @@ cmyth_recorder_change_channel(cmyth_recorder_t rec,
 	ret = 0;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -697,7 +697,7 @@ cmyth_recorder_set_channel(cmyth_recorder_t rec, char *channame)
 		return -ENOSYS;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg),
 		 "QUERY_RECORDER %"PRIu32"[]:[]SET_CHANNEL[]:[]%s",
@@ -731,7 +731,7 @@ cmyth_recorder_set_channel(cmyth_recorder_t rec, char *channame)
 	ret = 0;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -889,7 +889,7 @@ cmyth_recorder_check_channel(cmyth_recorder_t rec,
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg),
 		 "QUERY_RECORDER %"PRIu32"[]:[]CHECK_CHANNEL[]:[]%s",
@@ -910,7 +910,7 @@ cmyth_recorder_check_channel(cmyth_recorder_t rec,
 	ret = 1;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -976,7 +976,7 @@ cmyth_recorder_get_program_info(cmyth_recorder_t rec)
 			  __FUNCTION__);
 		goto out;
 	}
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	if(rec->rec_conn->conn_version >= 26)
 		snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]GET_CURRENT_RECORDING",
@@ -1010,7 +1010,7 @@ cmyth_recorder_get_program_info(cmyth_recorder_t rec)
 	}
 
   out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return proginfo;
 }
@@ -1106,7 +1106,7 @@ cmyth_recorder_get_next_program_info(cmyth_recorder_t rec,
 
 	control = rec->rec_conn;
 
-        pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	t = time(NULL);
 	tm = localtime(&t);
@@ -1192,7 +1192,7 @@ cmyth_recorder_get_next_program_info(cmyth_recorder_t rec,
 	ret = 0;
 
     out:
-        pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
         return ret;
 }
@@ -1351,7 +1351,7 @@ cmyth_recorder_spawn_livetv(cmyth_recorder_t rec)
 		return -ENOSYS;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]SPAWN_LIVETV",
 		 rec->rec_id);
@@ -1373,7 +1373,7 @@ cmyth_recorder_spawn_livetv(cmyth_recorder_t rec)
 	ret = 0;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -1395,7 +1395,7 @@ cmyth_recorder_spawn_chain_livetv(cmyth_recorder_t rec, char* channame)
 		return -ENOSYS;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 
 	/* Get our own IP address */
@@ -1436,7 +1436,7 @@ cmyth_recorder_spawn_chain_livetv(cmyth_recorder_t rec, char* channame)
 	ret = 0;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -1454,7 +1454,7 @@ cmyth_recorder_stop_livetv(cmyth_recorder_t rec)
 		return -ENOSYS;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]STOP_LIVETV",
 		 rec->rec_id);
@@ -1476,7 +1476,7 @@ cmyth_recorder_stop_livetv(cmyth_recorder_t rec)
 	ret = 0;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -1497,7 +1497,7 @@ cmyth_recorder_done_ringbuf(cmyth_recorder_t rec)
 	if(rec->rec_conn->conn_version >= 26)
 		return 0;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]DONE_RINGBUF",
 		 rec->rec_id);
@@ -1519,7 +1519,7 @@ cmyth_recorder_done_ringbuf(cmyth_recorder_t rec)
 	ret = 0;
 
     fail:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }

--- a/lib/cmyth/libcmyth/ringbuf.c
+++ b/lib/cmyth/libcmyth/ringbuf.c
@@ -145,7 +145,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 
 	control = rec->rec_conn;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg),
 		 "QUERY_RECORDER %"PRIu32"[]:[]SETUP_RING_BUFFER[]:[]0",
@@ -237,7 +237,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 	new_rec->rec_ring->ringbuf_fill = fill;
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return new_rec;
 }
@@ -344,7 +344,7 @@ cmyth_ringbuf_request_block(cmyth_recorder_t rec, int32_t len)
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	if(len > rec->rec_ring->conn_data->conn_tcp_rcvbuf)
 		len = rec->rec_ring->conn_data->conn_tcp_rcvbuf;
@@ -374,7 +374,7 @@ cmyth_ringbuf_request_block(cmyth_recorder_t rec, int32_t len)
 	ret = c;
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }
@@ -410,7 +410,7 @@ int32_t cmyth_ringbuf_read(cmyth_recorder_t rec, char *buf, int32_t len)
 		return -EINVAL;
 	}
 
-	pthread_mutex_lock (&mutex);
+	pthread_mutex_lock (&rec->rec_conn->conn_mutex);
 
 	if(len > rec->rec_ring->conn_data->conn_tcp_rcvbuf)
 		len = rec->rec_ring->conn_data->conn_tcp_rcvbuf;
@@ -507,7 +507,7 @@ int32_t cmyth_ringbuf_read(cmyth_recorder_t rec, char *buf, int32_t len)
 
 	ret = (int32_t)(cur - buf);
 out:
-	pthread_mutex_unlock (&mutex);
+	pthread_mutex_unlock (&rec->rec_conn->conn_mutex);
 	return ret;
 }
 
@@ -550,7 +550,7 @@ cmyth_ringbuf_seek(cmyth_recorder_t rec,
 	if ((offset == 0) && (whence == WHENCE_CUR))
 		return ring->file_pos;
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	snprintf(msg, sizeof(msg),
 		 "QUERY_RECORDER %"PRIu32"[]:[]SEEK_RINGBUF[]:[]%"PRId32"[]:[]%"PRId32"[]:[]%"PRId8"[]:[]%"PRId32"[]:[]%"PRId32,
@@ -593,7 +593,7 @@ cmyth_ringbuf_seek(cmyth_recorder_t rec,
 	ret = ring->file_pos;
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 
 	return ret;
 }

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -369,6 +369,17 @@ cmyth_rcv_string(cmyth_conn_t conn, int *err, char *buf, int buflen, int count)
 			}
 		}
 
+		if (sep_start && conn->conn_buf[conn->conn_pos] != (unsigned char)*state) {
+			/*
+			 * Reset separator in case the current character does not match
+			 * the expected part of the separator. This needs to take place
+			 * before checking if the current character starts a new separator.
+			 * (To resolve issues with strings that look like [[]:[])
+			 */
+			sep_start = NULL;
+			state = separator;
+		}
+
 		if (conn->conn_buf[conn->conn_pos] == (unsigned char)*state) {
 			/*
 			 * We matched the next (possibly first) step
@@ -378,13 +389,6 @@ cmyth_rcv_string(cmyth_conn_t conn, int *err, char *buf, int buflen, int count)
 				sep_start = &buf[placed];
 			}
 			++state;
-		} else {
-			/*
-			 * No match with separator, reset the state to the
-			 * beginning.
-			 */
-			sep_start = NULL;
-			state = separator;
 		}
 
 		if (placed < buflen) {

--- a/lib/cmyth/libcmyth/storagegroup.c
+++ b/lib/cmyth/libcmyth/storagegroup.c
@@ -175,7 +175,7 @@ cmyth_storagegroup_get_filelist(cmyth_conn_t control,char *storagegroup, char *h
 		return 0;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&control->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_SG_GETFILELIST[]:[]%s[]:[]%s[]:[][]:[]1", hostname, storagegroup);
 
@@ -246,7 +246,7 @@ cmyth_storagegroup_get_filelist(cmyth_conn_t control,char *storagegroup, char *h
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s: results= %d\n", __FUNCTION__, res);
 
     out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&control->conn_mutex);
 	return ret;
 }
 
@@ -284,7 +284,7 @@ cmyth_storagegroup_get_fileinfo(cmyth_conn_t control, char *storagegroup, char *
 		return 0;
 	}
 
-	pthread_mutex_lock(&mutex);
+	pthread_mutex_lock(&control->conn_mutex);
 
 	snprintf(msg, sizeof(msg), "QUERY_SG_FILEQUERY[]:[]%s[]:[]%s[]:[]%s", hostname, storagegroup, filename);
 
@@ -343,7 +343,7 @@ cmyth_storagegroup_get_fileinfo(cmyth_conn_t control, char *storagegroup, char *
 	cmyth_dbg(CMYTH_DBG_DEBUG, "%s: filename: %s\n", __FUNCTION__, ret->filename);
 
 out:
-	pthread_mutex_unlock(&mutex);
+	pthread_mutex_unlock(&control->conn_mutex);
 	return ret;
 }
 

--- a/lib/cmyth/libcmyth/timestamp.c
+++ b/lib/cmyth/libcmyth/timestamp.c
@@ -60,7 +60,7 @@ cmyth_timestamp_create(void)
 	ret->timestamp_hour = 0;
 	ret->timestamp_minute = 0;
 	ret->timestamp_second = 0;
-	ret->timestamp_isdst = 0;
+	ret->timestamp_isdst = -1;
 	return ret;
 }
 
@@ -201,8 +201,7 @@ cmyth_timestamp_from_string(const char *str)
 cmyth_timestamp_t
 cmyth_timestamp_from_tm(struct tm * tm_datetime)
 {
-    	cmyth_timestamp_t ret;
-	ret = cmyth_timestamp_create();
+	cmyth_timestamp_t ret = cmyth_timestamp_create();
 	if (!ret) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: NULL timestamp\n",
 			  __FUNCTION__);
@@ -263,15 +262,22 @@ cmyth_timestamp_from_unixtime(time_t l)
 time_t
 cmyth_timestamp_to_unixtime(cmyth_timestamp_t ts)
 {
-    struct tm tm;
-    tm.tm_sec = ts->timestamp_second;
-    tm.tm_min = ts->timestamp_minute;
-    tm.tm_hour = ts->timestamp_hour;
-    tm.tm_mday = ts->timestamp_day;
-    tm.tm_mon = ts->timestamp_month-1;
-    tm.tm_year = ts->timestamp_year-1900;
-    tm.tm_isdst = ts->timestamp_isdst;
-    return mktime(&tm);
+	struct tm tm_datetime;
+
+	if (!ts) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: NULL timestamp provided\n",
+			  __FUNCTION__);
+		return -EINVAL;
+	}
+
+	tm_datetime.tm_sec = ts->timestamp_second;
+	tm_datetime.tm_min = ts->timestamp_minute;
+	tm_datetime.tm_hour = ts->timestamp_hour;
+	tm_datetime.tm_mday = ts->timestamp_day;
+	tm_datetime.tm_mon = ts->timestamp_month-1;
+	tm_datetime.tm_year = ts->timestamp_year-1900;
+	tm_datetime.tm_isdst = ts->timestamp_isdst;
+	return mktime(&tm_datetime);
 }
 
 /*
@@ -285,6 +291,7 @@ cmyth_timestamp_to_unixtime(cmyth_timestamp_t ts)
  * user supplied buffer 'str'.  The size of 'str' must be
  * CMYTH_TIMESTAMP_LEN + 1 or this will overwrite beyond 'str'.
  *
+ * Format: ISO-8601 '%Y-%m-%dT%H:%i:%s' "2013-03-21T18:02:59"
  *
  * Return Value:
  *
@@ -327,6 +334,7 @@ cmyth_timestamp_to_string(char *str, cmyth_timestamp_t ts)
  * user supplied buffer 'str'.  The size of 'str' must be
  * CMYTH_TIMESTAMP_LEN + 1 or this will overwrite beyond 'str'.
  *
+ * Format: ISO-8601 '%Y-%m-%d' "2013-03-21"
  *
  * Return Value:
  *
@@ -356,8 +364,7 @@ cmyth_timestamp_to_isostring(char *str, cmyth_timestamp_t ts)
 }
 
 int
-cmyth_timestamp_to_display_string(char *str, cmyth_timestamp_t ts,
-																	int time_format_12)
+cmyth_timestamp_to_display_string(char *str, cmyth_timestamp_t ts, int time_format_12)
 {
 	if (!str) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: NULL output string provided\n",
@@ -455,7 +462,48 @@ cmyth_datetime_to_string(char *str, cmyth_timestamp_t ts)
 	return 0;
 }
 
-
+/*
+ * cmyth_timestamp_to_numstring(char *str, cmyth_timestamp_t ts)
+ *
+ * Scope: PUBLIC
+ *
+ * Description
+ *
+ * Create a string from the timestamp structure 'ts' and put it in the
+ * user supplied buffer 'str'.  The size of 'str' must be
+ * CMYTH_TIMESTAMP_NUMERIC_LEN + 1 or this will overwrite beyond 'str'.
+ *
+ * Format: Numeric big endian '%Y%m%d%H%i%s' "20130321180259"
+ *
+ * Return Value:
+ *
+ * Success: 0
+ *
+ * Failure: -(ERRNO)
+ */
+int
+cmyth_timestamp_to_numstring(char *str, cmyth_timestamp_t ts)
+{
+	if (!str) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: NULL output string provided\n",
+			  __FUNCTION__);
+		return -EINVAL;
+	}
+	if (!ts) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: NULL timestamp provided\n",
+			  __FUNCTION__);
+		return -EINVAL;
+	}
+	sprintf(str,
+		"%4.4ld%2.2ld%2.2ld%2.2ld%2.2ld%2.2ld",
+		ts->timestamp_year,
+		ts->timestamp_month,
+		ts->timestamp_day,
+		ts->timestamp_hour,
+		ts->timestamp_minute,
+		ts->timestamp_second);
+	return 0;
+}
 
 /*
  * cmyth_timestamp_compare(cmyth_timestamp_t ts1, cmyth_timestamp_t ts2)


### PR DESCRIPTION
This updates the MythTV addon to version 1.7.11.

Changelog:
- Fixed crash when setting up Live TV (in rare cases)
- Fixed issue with not updated recording list (Daylight Saving Time)
- Fixed issue with empty recording list (caused by '[' character)
- Fixed playback of recordings made by a slave backend
- Removed 'Failed to connect to MythTV Backend' notification
- Some changes under the hood (improve data buffers and mutexes). This does not have any functional impacts, but cleans up some code parts, and might improve performance under certain conditions.
