### PR TITLE
sync: Adapt CallMenuHook to API change

### DIFF
--- a/addons/pvr.argustv/src/client.cpp
+++ b/addons/pvr.argustv/src/client.cpp
@@ -388,9 +388,10 @@ PVR_ERROR DialogChannelScan()
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook)
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
   NOTUSED(menuhook);
+  NOTUSED(item);
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 

--- a/addons/pvr.demo/src/client.cpp
+++ b/addons/pvr.demo/src/client.cpp
@@ -305,7 +305,7 @@ PVR_ERROR GetRecordings(ADDON_HANDLE handle)
 
 /** UNUSED API FUNCTIONS */
 PVR_ERROR DialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR MoveChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -496,7 +496,7 @@ PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) { return PVR_E
 void DemuxAbort(void) { return; }
 DemuxPacket* DemuxRead(void) { return NULL; }
 PVR_ERROR DialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR MoveChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/addons/pvr.hts/src/client.cpp
+++ b/addons/pvr.hts/src/client.cpp
@@ -619,7 +619,7 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &g
   return HTSPData->GetChannelGroupMembers(handle, group);
 }
 
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook)
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
   if (!HTSPData || !HTSPData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.mediaportal.tvserver/src/client.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/client.cpp
@@ -535,7 +535,7 @@ PVR_ERROR DialogChannelScan()
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook)
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }

--- a/addons/pvr.mythtv.cmyth/src/client.cpp
+++ b/addons/pvr.mythtv.cmyth/src/client.cpp
@@ -532,12 +532,12 @@ PVR_ERROR DialogChannelScan()
   return PVR_ERROR_FAILED;
 }
 
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook)
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
   if (g_client == NULL)
     return PVR_ERROR_SERVER_ERROR;
 
-  return g_client->CallMenuHook(menuhook);
+  return g_client->CallMenuHook(menuhook, item);
 }
 
 /*******************************************/

--- a/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.cpp
+++ b/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.cpp
@@ -1692,9 +1692,10 @@ long long PVRClientMythTV::LengthRecordedStream()
   return retval;
 }
 
-PVR_ERROR PVRClientMythTV::CallMenuHook(const PVR_MENUHOOK &menuhook)
+PVR_ERROR PVRClientMythTV::CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
   (void)menuhook;
+  (void)item;
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 

--- a/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.h
+++ b/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.h
@@ -114,7 +114,7 @@ public:
   long long LengthRecordedStream();
 
   // Menu hook
-  PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook);
+  PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item);
 
   // Backend settings
   bool GetLiveTVPriority();

--- a/addons/pvr.nextpvr/src/client.cpp
+++ b/addons/pvr.nextpvr/src/client.cpp
@@ -367,7 +367,7 @@ PVR_ERROR DialogChannelScan()
   return PVR_ERROR_NOT_IMPLEMENTED;
 }
 
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook)
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item)
 {
   return PVR_ERROR_NOT_IMPLEMENTED;
 }

--- a/addons/pvr.njoy/src/client.cpp
+++ b/addons/pvr.njoy/src/client.cpp
@@ -244,7 +244,7 @@ unsigned int GetChannelSwitchDelay(void)
 /** UNUSED API FUNCTIONS */
 PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DialogChannelScan() { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetChannelGroupsAmount(void) { return 0; }
 PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/addons/pvr.vdr.vnsi/src/client.cpp
+++ b/addons/pvr.vdr.vnsi/src/client.cpp
@@ -647,7 +647,7 @@ long long LengthRecordedStream(void)
 }
 
 /** UNUSED API FUNCTIONS */
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR MoveChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/addons/pvr.vuplus/src/client.cpp
+++ b/addons/pvr.vuplus/src/client.cpp
@@ -585,7 +585,7 @@ PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES* pProperties) { return PVR_E
 void DemuxAbort(void) { return; }
 DemuxPacket* DemuxRead(void) { return NULL; }
 PVR_ERROR DialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR CallMenuHook(const PVR_MENUHOOK &menuhook, const PVR_MENUHOOK_DATA &item) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR RenameChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR MoveChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }


### PR DESCRIPTION
Needs to go in with https://github.com/xbmc/xbmc/pull/2812 and also requires a version bump.
