### PR TITLE
vnsi: fix Makefile.am, did not include all objs

### DIFF
--- a/addons/pvr.vdr.vnsi/Makefile.am
+++ b/addons/pvr.vdr.vnsi/Makefile.am
@@ -24,10 +24,9 @@ libvdrvnsi_addon_la_SOURCES = src/client.cpp \
                               src/tools.cpp
                               
 if HAVE_GLES2
-lib_LTLIBRARIES += libvdrvnsi-addon-helpers.la
-libvdrvnsi_addon_helpers_la_SOURCES = src/EGLHelpers/VisGUIShader.cpp \
-                                      src/EGLHelpers/VisShader.cpp \
-                                      src/EGLHelpers/VisMatrixGLES.cpp                     
+libvdrvnsi_addon_la_SOURCES += src/EGLHelpers/VisGUIShader.cpp \
+                               src/EGLHelpers/VisShader.cpp \
+                               src/EGLHelpers/VisMatrixGLES.cpp                     
 endif
 
 libvdrvnsi_addon_la_LDFLAGS = @TARGET_LDFLAGS@


### PR DESCRIPTION
I accidently thought that all LTLIBRARIES were linked to the addon lib. This is not the case. Fixes error when loading vnsi addon on rpi.
