### PR TITLE
[iptvsimple] Release v1.8.1

### DIFF
--- a/addons/pvr.iptvsimple/addon/addon.xml.in
+++ b/addons/pvr.iptvsimple/addon/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="1.8.0"
+  version="1.8.1"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.8.0"/>
+    <import addon="xbmc.pvr" version="1.8.1"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/addons/pvr.iptvsimple/addon/changelog.txt
+++ b/addons/pvr.iptvsimple/addon/changelog.txt
@@ -1,0 +1,9 @@
+v1.8.1
+- fixed issue with BOM header in EPG XML
+- fixed issue with update channels if they are changed in m3u
+- added setting starting number of channels
+
+v1.8.0
+- Initial version
+- Supports m3u as Live TV streams source and XMLTV as EPG source
+- Supports Live TV, Radio channels and EPG

--- a/addons/pvr.iptvsimple/addon/resources/language/English/strings.po
+++ b/addons/pvr.iptvsimple/addon/resources/language/English/strings.po
@@ -32,7 +32,7 @@ msgid "Remote Path (Internet address)"
 msgstr ""
 
 msgctxt "#30010"
-msgid "Play List Settings"
+msgid "General"
 msgstr ""
 
 msgctxt "#30011"
@@ -41,6 +41,10 @@ msgstr ""
 
 msgctxt "#30012"
 msgid "M3U Play List URL"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Numbering channels starts at"
 msgstr ""
 
 msgctxt "#30020"

--- a/addons/pvr.iptvsimple/addon/resources/language/French/strings.po
+++ b/addons/pvr.iptvsimple/addon/resources/language/French/strings.po
@@ -31,8 +31,8 @@ msgid "Remote Path (Internet address)"
 msgstr "Chemin d'accès (adresse internet)"
 
 msgctxt "#30010"
-msgid "Play List Settings"
-msgstr "Paramètres de la Playlist"
+msgid "General"
+msgstr "General"
 
 msgctxt "#30011"
 msgid "M3U Play List Path"
@@ -41,6 +41,10 @@ msgstr "Chemin de la Playlist M3U"
 msgctxt "#30012"
 msgid "M3U Play List URL"
 msgstr "URL de la playlist M3U"
+
+msgctxt "#30013"
+msgid "Numbering channels starts at"
+msgstr "Numbering channels starts at"
 
 msgctxt "#30020"
 msgid "EPG Settings"

--- a/addons/pvr.iptvsimple/addon/resources/language/Russian/strings.po
+++ b/addons/pvr.iptvsimple/addon/resources/language/Russian/strings.po
@@ -30,8 +30,8 @@ msgid "Remote Path (Internet address)"
 msgstr "Удалённый путь (сеть Интернет)"
 
 msgctxt "#30010"
-msgid "Play List Settings"
-msgstr "Установки плейлиста"
+msgid "General"
+msgstr "Основные"
 
 msgctxt "#30011"
 msgid "M3U Play List Path"
@@ -40,6 +40,10 @@ msgstr "Путь к M3U"
 msgctxt "#30012"
 msgid "M3U Play List URL"
 msgstr "Ссылка на M3U"
+
+msgctxt "#30013"
+msgid "Numbering channels starts at"
+msgstr "Начинать нумерацию каналов с"
 
 msgctxt "#30020"
 msgid "EPG Settings"

--- a/addons/pvr.iptvsimple/addon/resources/settings.xml
+++ b/addons/pvr.iptvsimple/addon/resources/settings.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-	<setting id="sep1" label="30010" type="lsep"/> 
-	<setting id="m3uPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
-	<setting id="m3uPath" type="file" label="30011" default="" visible="eq(-1,0)"/>
-	<setting id="m3uUrl" type="text" label="30012" default="" visible="eq(-2,1)"/>
+  <!-- M3U -->
+  <category label="30010">
+    <setting id="sep1" label="30010" type="lsep"/> 
+    <setting id="m3uPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
+    <setting id="m3uPath" type="file" label="30011" default="" visible="eq(-1,0)"/>
+    <setting id="m3uUrl" type="text" label="30012" default="" visible="eq(-2,1)"/>
+    <setting id="startNum" type="number" label="30013" default="1" />
+  </category>
 
-	<setting id="sep2" label="30020" type="lsep"/>
-	<setting id="epgPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
-	<setting id="epgPath" type="file" label="30021" default="" visible="eq(-1,0)"/>
-	<setting id="epgUrl" type="text" label="30022" default="" visible="eq(-2,1)"/>
-<!--	<setting id="epgTimeShift" type="slider" label="30024" default="0" range="-12,.5,12" option="float"/>-->
-	<setting id="epgTimeShift_" type="enum" label="30024" default="12" values="-12|-11|-10|-9|-8|-7|-6|-5|-4|-3|-2|-1|0|+1|+2|+3|+4|+5|+6|+7|+8|+9|+10|+11|+12"/>-->
-	<setting id="epgTSOverride" type="bool" label="30023" default="false"/>
+  <!-- EPG -->
+  <category label="30020">
+    <setting id="sep2" label="30020" type="lsep"/>
+    <setting id="epgPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
+    <setting id="epgPath" type="file" label="30021" default="" visible="eq(-1,0)"/>
+    <setting id="epgUrl" type="text" label="30022" default="" visible="eq(-2,1)"/>
+<!--    <setting id="epgTimeShift" type="slider" label="30024" default="0" range="-12,.5,12" option="float"/>-->
+    <setting id="epgTimeShift_" type="enum" label="30024" default="12" values="-12|-11|-10|-9|-8|-7|-6|-5|-4|-3|-2|-1|0|+1|+2|+3|+4|+5|+6|+7|+8|+9|+10|+11|+12"/>-->
+    <setting id="epgTSOverride" type="bool" label="30023" default="false"/>
+  </category>
 
-	<setting id="sep3" label="30030" type="lsep"/>
-	<setting id="logoPath" type="folder" label="30031" default="" />
+  <!-- Logos -->
+  <category label="30030">
+    <setting id="sep3" label="30030" type="lsep"/>
+    <setting id="logoPath" type="folder" label="30031" default="" />
+  </category>
 </settings>

--- a/addons/pvr.iptvsimple/src/PVRIptvData.h
+++ b/addons/pvr.iptvsimple/src/PVRIptvData.h
@@ -103,6 +103,7 @@ protected:
   virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath, std::string &strContent);
   virtual void                 ApplyChannelsLogos();
   virtual CStdString           ReadMarkerValue(std::string &strLine, const char * strMarkerName);
+  virtual int                  GetChannelId(const char * strChannelName, const char * strStreamUrl);
 
 protected:
   virtual void *Process(void);

--- a/addons/pvr.iptvsimple/src/client.cpp
+++ b/addons/pvr.iptvsimple/src/client.cpp
@@ -54,6 +54,7 @@ std::string g_strTvgPath    = "";
 std::string g_strM3UPath    = "";
 std::string g_strLogoPath   = "";
 int         g_iEPGTimeShift = 0;
+int         g_iStartNumber  = 1;
 bool        g_bTSOverride   = true;
 
 extern std::string PathCombine(const std::string &strPath, const std::string &strFileName)
@@ -102,7 +103,10 @@ void ADDON_ReadSettings(void)
   {
     g_strM3UPath = GetClientFilePath(M3U_FILE_NAME);
   }
-
+  if (!XBMC->GetSetting("startNum", &g_iStartNumber)) 
+  {
+    g_iStartNumber = 1;
+  }
   if (!XBMC->GetSetting("epgPathType", &iPathType)) 
   {
     iPathType = 1;

--- a/addons/pvr.iptvsimple/src/client.h
+++ b/addons/pvr.iptvsimple/src/client.h
@@ -27,7 +27,7 @@
 #include "libXBMC_pvr.h"
 #include "libXBMC_gui.h"
 
-#define PVR_CLIENT_VERSION     "0.1.3"
+#define PVR_CLIENT_VERSION     "1.8.1"
 #define M3U_FILE_NAME          "iptv.m3u.cache"
 #define TVG_FILE_NAME          "xmltv.xml.cache"
 
@@ -47,6 +47,7 @@ extern std::string g_strM3UPath;
 extern std::string g_strTvgPath;
 extern std::string g_strLogoPath;
 extern int         g_iEPGTimeShift;
+extern int         g_iStartNumber;
 extern bool        g_bTSOverride;
 
 extern std::string PathCombine(const std::string &strPath, const std::string &strFileName);


### PR DESCRIPTION
This updates the IPTV Simple addon to version 1.8.1.

Changelog:
- Fixed issue with BOM header in EPG XML
- Fixed issue with update channels if they are changed in m3u
- Added setting starting number of channels

Some changes under the hood (cosmetics and improved finding data).
