### PR TITLE
Allow to change channels numbering from M3U playlist directly

### DIFF
--- a/addons/pvr.iptvsimple/src/PVRIptvData.cpp
+++ b/addons/pvr.iptvsimple/src/PVRIptvData.cpp
@@ -325,7 +325,6 @@ bool PVRIptvData::LoadPlayList(void)
   int iUniqueChannelId  = 0;
   int iUniqueGroupId    = 0;
   int iCurrentGroupId   = 0;
-  int iChannelNum       = 0;
   int iEPGTimeShift     = 0;
 
   PVRIptvChannel tmpChannel;
@@ -360,7 +359,6 @@ bool PVRIptvData::LoadPlayList(void)
       {
         double fTvgShift = atof(ReadMarkerValue(strLine, TVG_INFO_SHIFT_MARKER));
         iEPGTimeShift = (int) (fTvgShift * 3600.0);
-        iChannelNum = atoi(ReadMarkerValue(strLine, TVG_INFO_NUM_MARKER));
         continue;
       }
       else
@@ -373,6 +371,7 @@ bool PVRIptvData::LoadPlayList(void)
     {
       bool        bRadio       = false;
       double      fTvgShift    = 0;
+      int         iTvgNum      = 1;
       CStdString  strChnlName  = "";
       CStdString  strTvgId     = "";
       CStdString  strTvgName   = "";
@@ -399,6 +398,7 @@ bool PVRIptvData::LoadPlayList(void)
         strGroupName  = ReadMarkerValue(strInfoLine, GROUP_NAME_MARKER);
         strRadio      = ReadMarkerValue(strInfoLine, RADIO_MARKER);
         fTvgShift     = atof(ReadMarkerValue(strInfoLine, TVG_INFO_SHIFT_MARKER));
+        iTvgNum       = atoi(ReadMarkerValue(strInfoLine, TVG_INFO_NUM_MARKER));
 
         if (strTvgId.IsEmpty())
         {
@@ -411,12 +411,13 @@ bool PVRIptvData::LoadPlayList(void)
           strTvgLogo = strChnlName;
         }
 
-        bRadio                = !strRadio.CompareNoCase("true");
-        tmpChannel.strTvgId   = strTvgId;
-        tmpChannel.strTvgName = XBMC->UnknownToUTF8(strTvgName);
-        tmpChannel.strTvgLogo = XBMC->UnknownToUTF8(strTvgLogo);
-        tmpChannel.iTvgShift  = (int)(fTvgShift * 3600.0);
-        tmpChannel.bRadio     = bRadio;
+        bRadio                    = !strRadio.CompareNoCase("true");
+        tmpChannel.iChannelNumber = iTvgNum;
+        tmpChannel.strTvgId       = strTvgId;
+        tmpChannel.strTvgName     = XBMC->UnknownToUTF8(strTvgName);
+        tmpChannel.strTvgLogo     = XBMC->UnknownToUTF8(strTvgLogo);
+        tmpChannel.iTvgShift      = (int)(fTvgShift * 3600.0);
+        tmpChannel.bRadio         = bRadio;
 
         if (tmpChannel.iTvgShift == 0 && iEPGTimeShift != 0)
         {
@@ -449,7 +450,7 @@ bool PVRIptvData::LoadPlayList(void)
     {
       PVRIptvChannel channel;
       channel.iUniqueId         = ++iUniqueChannelId;
-      channel.iChannelNumber    = ++iChannelNum;
+      channel.iChannelNumber    = tmpChannel.iChannelNumber;
       channel.strTvgId          = tmpChannel.strTvgId;
       channel.strChannelName    = tmpChannel.strChannelName;
       channel.strTvgName        = tmpChannel.strTvgName;


### PR DESCRIPTION
This allows to set a "min" channel number directly in M3U playlist, like it is done in other PVR addons (eg. tvheadend allows to set channel number individually per channel in webui).
