### PR TITLE
populate service/provider name and mux in PVR_SIGNAL_STATUS

### DIFF
--- a/addons/pvr.hts/src/HTSPDemux.cpp
+++ b/addons/pvr.hts/src/HTSPDemux.cpp
@@ -235,6 +235,10 @@ bool CHTSPDemux::GetSignalStatus(PVR_SIGNAL_STATUS &qualityinfo)
 
   strncpy(qualityinfo.strAdapterName, m_SourceInfo.si_adapter.c_str(), sizeof(qualityinfo.strAdapterName));
   strncpy(qualityinfo.strAdapterStatus, m_Quality.fe_status.c_str(), sizeof(qualityinfo.strAdapterStatus));
+  strncpy(qualityinfo.strServiceName, m_SourceInfo.si_service.c_str(), sizeof(qualityinfo.strServiceName));
+  strncpy(qualityinfo.strProviderName, m_SourceInfo.si_provider.c_str(), sizeof(qualityinfo.strProviderName));
+  strncpy(qualityinfo.strMuxName, m_SourceInfo.si_mux.c_str(), sizeof(qualityinfo.strMuxName));
+
   qualityinfo.iSignal       = (uint16_t)m_Quality.fe_signal;
   qualityinfo.iSNR          = (uint16_t)m_Quality.fe_snr;
   qualityinfo.iBER          = (uint32_t)m_Quality.fe_ber;

--- a/xbmc/xbmc_pvr_types.h
+++ b/xbmc/xbmc_pvr_types.h
@@ -194,6 +194,9 @@ extern "C" {
   {
     char   strAdapterName[PVR_ADDON_NAME_STRING_LENGTH];   /*!< @brief (optional) name of the adapter that's being used */
     char   strAdapterStatus[PVR_ADDON_NAME_STRING_LENGTH]; /*!< @brief (optional) status of the adapter that's being used */
+    char   strServiceName[PVR_ADDON_NAME_STRING_LENGTH];   /*!< @brief (optional) name of the current service */
+    char   strProviderName[PVR_ADDON_NAME_STRING_LENGTH];  /*!< @brief (optional) name of the current service's provider */
+    char   strMuxName[PVR_ADDON_NAME_STRING_LENGTH];       /*!< @brief (optional) name of the current mux */
     int    iSNR;                                           /*!< @brief (optional) signal/noise ratio */
     int    iSignal;                                        /*!< @brief (optional) signal strength */
     long   iBER;                                           /*!< @brief (optional) bit error rate */


### PR DESCRIPTION
See https://github.com/xbmc/xbmc/pull/3132

I don't know if the current approach to parsing the mux string to a double is very elegant, but it seems fairly robust.
