### PR TITLE
[argustv-fix] Live-TV was not working on XBMC Gotham Windows

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.8.166"
+  version="1.8.167"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.8.167 (29-08-2013)
+- Fixed Live-TV XBMC Gotham
 v1.8.166 (08-06-2013)
 - sync with PVR API v1.8.0
 v1.7.166 (13-03-2013)

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -1261,23 +1261,21 @@ bool cPVRClientArgusTV::_OpenLiveStream(const PVR_CHANNEL &channelinfo)
       }
     }
 
-#if defined(TARGET_LINUX) || defined(TARGET_DARWIN)
-    // TODO FHo: merge this code and the code that translates names from recordings
     std::string CIFSname = filename;
     std::string SMBPrefix = "smb://";
-    if (g_szUser.length() > 0)
-    {
-      SMBPrefix += g_szUser;
-      if (g_szPass.length() > 0)
-      {
-        SMBPrefix += ":" + g_szPass;
-      }
-    }
-    else
-    {
-      SMBPrefix += "Guest";
-    }
-    SMBPrefix += "@";
+    //if (g_szUser.length() > 0)
+    //{
+    //  SMBPrefix += g_szUser;
+    //  if (g_szPass.length() > 0)
+    //  {
+    //    SMBPrefix += ":" + g_szPass;
+    //  }
+    //}
+    //else
+    //{
+    //  SMBPrefix += "Guest";
+    //}
+    //SMBPrefix += "@";
     size_t found;
     while ((found = CIFSname.find("\\")) != std::string::npos)
     {
@@ -1286,7 +1284,6 @@ bool cPVRClientArgusTV::_OpenLiveStream(const PVR_CHANNEL &channelinfo)
     CIFSname.erase(0,2);
     CIFSname.insert(0, SMBPrefix.c_str());
     filename = CIFSname;
-#endif
 
     if (retval != E_SUCCESS || filename.length() == 0)
     {


### PR DESCRIPTION
Due to changes in the XBMC-> file I/O handling Live-TV was no longer working in Windows. Using smb:// style names for file shares on Windows too now.
