### PR TITLE
[pvr.hts] move m_bIsOpen=true; from ParseSubscriptionStart() back to Open(), fixes deadlock in GetStreamProperties() when all adapters in backend are busy (closes #14571)

### DIFF
--- a/addons/pvr.hts/src/HTSPDemux.cpp
+++ b/addons/pvr.hts/src/HTSPDemux.cpp
@@ -59,6 +59,7 @@ bool CHTSPDemux::Open(const PVR_CHANNEL &channelinfo)
   if(!SendSubscribe(++m_subs, m_channel))
     return false;
 
+  m_bIsOpen = true;
   return true;
 }
 
@@ -392,7 +393,6 @@ void CHTSPDemux::ParseSubscriptionStart(htsmsg_t *m)
     XBMC->Log(LOG_INFO, "%s - subscription started on an unknown device", __FUNCTION__);
   }
 
-  m_bIsOpen = true;
   m_startedCondition.Signal();
 }
 


### PR DESCRIPTION
In https://github.com/opdenkamp/xbmc-pvr-addons/commit/388a25ed8200826e05311d1db07926466fea9311 in HTSPDemux.cpp, the m_bIsOpen bool update was moved from Open() to the end of ParseSubscriptionStart(). That flag is then checked in GetStreamProperties() with a wait-lock. When on the server side all adapters are in use however, the code in ParseSubscriptionStart() which updated the bool is never reached while GetStreamProperties() is called, running into an endless wait on bIsOpen to become true, which will eventually only be the case if some backend resources (adapters) are freed. Until then, XBMC appears to be frozen/deadlocked.

This small patch reverts the portion of the mentioned commit that moves the m_bIsOpen update back into Open() (judging by the name it belongs there - all things in Open() succeeded, so declare IsOpen=true), restoring behaviour as of before that commit, which seems to have worked out without problems in the past.

I'm not sure if the move down into ParseSubscriptionStart() was done intentionally (you/others most likely know all interworkings better ;) ), but this way the deadlock/freeze is gone, and hammering in the client didn't cause any harm.

Closes Trac#14571.
