### PR TITLE
add support to build in a seperate builddir like OpenELEC does per stand...

### DIFF
--- a/addons/Makefile.include.am
+++ b/addons/Makefile.include.am
@@ -36,7 +36,9 @@ else
 	mkdir -m 755 -p $(DESTDIR)@LIBDIR@/$(ADDONNAME)
 	mkdir -m 755 -p $(DESTDIR)@DATADIR@/$(ADDONNAME)
 	cp -f @BINPREFIX@$(ADDONBINNAME)@BIN_EXT@ $(DESTDIR)@LIBDIR@/$(ADDONNAME) ; chmod 655 $(DESTDIR)@LIBDIR@/$(ADDONNAME)/@BINPREFIX@$(ADDONBINNAME)@BIN_EXT@
-	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon/* $(DESTDIR)@DATADIR@/$(ADDONNAME) ; chmod -R o+rx $(DESTDIR)@DATADIR@/$(ADDONNAME)
+	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon/* $(DESTDIR)@DATADIR@/$(ADDONNAME)
+	cp -r -f @abs_top_builddir@/addons/$(ADDONNAME)/addon/* $(DESTDIR)@DATADIR@/$(ADDONNAME)
+	chmod -R o+rx $(DESTDIR)@DATADIR@/$(ADDONNAME)
 endif
 
 all: @BUILD_TYPE@

--- a/addons/pvr.argustv/Makefile.am
+++ b/addons/pvr.argustv/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.argustv
 LIBNAME         = libargustv-addon
 lib_LTLIBRARIES = libargustv-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/jsoncpp/libjsoncpp.la
+LIBS            = @abs_top_builddir@/lib/jsoncpp/libjsoncpp.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc -Isrc/lib/filesystem -I@abs_top_srcdir@/lib/jsoncpp/include
+INCLUDES+=-I$(srcdir)/src -I$(srcdir)/src/lib/filesystem -I@abs_top_srcdir@/lib/jsoncpp/include
 
 libargustv_addon_la_SOURCES = src/activerecording.cpp \
                                    src/channel.cpp \

--- a/addons/pvr.demo/Makefile.am
+++ b/addons/pvr.demo/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.demo
 LIBNAME         = libpvrdemo-addon
 lib_LTLIBRARIES = libpvrdemo-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/addons/pvr.hts/Makefile.am
+++ b/addons/pvr.hts/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.hts
 LIBNAME         = libtvheadend-addon
 lib_LTLIBRARIES = libtvheadend-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/libhts/libhts.la -ldl
+LIBS            = @abs_top_builddir@/lib/libhts/libhts.la -ldl
 
 include ../Makefile.include.am
 

--- a/addons/pvr.mediaportal.tvserver/Makefile.am
+++ b/addons/pvr.mediaportal.tvserver/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.mediaportal.tvserver
 LIBNAME         = libmediaportal-addon
 lib_LTLIBRARIES = libmediaportal-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc
+INCLUDES+=-I$(srcdir)/src
 
 libmediaportal_addon_la_SOURCES = src/Cards.cpp \
                                   src/channels.cpp \

--- a/addons/pvr.mythtv.cmyth/Makefile.am
+++ b/addons/pvr.mythtv.cmyth/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.mythtv.cmyth
 LIBNAME         = libmythtvcmyth-addon
 lib_LTLIBRARIES = libmythtvcmyth-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/cmyth/libcmyth.la
+LIBS            = @abs_top_builddir@/lib/cmyth/libcmyth.la
 
 AM_CPPFLAGS = -I$(abs_top_srcdir)/lib/cmyth/include
 

--- a/addons/pvr.nextpvr/Makefile.am
+++ b/addons/pvr.nextpvr/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.nextpvr
 LIBNAME         = libnextpvr-addon
 lib_LTLIBRARIES = libnextpvr-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc
+INCLUDES+=-I$(srcdir)/src
 
 libnextpvr_addon_la_SOURCES = src/client.cpp \
                                   src/pvrclient-nextpvr.cpp \

--- a/addons/pvr.njoy/Makefile.am
+++ b/addons/pvr.njoy/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.njoy
 LIBNAME         = libpvrnjoy-addon
 lib_LTLIBRARIES = libpvrnjoy-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/addons/pvr.vuplus/Makefile.am
+++ b/addons/pvr.vuplus/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.vuplus
 LIBNAME         = libvuplus-addon
 lib_LTLIBRARIES = libvuplus-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/lib/cmyth/libcmyth/Makefile.am
+++ b/lib/cmyth/libcmyth/Makefile.am
@@ -25,7 +25,7 @@ libcmyth_la_SOURCES = bookmark.c \
                      channel.c \
                      storagegroup.c
 
-INCLUDES=-I../include/ $(MYSQL_INCLUDES)
+INCLUDES=-I$(srcdir)/../include/ $(MYSQL_INCLUDES)
 
 $(LIB): libcmyth.la
 	cp -f .libs/libcmyth.a .

--- a/lib/cmyth/librefmem/Makefile.am
+++ b/lib/cmyth/librefmem/Makefile.am
@@ -3,7 +3,7 @@ noinst_LTLIBRARIES = librefmem.la
 librefmem_la_SOURCES = alloc.c \
                       debug_refmem.c
 
-INCLUDES=-I../include/ -I../libcmyth/
+INCLUDES=-I$(srcdir)/../include/ -I$(srcdir)/../libcmyth/
 
 $(LIB): librefmem.la
 	cp -f .libs/librefmem.a .

--- a/lib/jsoncpp/Makefile.am
+++ b/lib/jsoncpp/Makefile.am
@@ -4,7 +4,7 @@ libjsoncpp_la_SOURCES = src/lib_json/json_reader.cpp \
                         src/lib_json/json_value.cpp \
                         src/lib_json/json_writer.cpp
 
-INCLUDES=-Iinclude/
+INCLUDES=-I$(srcdir)/include/
 
 $(LIB): libjsoncpp.la
 	cp -f .libs/libjsoncpp.a .


### PR DESCRIPTION
...ard with the new packageformat. For this its needed to change @abs_top_srcdir@ (the sourcedir) to @abs_top_builddir@ (the real builddir) and changing all relative paths to absolute paths with help of $(srcdir) in includes.
