### PR TITLE
Fixes playing recordings on Windows

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.8.168"
+  version="1.8.169"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,6 @@
+v1.8.169 (28-09-2013)
+- Fixes playing recordings on Windows
+- Migrated all UNC share name handling to single method
 v1.8.168 (12-09-2013)
 - Minimum ARGUS TV version 2.1 required
 - Switched to integer ID's

--- a/addons/pvr.argustv/src/argustvrpc.cpp
+++ b/addons/pvr.argustv/src/argustvrpc.cpp
@@ -1309,56 +1309,6 @@ namespace ArgusTV
     return wcfdate;
   }
 
-  // transform [\\nascat\qrecordings\NCIS\2012-05-15_20-30_SBS 6_NCIS.ts]
-  // into      [smb://user:password@nascat/qrecordings/NCIS/2012-05-15_20-30_SBS 6_NCIS.ts]
-  std::string ToCIFS(std::string& UNCName)
-  {
-    std::string CIFSname = UNCName;
-    std::string SMBPrefix = "smb://";
-    if (g_szUser.length() > 0)
-    {
-      SMBPrefix += g_szUser;
-      if (g_szPass.length() > 0)
-      {
-        SMBPrefix += ":" + g_szPass;
-      }
-    }
-    else
-    {
-      SMBPrefix += "Guest";
-    }
-    SMBPrefix += "@";
-    size_t found;
-    while ((found = CIFSname.find("\\")) != std::string::npos)
-    {
-      CIFSname.replace(found, 1, "/");
-    }
-    CIFSname.erase(0,2);
-    CIFSname.insert(0, SMBPrefix);
-    return CIFSname;
-  }
-
-
-  // transform [smb://user:password@nascat/qrecordings/NCIS/2012-05-15_20-30_SBS 6_NCIS.ts]
-  // into      [\\nascat\qrecordings\NCIS\2012-05-15_20-30_SBS 6_NCIS.ts]
-  std::string ToUNC(std::string& CIFSName)
-  {
-    std::string UNCname = CIFSName;
-
-    UNCname.erase(0,6);
-    size_t found = UNCname.find("@");
-    if (found != std::string::npos) {
-      UNCname.erase(0, found+1);
-    }
-
-    while ((found = UNCname.find("/")) != std::string::npos)
-    {
-      UNCname.replace(found, 1, "\\");
-    }
-    UNCname.insert(0, "\\\\");
-    return UNCname;
-  }
-
 }
 
    

--- a/addons/pvr.argustv/src/argustvrpc.h
+++ b/addons/pvr.argustv/src/argustvrpc.h
@@ -344,6 +344,4 @@ namespace ArgusTV
 
   time_t WCFDateToTimeT(const std::string& wcfdate, int& offset);
   std::string TimeTToWCFDate(const time_t thetime);
-  std::string ToCIFS(std::string& UNCName);
-  std::string ToUNC(std::string& CIFSName);
 } //namespace ArgusTV

--- a/addons/pvr.argustv/src/recording.cpp
+++ b/addons/pvr.argustv/src/recording.cpp
@@ -107,7 +107,8 @@ bool cRecording::Parse(const Json::Value& data)
   programstoptime = ArgusTV::WCFDateToTimeT(t, offset);
   rating = data["Rating"].asString();
   recordingfileformatid = data["RecordingFileFormatId"].asString();
-  recordingfilename = data["RecordingFileName"].asString();
+  t = data["RecordingFileName"].asString();
+  recordingfilename = ToCIFS(t);
   recordingid = data["RecordingId"].asString();
   t = data["RecordingStartTime"].asString();
   recordingstarttime = ArgusTV::WCFDateToTimeT(t, offset);
@@ -126,29 +127,6 @@ bool cRecording::Parse(const Json::Value& data)
   thumbnailfilename = data["ThumbnailFileName"].asString();
   title = data["Title"].asString();
   videoaspect = (ArgusTV::VideoAspectRatio) data["VideoAspect"].asInt();
-  std::string CIFSname = recordingfilename;
-  std::string SMBPrefix = "smb://";
-  if (g_szUser.length() > 0)
-  {
-    SMBPrefix += g_szUser;
-    if (g_szPass.length() > 0)
-    {
-      SMBPrefix += ":" + g_szPass;
-    }
-  }
-  else
-  {
-    SMBPrefix += "Guest";
-  }
-  SMBPrefix += "@";
-  size_t found;
-  while ((found = CIFSname.find("\\")) != std::string::npos)
-  {
-    CIFSname.replace(found, 1, "/");
-  }
-  CIFSname.erase(0,2);
-  CIFSname.insert(0, SMBPrefix);
-  cifsrecordingfilename = CIFSname;  
 
   return true;
 }

--- a/addons/pvr.argustv/src/recording.h
+++ b/addons/pvr.argustv/src/recording.h
@@ -54,7 +54,6 @@ private:
   std::string rating;
   std::string recordingfileformatid;
   std::string recordingfilename;
-  std::string cifsrecordingfilename;
   std::string recordingid;
   time_t recordingstarttime;
   time_t recordingstoptime;
@@ -104,7 +103,6 @@ public:
   const char *Rating(void) const { return rating.c_str(); }
   const char *RecordingFileFormatId(void) const { return recordingfileformatid.c_str(); }
   const char *RecordingFileName(void) const { return recordingfilename.c_str(); }
-  const char *CIFSRecordingFileName(void) const { return cifsrecordingfilename.c_str(); }
   const char *RecordingId(void) const { return recordingid.c_str(); }
   time_t RecordingStartTime(void) const { return recordingstarttime; }
   time_t RecordingStopTime(void) const { return recordingstoptime; }

--- a/addons/pvr.argustv/src/utils.cpp
+++ b/addons/pvr.argustv/src/utils.cpp
@@ -85,6 +85,44 @@ namespace Json
 } //namespace Json
 
 
+// transform [\\nascat\qrecordings\NCIS\2012-05-15_20-30_SBS 6_NCIS.ts]
+// into      [smb://user:password@nascat/qrecordings/NCIS/2012-05-15_20-30_SBS 6_NCIS.ts]
+std::string ToCIFS(std::string& UNCName)
+{
+  std::string CIFSname = UNCName;
+  std::string SMBPrefix = "smb://";
+  size_t found;
+  while ((found = CIFSname.find("\\")) != std::string::npos)
+  {
+    CIFSname.replace(found, 1, "/");
+  }
+  CIFSname.erase(0,2);
+  CIFSname.insert(0, SMBPrefix);
+  return CIFSname;
+}
+
+
+// transform [smb://user:password@nascat/qrecordings/NCIS/2012-05-15_20-30_SBS 6_NCIS.ts]
+// into      [\\nascat\qrecordings\NCIS\2012-05-15_20-30_SBS 6_NCIS.ts]
+std::string ToUNC(std::string& CIFSName)
+{
+  std::string UNCname = CIFSName;
+
+  UNCname.erase(0,6);
+  size_t found;
+  while ((found = UNCname.find("/")) != std::string::npos)
+  {
+    UNCname.replace(found, 1, "\\");
+  }
+  UNCname.insert(0, "\\\\");
+  return UNCname;
+}
+
+std::string ToUNC(const char* CIFSName)
+{
+  std::string temp = CIFSName;
+  return ToUNC(temp);
+}
 #if defined(TARGET_WINDOWS)
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/addons/pvr.argustv/src/utils.h
+++ b/addons/pvr.argustv/src/utils.h
@@ -36,6 +36,10 @@ namespace Json
   void printValueTree( const Json::Value& value, const std::string& path = "." );
 }
 
+std::string ToCIFS(std::string& UNCName);
+std::string ToUNC(std::string& CIFSName);
+std::string ToUNC(const char* CIFSName);
+
 #if defined(TARGET_WINDOWS)
 namespace UTF8Util
 {


### PR DESCRIPTION
**FIX!**

It turned out that on the Windows platform, names of recordings were still passed as UNC share names. This causes the built-in player to fail in Gotham.

Now all UNC share name versus CIFS name handling is isolated into just two methods, and the addon internally always works with CIFS names (smb://....).

This actually strips a lot of code, making the addon code easier to follow, and hopefully more robust.
