### PR TITLE
Update socket.c to correctly match MythTV priorities

### DIFF
--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -1869,7 +1869,7 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	/*
 	 * Get proginfo_rec_priority (byte)
 	 */
-	consumed = cmyth_rcv_int8(conn, err,
+	consumed = cmyth_rcv_int32(conn, err,
 				    &buf->proginfo_rec_priority, count);
 	count -= consumed;
 	total += consumed;
@@ -2211,7 +2211,7 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 		/*
 		 * Get proginfo_recpriority_2 (byte)
 		 */
-		consumed = cmyth_rcv_int8(conn, err,
+		consumed = cmyth_rcv_int32(conn, err,
 					    &buf->proginfo_recpriority_2,
 					    count);
 		count -= consumed;


### PR DESCRIPTION
MythTV priorities can be significantly larger than the limits of a int8. This change allows users with recordings that have priorities outside of the int8 range to load recordings and use the MythTV PVR addon. 

Without this, the addon will fail to populate the recordings list if there are any recordings that had a priority outside the int8 range.
