### PR TITLE
vdr 2.1.2 buildfix (vnsiserver)

### DIFF
--- a/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/videobuffer.c
+++ b/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/videobuffer.c
@@ -386,7 +386,11 @@ bool cVideoBufferFile::Init()
       m_Filename = cString::sprintf("%s/Timeshift-%d.vnsi", TimeshiftBufferDir, m_ClientID);
   }
   else
+#if VDRVERSNUM >= 20102
+    m_Filename = cString::sprintf("%s/Timeshift-%d.vnsi", cVideoDirectory::Name(), m_ClientID);
+#else
     m_Filename = cString::sprintf("%s/Timeshift-%d.vnsi", VideoDirectory, m_ClientID);
+#endif
 
   m_Fd = open(m_Filename, O_RDWR | O_CREAT | O_TRUNC, S_IRWXU);
   if (m_Fd == -1)

--- a/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/vnsiclient.c
+++ b/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/vnsiclient.c
@@ -1403,7 +1403,11 @@ bool cVNSIClient::processTIMER_Update() /* OPCODE 85 */
 bool cVNSIClient::processRECORDINGS_GetDiskSpace() /* OPCODE 100 */
 {
   int FreeMB;
+#if VDRVERSNUM >= 20102
+  int Percent = cVideoDirectory::VideoDiskSpace(&FreeMB);
+#else
   int Percent = VideoDiskSpace(&FreeMB);
+#endif
   int Total   = (FreeMB / (100 - Percent)) * 100;
 
   m_resp->add_U32(Total);

--- a/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/vnsiserver.c
+++ b/addons/pvr.vdr.vnsi/vdr-plugin-vnsiserver/vnsiserver.c
@@ -213,7 +213,11 @@ void cVNSIServer::Action(void)
   }
   else
   {
+#if VDRVERSNUM >= 20102
+    cmd = cString::sprintf("rm -f %s/*.vnsi", cVideoDirectory::Name());
+#else
     cmd = cString::sprintf("rm -f %s/*.vnsi", VideoDirectory);
+#endif
   }
   int ret = system(cmd);
 


### PR DESCRIPTION
not sure if I should send this to @FernetMenta instead

from vdr changelog:
- The functions OpenVideoFile(), RenameVideoFile(), RemoveVideoFile(), VideoFileSpaceAvailable(),
  VideoDiskSpace(), RemoveEmptyVideoDirectories(), IsOnVideoDirectoryFileSystem() and
  PrefixVideoFileName() are now static members of cVideoDirectory and need to be called
  with the proper prefix.
- The name of the video directory is now available through cVideoDirectory::Name().
