### PR TITLE
[mythtv-cmyth] Release v1.8.13

### DIFF
--- a/addons/pvr.mythtv.cmyth/Makefile.am
+++ b/addons/pvr.mythtv.cmyth/Makefile.am
@@ -32,4 +32,5 @@ libmythtvcmyth_addon_la_SOURCES = src/client.cpp \
                                   src/cppmyth/MythSignal.cpp \
                                   src/cppmyth/MythRecordingRule.cpp \
                                   src/cppmyth/MythTimestamp.cpp \
-                                  src/cppmyth/MythEPGInfo.cpp
+                                  src/cppmyth/MythEPGInfo.cpp \
+                                  src/cppmyth/MythScheduleManager.cpp

--- a/addons/pvr.mythtv.cmyth/addon/addon.xml.in
+++ b/addons/pvr.mythtv.cmyth/addon/addon.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv.cmyth"
-  version="1.8.12"
+  version="1.8.13"
   name="MythTV cmyth PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière, Tonny Petersen">
   <requires>
     <c-pluff version="0.1"/>
-    <import addon="xbmc.pvr" version="1.8.0"/>
+    <import addon="xbmc.pvr" version="1.8.1"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/addons/pvr.mythtv.cmyth/addon/changelog.txt
+++ b/addons/pvr.mythtv.cmyth/addon/changelog.txt
@@ -1,3 +1,17 @@
+v1.8.13
+- Fixed crash when reconnecting to the backend
+- Fixed setting bookmarks when using MythTV 0.27 backend
+- Fixed usage of priority values (>256)
+- Fixed remaining time zone issues by using UTC based timestamps
+- Schedule management refactoring
+     - Fixed recording rule deletion
+     - Fixed handling of backend version specific varieties
+     - Fixed failed mappings due to gaps in the EPG
+     - Various smaller improvements and bug fixes
+- Provide accurate EDLs for videos with variable frame rate when using MythTV 0.27 backend
+- Added 'Keep Live TV recording' functionality
+- Improved start of Live TV playback
+
 v1.8.12
 - Added 'Delete and re-record' menuhook
 - Added support for MythTV protocol 76 and 77 (MythTV 0.27)

--- a/addons/pvr.mythtv.cmyth/addon/resources/language/English/strings.po
+++ b/addons/pvr.mythtv.cmyth/addon/resources/language/English/strings.po
@@ -168,7 +168,15 @@ msgctxt "#30308"
 msgid "Stopping Live TV due to conflicting recording: %s"
 msgstr ""
 
+msgctxt "#30309"
+msgid "Not recording"
+msgstr ""
+
 # Menu Hooks
 msgctxt "#30411"
 msgid "Delete and re-record"
+msgstr ""
+
+msgctxt "#30412"
+msgid "Keep LiveTV recording"
 msgstr ""

--- a/addons/pvr.mythtv.cmyth/addon/resources/settings.xml
+++ b/addons/pvr.mythtv.cmyth/addon/resources/settings.xml
@@ -2,12 +2,12 @@
 <settings>
   <category label="30019">
     <setting id="host" type="text" label="30000" default="127.0.0.1" />
-    <setting id="port" type="number" label="30001" default="6543" />
+    <setting id="port" type="number" option="int" label="30001" default="6543" />
     <setting id="db_user" type="text" label="30002" default="mythtv" />
     <setting id="db_password" type="text" label="30003" default="mythtv" />
     <setting id="db_name" type="text" label="30004" default="mythconverg" />
     <setting id="db_host" type="text" visible="false" />
-    <setting id="db_port" type="number" visible="false" default="3306" />
+    <setting id="db_port" type="number" option="int" visible="false" default="3306" />
     <setting id="extradebug" type="bool" label="30005" default="false" />
     <setting id="livetv" type="bool" label="30006" default="true" />
     <setting id="livetv_priority" type="bool" label="30007" default="true" />
@@ -20,7 +20,7 @@
     <setting id="rec_autocommflag" type="bool" label="30027" enable="eq(-3,0)" default="true" />
     <setting id="rec_autoexpire" type="bool" label="30034" enable="eq(-4,0)" default="true" />
     <setting id="rec_autotranscode" type="bool" label="30028" enable="eq(-5,0)" default="false" />
-    <setting id="rec_transcoder" type="number" label="30033" enable="eq(-6,0)" default="0" />
+    <setting id="rec_transcoder" type="number" option="int" label="30033" enable="eq(-6,0)" default="0" />
     <setting id="rec_autorunjob1" type="bool" label="30029" enable="eq(-7,0)" default="false" />
     <setting id="rec_autorunjob2" type="bool" label="30030" enable="eq(-8,0)" default="false" />
     <setting id="rec_autorunjob3" type="bool" label="30031" enable="eq(-9,0)" default="false" />

--- a/addons/pvr.mythtv.cmyth/project/VS2010Express/pvr.mythtv.cmyth.vcxproj
+++ b/addons/pvr.mythtv.cmyth/project/VS2010Express/pvr.mythtv.cmyth.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="..\..\src\cppmyth\MythProgramInfo.cpp" />
     <ClCompile Include="..\..\src\cppmyth\MythRecorder.cpp" />
     <ClCompile Include="..\..\src\cppmyth\MythRecordingRule.cpp" />
+    <ClCompile Include="..\..\src\cppmyth\MythScheduleManager.cpp" />
     <ClCompile Include="..\..\src\cppmyth\MythStorageGroupFile.cpp" />
     <ClCompile Include="..\..\src\cppmyth\MythSignal.cpp" />
     <ClCompile Include="..\..\src\cppmyth\MythTimestamp.cpp" />
@@ -42,6 +43,7 @@
     <ClInclude Include="..\..\src\cppmyth\MythProgramInfo.h" />
     <ClInclude Include="..\..\src\cppmyth\MythRecorder.h" />
     <ClInclude Include="..\..\src\cppmyth\MythRecordingRule.h" />
+    <ClInclude Include="..\..\src\cppmyth\MythScheduleManager.h" />
     <ClInclude Include="..\..\src\cppmyth\MythStorageGroupFile.h" />
     <ClInclude Include="..\..\src\cppmyth\MythSignal.h" />
     <ClInclude Include="..\..\src\cppmyth\MythTimestamp.h" />
@@ -111,7 +113,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_WINSOCKAPI_;USE_DEMUX;__STDC_CONSTANT_MACROS;__WINDOWS__;TARGET_WINDOWS;_WINDOWS;_MSVC;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_WINSOCKAPI_;USE_DEMUX;__STDC_CONSTANT_MACROS;__STDC_FORMAT_MACROS;__WINDOWS__;TARGET_WINDOWS;_WINDOWS;_MSVC;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\..\..\project\BuildDependencies\include;..\..\..\..\xbmc;..\..\..\..\lib;..\..\..\..\lib\platform\windows;..\..\..\..\lib\cmyth\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
@@ -139,7 +141,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <AdditionalIncludeDirectories>..\..\..\..\xbmc;..\..\..\..\lib;..\..\..\..\lib\platform\windows;..\..\..\..\project\BuildDependencies\include;..\..\..\..\lib\cmyth\include</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_WINSOCKAPI_;USE_DEMUX;__STDC_CONSTANT_MACROS;__WINDOWS__;TARGET_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_USE_32BIT_TIME_T;_WINSOCKAPI_;USE_DEMUX;__STDC_CONSTANT_MACROS;__STDC_FORMAT_MACROS;__WINDOWS__;TARGET_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
     <Link>

--- a/addons/pvr.mythtv.cmyth/project/VS2010Express/pvr.mythtv.cmyth.vcxproj.filters
+++ b/addons/pvr.mythtv.cmyth/project/VS2010Express/pvr.mythtv.cmyth.vcxproj.filters
@@ -41,6 +41,9 @@
     <ClCompile Include="..\..\src\cppmyth\MythEPGInfo.cpp">
       <Filter>cppmyth</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\cppmyth\MythScheduleManager.cpp">
+      <Filter>cppmyth</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\client.h" />
@@ -86,6 +89,9 @@
       <Filter>cppmyth</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\cppmyth\MythEPGInfo.h">
+      <Filter>cppmyth</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\cppmyth\MythScheduleManager.h">
       <Filter>cppmyth</Filter>
     </ClInclude>
   </ItemGroup>

--- a/addons/pvr.mythtv.cmyth/src/client.cpp
+++ b/addons/pvr.mythtv.cmyth/src/client.cpp
@@ -230,28 +230,25 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
     XBMC->Log(LOG_ERROR, "Couldn't get 'rec_template_provider' setting, falling back to '%i' as default", DEFAULT_RECORD_TEMPLATE);
     g_iRecTemplateType = DEFAULT_RECORD_TEMPLATE;
   }
-  /* Get internal template settings when selected (0) */
-  if (g_iRecTemplateType == 0)
-  {
-    if (!XBMC->GetSetting("rec_autometadata", &g_bRecAutoMetadata))
-      g_bRecAutoMetadata = true;
-    if (!XBMC->GetSetting("rec_autocommflag", &g_bRecAutoCommFlag))
-      g_bRecAutoCommFlag = false;
-    if (!XBMC->GetSetting("rec_autotranscode", &g_bRecAutoTranscode))
-      g_bRecAutoTranscode = false;
-    if (!XBMC->GetSetting("rec_autorunjob1", &g_bRecAutoRunJob1))
-      g_bRecAutoRunJob1 = false;
-    if (!XBMC->GetSetting("rec_autorunjob2", &g_bRecAutoRunJob2))
-      g_bRecAutoRunJob2 = false;
-    if (!XBMC->GetSetting("rec_autorunjob3", &g_bRecAutoRunJob3))
-      g_bRecAutoRunJob3 = false;
-    if (!XBMC->GetSetting("rec_autorunjob4", &g_bRecAutoRunJob4))
-      g_bRecAutoRunJob4 = false;
-    if (!XBMC->GetSetting("rec_autoexpire", &g_bRecAutoExpire))
-      g_bRecAutoExpire = false;
-    if (!XBMC->GetSetting("rec_transcoder", &g_iRecTranscoder))
-      g_iRecTranscoder = 0;
-  }
+  /* Get internal template settings */
+  if (!XBMC->GetSetting("rec_autometadata", &g_bRecAutoMetadata))
+    g_bRecAutoMetadata = true;
+  if (!XBMC->GetSetting("rec_autocommflag", &g_bRecAutoCommFlag))
+    g_bRecAutoCommFlag = false;
+  if (!XBMC->GetSetting("rec_autotranscode", &g_bRecAutoTranscode))
+    g_bRecAutoTranscode = false;
+  if (!XBMC->GetSetting("rec_autorunjob1", &g_bRecAutoRunJob1))
+    g_bRecAutoRunJob1 = false;
+  if (!XBMC->GetSetting("rec_autorunjob2", &g_bRecAutoRunJob2))
+    g_bRecAutoRunJob2 = false;
+  if (!XBMC->GetSetting("rec_autorunjob3", &g_bRecAutoRunJob3))
+    g_bRecAutoRunJob3 = false;
+  if (!XBMC->GetSetting("rec_autorunjob4", &g_bRecAutoRunJob4))
+    g_bRecAutoRunJob4 = false;
+  if (!XBMC->GetSetting("rec_autoexpire", &g_bRecAutoExpire))
+    g_bRecAutoExpire = false;
+  if (!XBMC->GetSetting("rec_transcoder", &g_iRecTranscoder))
+    g_iRecTranscoder = 0;
 
   free (buffer);
 
@@ -286,6 +283,12 @@ ADDON_STATUS ADDON_Create(void *hdl, void *props)
   menuHookDeleteAndRerecord.iHookId = MENUHOOK_REC_DELETE_AND_RERECORD;
   menuHookDeleteAndRerecord.iLocalizedStringId = 30411;
   PVR->AddMenuHook(&menuHookDeleteAndRerecord);
+
+  PVR_MENUHOOK menuHookKeepLiveTVRec;
+  menuHookKeepLiveTVRec.category = PVR_MENUHOOK_RECORDING;
+  menuHookKeepLiveTVRec.iHookId = MENUHOOK_KEEP_LIVETV_RECORDING;
+  menuHookKeepLiveTVRec.iLocalizedStringId = 30412;
+  PVR->AddMenuHook(&menuHookKeepLiveTVRec);
 
   XBMC->Log(LOG_DEBUG, "MythTV cmyth PVR-Client successfully created");
   m_CurStatus = ADDON_STATUS_OK;
@@ -414,19 +417,13 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   {
     XBMC->Log(LOG_INFO, "Changed Setting 'extra debug' from %u to %u", g_bExtraDebug, *(bool*)settingValue);
     if (g_bExtraDebug != *(bool*)settingValue)
-    {
      g_bExtraDebug = *(bool*)settingValue;
-      return ADDON_STATUS_OK;
-    }
   }
   else if (str == "livetv")
   {
     XBMC->Log(LOG_INFO, "Changed Setting 'livetv' from %u to %u", g_bLiveTV, *(bool*)settingValue);
     if (g_bLiveTV != *(bool*)settingValue)
-    {
       g_bLiveTV = *(bool*)settingValue;
-      return ADDON_STATUS_OK;
-    }
   }
   else if (str == "livetv_priority")
   {
@@ -435,8 +432,67 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     {
       g_bLiveTVPriority = *(bool*)settingValue;
       g_client->SetLiveTVPriority(g_bLiveTVPriority);
-      return ADDON_STATUS_OK;
     }
+  }
+  else if (str == "rec_template_provider")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_template_provider' from %u to %u", g_iRecTemplateType, *(int*)settingValue);
+    if (g_iRecTemplateType != *(int*)settingValue)
+      g_iRecTemplateType = *(int*)settingValue;
+  }
+  else if (str == "rec_autometadata")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autometadata' from %u to %u", g_bRecAutoMetadata, *(bool*)settingValue);
+    if (g_bRecAutoMetadata != *(bool*)settingValue)
+      g_bRecAutoMetadata = *(bool*)settingValue;
+  }
+  else if (str == "rec_autocommflag")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autocommflag' from %u to %u", g_bRecAutoCommFlag, *(bool*)settingValue);
+    if (g_bRecAutoCommFlag != *(bool*)settingValue)
+      g_bRecAutoCommFlag = *(bool*)settingValue;
+  }
+  else if (str == "rec_autotranscode")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autotranscode' from %u to %u", g_bRecAutoTranscode, *(bool*)settingValue);
+    if (g_bRecAutoTranscode != *(bool*)settingValue)
+      g_bRecAutoTranscode = *(bool*)settingValue;
+  }
+  else if (str == "rec_transcoder")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_transcoder' from %u to %u", g_iRecTranscoder, *(int*)settingValue);
+    if (g_iRecTranscoder != *(int*)settingValue)
+      g_iRecTranscoder = *(int*)settingValue;
+  }
+  else if (str == "rec_autorunjob1")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autorunjob1' from %u to %u", g_bRecAutoRunJob1, *(bool*)settingValue);
+    if (g_bRecAutoRunJob1 != *(bool*)settingValue)
+      g_bRecAutoRunJob1 = *(bool*)settingValue;
+  }
+  else if (str == "rec_autorunjob2")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autorunjob2' from %u to %u", g_bRecAutoRunJob2, *(bool*)settingValue);
+    if (g_bRecAutoRunJob2 != *(bool*)settingValue)
+      g_bRecAutoRunJob2 = *(bool*)settingValue;
+  }
+  else if (str == "rec_autorunjob3")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autorunjob3' from %u to %u", g_bRecAutoRunJob3, *(bool*)settingValue);
+    if (g_bRecAutoRunJob3 != *(bool*)settingValue)
+      g_bRecAutoRunJob3 = *(bool*)settingValue;
+  }
+  else if (str == "rec_autorunjob4")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autorunjob4' from %u to %u", g_bRecAutoRunJob4, *(bool*)settingValue);
+    if (g_bRecAutoRunJob4 != *(bool*)settingValue)
+      g_bRecAutoRunJob4 = *(bool*)settingValue;
+  }
+  else if (str == "rec_autoexpire")
+  {
+    XBMC->Log(LOG_INFO, "Changed Setting 'rec_autoexpire' from %u to %u", g_bRecAutoExpire, *(bool*)settingValue);
+    if (g_bRecAutoExpire != *(bool*)settingValue)
+      g_bRecAutoExpire = *(bool*)settingValue;
   }
   return ADDON_STATUS_OK;
 }

--- a/addons/pvr.mythtv.cmyth/src/client.h
+++ b/addons/pvr.mythtv.cmyth/src/client.h
@@ -34,6 +34,18 @@ extern "C" {
 
 #ifdef __WINDOWS__
 #define strdup _strdup // # strdup is POSIX, _strdup should be used instead
+
+static inline struct tm *localtime_r(const time_t * clock, struct tm *result)
+{
+	struct tm *data;
+	if (!clock || !result)
+		return NULL;
+	data = localtime(clock);
+	if (!data)
+		return NULL;
+	memcpy(result, data, sizeof(*result));
+	return result;
+}
 #endif
 
 #define TCP_RCV_BUF_CONTROL_SIZE           128000 // Inherited from MythTV's MythSocket class
@@ -61,6 +73,7 @@ extern "C" {
 #define SUBTITLE_SEPARATOR " - "
 
 #define MENUHOOK_REC_DELETE_AND_RERECORD   1
+#define MENUHOOK_KEEP_LIVETV_RECORDING     2
 
 /*!
  * @brief PVR macros for string exchange

--- a/addons/pvr.mythtv.cmyth/src/cppmyth.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth.h
@@ -11,3 +11,4 @@
 #include "cppmyth/MythSignal.h"
 #include "cppmyth/MythRecordingRule.h"
 #include "cppmyth/MythTimestamp.h"
+#include "cppmyth/MythScheduleManager.h"

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.cpp
@@ -280,6 +280,13 @@ MythProgramInfo MythConnection::GetRecordedProgram(int chanid, const MythTimesta
   return retval;
 }
 
+bool MythConnection::GenerateRecordingPreview(MythProgramInfo &recording)
+{
+  int retval = 0;
+  CMYTH_CONN_CALL(retval, retval < 0, cmyth_proginfo_generate_pixmap(*m_conn_t, *recording.m_proginfo_t));
+  return retval >= 0;
+}
+
 ProgramInfoMap MythConnection::GetPendingPrograms()
 {
   Lock();
@@ -351,7 +358,7 @@ MythFile MythConnection::ConnectFile(MythProgramInfo &recording)
   // so always check after calling cmyth_conn_connect_file if still connected to control socket.
   cmyth_file_t file = NULL;
   CMYTH_CONN_CALL_REF(file, true, cmyth_conn_connect_file(*recording.m_proginfo_t, *m_conn_t, RCV_BUF_DATA_SIZE, TCP_RCV_BUF_DATA_SIZE));
-  MythFile retval = MythFile(file, *this);
+  MythFile retval = MythFile(file);
   return retval;
 }
 
@@ -359,7 +366,7 @@ MythFile MythConnection::ConnectPath(const CStdString &filename, const CStdStrin
 {
   cmyth_file_t file = NULL;
   CMYTH_CONN_CALL_REF(file, file == NULL, cmyth_conn_connect_path(const_cast<char*>(filename.c_str()), *m_conn_t, RCV_BUF_DATA_SIZE, TCP_RCV_BUF_DATA_SIZE, const_cast<char*>(storageGroup.c_str())));
-  return MythFile(file, *this);
+  return MythFile(file);
 }
 
 bool MythConnection::SetBookmark(MythProgramInfo &recording, long long bookmark)

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythConnection.h
@@ -78,6 +78,7 @@ public:
   ProgramInfoMap GetRecordedPrograms();
   MythProgramInfo GetRecordedProgram(const CStdString &basename);
   MythProgramInfo GetRecordedProgram(int chanid, const MythTimestamp &recstartts);
+  bool GenerateRecordingPreview(MythProgramInfo &recording);
 
   // Timers
   ProgramInfoMap GetPendingPrograms();

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythDatabase.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythDatabase.cpp
@@ -97,19 +97,19 @@ bool MythDatabase::FindProgram(time_t starttime, int channelid, const CStdString
   return retval > 0;
 }
 
-bool MythDatabase::FindCurrentProgram(int channelid, MythEPGInfo &epgInfo)
+bool MythDatabase::FindCurrentProgram(time_t attime, int channelid, MythEPGInfo &epgInfo)
 {
   int retval = 0;
   cmyth_epginfo_t epg = NULL;
-  CMYTH_DB_CALL(retval, retval < 0, cmyth_mysql_get_prog_finder_chan(*m_database_t, &epg, channelid));
+  CMYTH_DB_CALL(retval, retval < 0, cmyth_mysql_get_prog_finder_chan(*m_database_t, &epg, attime, channelid));
   epgInfo = MythEPGInfo(epg);
   return retval > 0;
 }
 
-EPGInfoList MythDatabase::GetGuide(int channelid, time_t starttime, time_t endtime)
+EPGInfoMap MythDatabase::GetGuide(int channelid, time_t starttime, time_t endtime)
 {
   int ret;
-  EPGInfoList retval;
+  EPGInfoMap retval;
   cmyth_epginfolist_t epgInfoList = NULL;
   CMYTH_DB_CALL(ret, ret < 0, cmyth_mysql_get_guide(*m_database_t, &epgInfoList, channelid, starttime, endtime));
   int epgCount = cmyth_epginfolist_get_count(epgInfoList);
@@ -117,7 +117,8 @@ EPGInfoList MythDatabase::GetGuide(int channelid, time_t starttime, time_t endti
   for (int i = 0; i < epgCount; i++)
   {
     cmyth_epginfo_t epg = cmyth_epginfolist_get_item(epgInfoList, i);
-    retval.push_back(MythEPGInfo(epg));
+    MythEPGInfo epgInfo = MythEPGInfo(epg);
+    retval.insert(std::make_pair(epgInfo.StartTime(), epgInfo));
   }
   ref_release(epgInfoList);
   return retval;
@@ -218,10 +219,10 @@ bool MythDatabase::UpdateRecordingRule(const MythRecordingRule &rule)
   return retval > 0;
 }
 
-bool MythDatabase::DeleteRecordingRule(unsigned int recordid)
+bool MythDatabase::DeleteRecordingRule(const MythRecordingRule &rule)
 {
   int retval = 0;
-  CMYTH_DB_CALL(retval, retval < 0, cmyth_mysql_delete_recordingrule(*m_database_t, recordid));
+  CMYTH_DB_CALL(retval, retval < 0, cmyth_mysql_delete_recordingrule(*m_database_t, *rule.m_recordingrule_t));
   return retval > 0;
 }
 
@@ -273,10 +274,10 @@ long long MythDatabase::GetBookmarkMark(const MythProgramInfo &recording, long l
   return mark;
 }
 
-long long MythDatabase::GetRecordingMarkup(const MythProgramInfo &recording, int type)
+long long MythDatabase::GetRecordingMarkup(const MythProgramInfo &recording, cmyth_recording_markup_t type)
 {
   long long value = 0;
-  CMYTH_DB_CALL(value, value < 0, cmyth_mysql_get_recording_markup(*m_database_t, *recording.m_proginfo_t, (cmyth_recording_markup_t)type));
+  CMYTH_DB_CALL(value, value < 0, cmyth_mysql_get_recording_markup(*m_database_t, *recording.m_proginfo_t, type));
   return value;
 }
 
@@ -285,6 +286,13 @@ long long MythDatabase::GetRecordingFrameRate(const MythProgramInfo &recording)
   long long value = 0;
   CMYTH_DB_CALL(value, value < 0, cmyth_mysql_get_recording_framerate(*m_database_t, *recording.m_proginfo_t));
   return value;
+}
+
+int MythDatabase::GetRecordingSeekOffset(const MythProgramInfo &recording, cmyth_recording_markup_t type, int64_t mark, int64_t *psoffset, int64_t *nsoffset)
+{
+  int mask = 0;
+  CMYTH_DB_CALL(mask, mask < 0, cmyth_mysql_get_recording_seek_offset(*m_database_t, *recording.m_proginfo_t, type, mark, psoffset, nsoffset));
+  return mask;
 }
 
 bool MythDatabase::FillRecordingArtwork(MythProgramInfo &recording)
@@ -305,3 +313,11 @@ bool MythDatabase::FillRecordingArtwork(MythProgramInfo &recording)
   }
   return false;
 }
+
+bool MythDatabase::KeepLiveTVRecording(MythProgramInfo& recording, bool keep)
+{
+  int retval = 0;
+  CMYTH_DB_CALL(retval, retval < 0, cmyth_mysql_keep_livetv_recording(*m_database_t, *recording.m_proginfo_t, (keep ? 1 : 0)));
+  return (retval > 0);
+}
+

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythDatabase.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythDatabase.h
@@ -37,7 +37,7 @@ class MythProgramInfo;
 
 template <class T> class MythPointerThreadSafe;
 
-typedef std::vector<MythEPGInfo> EPGInfoList;
+typedef std::map<time_t, MythEPGInfo> EPGInfoMap;
 
 typedef std::map<int, MythChannel> ChannelIdMap;
 typedef std::multimap<CStdString, MythChannel> ChannelNumberMap;
@@ -71,8 +71,8 @@ public:
   CStdString GetSetting(const CStdString &setting);
 
   bool FindProgram(time_t starttime, int channelid, const CStdString &title, MythEPGInfo &epgInfo);
-  bool FindCurrentProgram(int channelid, MythEPGInfo &epgInfo);
-  EPGInfoList GetGuide(int channelid, time_t starttime, time_t endtime);
+  bool FindCurrentProgram(time_t attime, int channelid, MythEPGInfo &epgInfo);
+  EPGInfoMap GetGuide(int channelid, time_t starttime, time_t endtime);
 
   ChannelIdMap GetChannels();
   ChannelGroupMap GetChannelGroups();
@@ -82,7 +82,7 @@ public:
   RecordingRuleMap GetRecordingRules();
   bool AddRecordingRule(const MythRecordingRule &rule);
   bool UpdateRecordingRule(const MythRecordingRule &rule);
-  bool DeleteRecordingRule(unsigned int recordid);
+  bool DeleteRecordingRule(const MythRecordingRule &rule);
   MythRecordingRule LoadRecordingRuleTemplate(const CStdString &category, const CStdString &category_type);
 
   RecordingProfileList GetRecordingProfiles();
@@ -90,10 +90,12 @@ public:
   bool SetWatchedStatus(const MythProgramInfo &recording, bool watched);
   long long GetBookmarkMark(const MythProgramInfo &recording, long long bk, int mode);
 
-  long long GetRecordingMarkup(const MythProgramInfo &recording, int type);
+  long long GetRecordingMarkup(const MythProgramInfo &recording, cmyth_recording_markup_t type);
   long long GetRecordingFrameRate(const MythProgramInfo &recording);
+  int GetRecordingSeekOffset(const MythProgramInfo &recording, cmyth_recording_markup_t type, int64_t mark, int64_t *psoffset, int64_t *nsoffset);
 
   bool FillRecordingArtwork(MythProgramInfo &recording);
+  bool KeepLiveTVRecording(MythProgramInfo &recording, bool keep);
 
 private:
   boost::shared_ptr<MythPointerThreadSafe<cmyth_database_t> > m_database_t;

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythEventHandler.h
@@ -43,6 +43,8 @@ class MythEventObserver
 public:
   // Request to stop Live TV
   virtual void CloseLiveStream() = 0;
+  virtual void UpdateSchedules() = 0;
+  virtual void UpdateRecordings() = 0;
 };
 
 class MythEventHandler
@@ -82,7 +84,7 @@ public:
       : m_type(type)
       , m_channelID(chanid)
     {
-      m_recordingStartTimeSlot = MythTimestamp(recstartts, false);
+      m_recordingStartTimeSlot = MythTimestamp(recstartts);
     }
 
     RecordingChangeEvent(RecordingChangeType type, const MythProgramInfo &prog)

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythFile.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythFile.cpp
@@ -23,13 +23,11 @@
 
 MythFile::MythFile()
   : m_file_t(new MythPointer<cmyth_file_t>())
-  , m_conn(MythConnection())
 {
 }
 
-MythFile::MythFile(cmyth_file_t myth_file, MythConnection conn)
+MythFile::MythFile(cmyth_file_t myth_file)
   : m_file_t(new MythPointer<cmyth_file_t>())
-  , m_conn(conn)
 {
   *m_file_t = myth_file;
 }

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythFile.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythFile.h
@@ -31,7 +31,7 @@ class MythFile
 {
 public:
   MythFile();
-  MythFile(cmyth_file_t myth_file, MythConnection conn);
+  MythFile(cmyth_file_t myth_file);
 
   bool IsNull() const;
 
@@ -44,5 +44,4 @@ public:
 
 private:
   boost::shared_ptr<MythPointer<cmyth_file_t> > m_file_t;
-  MythConnection m_conn;
 };

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythProgramInfo.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythProgramInfo.h
@@ -41,9 +41,22 @@ public:
   MythProgramInfo();
   MythProgramInfo(cmyth_proginfo_t cmyth_proginfo);
 
-  bool IsNull() const;
+  /**
+   * \brief Returns internal Unique Identifier for recording
+   *
+   * Make recording UID like "1001 2011-12-10T12:00:00Z" based on 'channelid'
+   * and 'recstartts'.
+   * 'channelid' is the myth channel identifier of the RECORDED PROGRAM.
+   * 'recstartts' is the start time of the RECORDED PROGRAM. Do not confuse with
+   * start time of PROGRAM which is time of EPG program.
+   */
+  static CStdString MakeUID(unsigned int chanid, MythTimestamp &ts);
 
-  CStdString UID();
+  bool IsNull() const;
+  bool operator ==(MythProgramInfo &other);
+  bool operator !=(MythProgramInfo &other);
+
+  CStdString UID() const;
   CStdString ProgramID();
   CStdString Title();
   CStdString Subtitle();
@@ -57,6 +70,7 @@ public:
   bool IsDeletePending();
   bool HasBookmark();
   bool IsVisible();
+  bool IsLiveTV();
 
   unsigned int ChannelID();
   CStdString ChannelName();
@@ -78,11 +92,10 @@ public:
 
 private:
   boost::shared_ptr<MythPointer<cmyth_proginfo_t> > m_proginfo_t;
+  CStdString m_UID;
 
   // Cached PVR attributes
   long long m_frameRate;
-
-  // Artworks
   CStdString m_coverart;
   CStdString m_fanart;
 };

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecorder.h
@@ -31,6 +31,7 @@ extern "C" {
 
 class MythProgramInfo;
 class MythChannel;
+class MythFile;
 
 template <class T> class MythPointer;
 
@@ -60,13 +61,20 @@ public:
   int ReadLiveTV(void *buffer, unsigned int length);
   long long LiveTVSeek(long long offset, int whence);
   long long LiveTVDuration();
+  int GetLiveTVChainLast();
+  MythProgramInfo GetLiveTVChainProgram(int index);
+  MythFile GetLiveTVChainFile(int index);
 
   bool Stop();
+
+  bool IsLiveRecording();
+  bool SetLiveRecording(bool recording);
 
 private:
   boost::shared_ptr<MythPointerThreadSafe<cmyth_recorder_t> > m_recorder_t;
   boost::shared_ptr<int> m_liveChainUpdated;
   MythConnection m_conn;
+  bool m_liveRecording;
 
   static void prog_update_callback(cmyth_proginfo_t prog);
 };

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecordingRule.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecordingRule.cpp
@@ -40,6 +40,11 @@ bool MythRecordingRule::IsNull() const
   return *m_recordingrule_t == NULL;
 }
 
+MythRecordingRule MythRecordingRule::DuplicateRecordingRule() const
+{
+  return MythRecordingRule(cmyth_recordingrule_dup(*m_recordingrule_t));
+}
+
 unsigned int MythRecordingRule::RecordID() const
 {
   return cmyth_recordingrule_recordid(*m_recordingrule_t);
@@ -361,4 +366,24 @@ unsigned int MythRecordingRule::Transcoder() const
 void MythRecordingRule::SetTranscoder(unsigned int transcoder)
 {
   cmyth_recordingrule_set_transcoder(*m_recordingrule_t, transcoder);
+}
+
+unsigned int MythRecordingRule::ParentID() const
+{
+  return cmyth_recordingrule_parentid(*m_recordingrule_t);
+}
+
+void MythRecordingRule::SetParentID(unsigned int parentid)
+{
+  cmyth_recordingrule_set_parentid(*m_recordingrule_t, parentid);
+}
+
+unsigned int MythRecordingRule::Filter() const
+{
+  return cmyth_recordingrule_filter(*m_recordingrule_t);
+}
+
+void MythRecordingRule::SetFilter(unsigned int filter)
+{
+  cmyth_recordingrule_set_filter(*m_recordingrule_t, filter);
 }

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecordingRule.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythRecordingRule.h
@@ -36,51 +36,67 @@ class MythRecordingRule
 public:
   enum RuleType
   {
-    NotRecording = 0,
-    SingleRecord = 1,
-    TimeslotRecord,
-    ChannelRecord,
-    AllRecord,
-    WeekslotRecord,
-    FindOneRecord,
-    OverrideRecord,
-    DontRecord,
-    FindDailyRecord,
-    FindWeeklyRecord,
-    TemplateRecord
+    RT_NotRecording                   = 0,
+    RT_SingleRecord                   = 1,
+    RT_DailyRecord                    = 2,
+    RT_ChannelRecord                  = 3,
+    RT_AllRecord                      = 4,
+    RT_WeeklyRecord                   = 5,
+    RT_OneRecord                      = 6,
+    RT_OverrideRecord                 = 7,
+    RT_DontRecord                     = 8,
+    RT_FindDailyRecord                = 9,  // Obsolete (0.27). cf DailyRecord
+    RT_FindWeeklyRecord               = 10, // Obsolete (0.27). cf WeeklyRecord
+    RT_TemplateRecord                 = 11
   };
 
   enum RuleSearchType
   {
-    NoSearch = 0,
-    PowerSearch,
-    TitleSearch,
-    KeywordSearch,
-    PeopleSearch,
-    ManualSearch
+    ST_NoSearch                       = 0,
+    ST_PowerSearch,
+    ST_TitleSearch,
+    ST_KeywordSearch,
+    ST_PeopleSearch,
+    ST_ManualSearch
   };
 
   enum RuleDuplicateControlMethod
   {
-    CheckNone                    = 0x01,
-    CheckSubtitle                = 0x02,
-    CheckDescription             = 0x04,
-    CheckSubtitleAndDescription  = 0x06,
-    CheckSubtitleThenDescription = 0x08
+    DM_CheckNone                      = 0x01,
+    DM_CheckSubtitle                  = 0x02,
+    DM_CheckDescription               = 0x04,
+    DM_CheckSubtitleAndDescription    = 0x06,
+    DM_CheckSubtitleThenDescription   = 0x08
   };
 
   enum RuleCheckDuplicatesInType
   {
-    InRecorded    = 0x01,
-    InOldRecorded = 0x02,
-    InAll         = 0x0F,
-    NewEpi        = 0x10
+    DI_InRecorded                     = 0x01,
+    DI_InOldRecorded                  = 0x02,
+    DI_InAll                          = 0x0F,
+    DI_NewEpi                         = 0x10
+  };
+
+  enum RuleFilterMask
+  {
+    FM_NewEpisode                     = 0x001,
+    FM_IdentifiableEpisode            = 0x002,
+    FM_FirstShowing                   = 0x004,
+    FM_PrimeTime                      = 0x008,
+    FM_CommercialFree                 = 0x010,
+    FM_HighDefinition                 = 0x020,
+    FM_ThisEpisode                    = 0x040,
+    FM_ThisSeries                     = 0x080,
+    FM_ThisTime                       = 0x100,
+    FM_ThisDayAndTime                 = 0x200
   };
 
   MythRecordingRule();
   MythRecordingRule(cmyth_recordingrule_t cmyth_recordingrule);
 
   bool IsNull() const;
+
+  MythRecordingRule DuplicateRecordingRule() const;
 
   unsigned int RecordID() const;
   void SetRecordID(unsigned int recordid);
@@ -168,6 +184,12 @@ public:
 
   unsigned int Transcoder() const;
   void SetTranscoder(unsigned int transcoder);
+
+  unsigned int ParentID() const;
+  void SetParentID(unsigned int parentid);
+
+  unsigned int Filter() const;
+  void SetFilter(unsigned int filter);
 
 private:
   boost::shared_ptr<MythPointer<cmyth_recordingrule_t> > m_recordingrule_t;

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythScheduleManager.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythScheduleManager.cpp
@@ -1,0 +1,1132 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MythScheduleManager.h"
+#include "../client.h"
+#include "../tools.h"
+
+using namespace ADDON;
+using namespace PLATFORM;
+
+enum
+{
+  METHOD_UNKNOWN = 0,
+  METHOD_UPDATE_INACTIVE = 1,
+  METHOD_CREATE_OVERRIDE = 2,
+  METHOD_DELETE = 3,
+  METHOD_DISCREET_UPDATE = 4,
+  METHOD_FULL_UPDATE = 5
+};
+
+static uint_fast32_t hashvalue(uint_fast32_t maxsize, const char *value)
+{
+  uint_fast32_t h = 0, g;
+
+  while (*value)
+  {
+    h = (h << 4) + *value++;
+    if ((g = h & 0xF0000000L))
+    {
+      h ^= g >> 24;
+    }
+    h &= ~g;
+  }
+
+  return h % maxsize;
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// MythRecordingRuleNode
+////
+
+MythRecordingRuleNode::MythRecordingRuleNode(const MythRecordingRule &rule)
+  : m_rule(rule)
+  , m_mainRule()
+  , m_overrideRules()
+{
+}
+
+bool MythRecordingRuleNode::IsOverrideRule() const
+{
+  return (m_rule.Type() == MythRecordingRule::RT_DontRecord || m_rule.Type() == MythRecordingRule::RT_OverrideRecord);
+}
+
+MythRecordingRule MythRecordingRuleNode::GetRule() const
+{
+  return m_rule;
+}
+
+MythRecordingRule MythRecordingRuleNode::GetMainRule() const
+{
+  if (this->IsOverrideRule())
+    return m_mainRule;
+  return m_rule;
+}
+
+bool MythRecordingRuleNode::HasOverrideRules() const
+{
+  return (!m_overrideRules.empty());
+}
+
+OverrideRuleList MythRecordingRuleNode::GetOverrideRules() const
+{
+  return m_overrideRules;
+}
+
+bool MythRecordingRuleNode::IsInactiveRule() const
+{
+  return m_rule.Inactive();
+}
+
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// MythScheduleManager
+////
+
+MythScheduleManager::MythScheduleManager()
+  : m_con()
+  , m_db()
+  , m_dbSchemaVersion(0)
+  , m_versionHelper(new MythScheduleHelperNoHelper())
+{
+}
+
+MythScheduleManager::MythScheduleManager(MythConnection &con, MythDatabase &db)
+  : m_con(con)
+  , m_db(db)
+  , m_dbSchemaVersion(0)
+{
+  this->Update();
+}
+
+void MythScheduleManager::Setup()
+{
+  int old = m_dbSchemaVersion;
+  m_dbSchemaVersion = m_db.GetSchemaVersion();
+
+  // On new DB connection the schema version could change
+  if (m_dbSchemaVersion != old)
+  {
+    if (m_dbSchemaVersion >= 1309)
+      m_versionHelper = boost::shared_ptr<VersionHelper>(new MythScheduleHelper1309(m_db));
+    else if (m_dbSchemaVersion >= 1302)
+      m_versionHelper = boost::shared_ptr<VersionHelper>(new MythScheduleHelper1302(m_db));
+    else if (m_dbSchemaVersion >= 1276)
+      m_versionHelper = boost::shared_ptr<VersionHelper>(new MythScheduleHelper1278(m_db));
+    else if (m_dbSchemaVersion > 0)
+      m_versionHelper = boost::shared_ptr<VersionHelper>(new MythScheduleHelper1226(m_db));
+    else
+      m_versionHelper = boost::shared_ptr<VersionHelper>(new MythScheduleHelperNoHelper());
+  }
+}
+
+unsigned int MythScheduleManager::MakeIndex(MythProgramInfo& recording) const
+{
+  // Recordings must keep same identifier even after refreshing cache (cf Update).
+  // Numeric hash of UID is used to make the constant numeric identifier.
+  return (recording.RecordID() << 16) + hashvalue(0xFFFF, recording.UID().c_str());
+}
+
+ScheduleList MythScheduleManager::GetUpcomingRecordings()
+{
+  ScheduleList recordings;
+  CLockObject lock(m_lock);
+  for (RecordingList::iterator it = m_recordings.begin(); it != m_recordings.end(); ++it)
+  {
+    recordings.push_back(std::make_pair(it->first, it->second));
+  }
+  return recordings;
+}
+
+MythScheduleManager::MSM_ERROR MythScheduleManager::ScheduleRecording(const MythRecordingRule &rule)
+{
+  if (!m_db.AddRecordingRule(rule))
+    return MSM_ERROR_FAILED;
+
+  if (!m_con.UpdateSchedules(rule.RecordID()))
+    return MSM_ERROR_FAILED;
+
+  return MSM_ERROR_SUCCESS;
+}
+
+MythScheduleManager::MSM_ERROR MythScheduleManager::DeleteRecording(unsigned int index)
+{
+  CLockObject lock(m_lock);
+
+  boost::shared_ptr<MythProgramInfo> recording = this->FindUpComingByIndex(index);
+  if (!recording)
+    return MSM_ERROR_FAILED;
+
+  boost::shared_ptr<MythRecordingRuleNode> node = this->FindRuleById(recording->RecordID());
+  if (node)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - %u : Found rule %u type %d", __FUNCTION__, index, node->m_rule.RecordID(), node->m_rule.Type());
+
+    // Delete override rules
+    if (node->HasOverrideRules())
+    {
+      for (OverrideRuleList::iterator ito = node->m_overrideRules.begin(); ito != node->m_overrideRules.end(); ++ito)
+      {
+        XBMC->Log(LOG_DEBUG, "%s - %u : Found override rule %u type %d", __FUNCTION__, index, ito->RecordID(), ito->Type());
+        ScheduleList rec = this->FindUpComingByRuleId(ito->RecordID());
+        for (ScheduleList::iterator itr = rec.begin(); itr != rec.end(); ++itr)
+        {
+          XBMC->Log(LOG_DEBUG, "%s - %u : Found override recording %s status %d", __FUNCTION__, index, itr->second->UID().c_str(), itr->second->Status());
+          if (itr->second->Status() == RS_RECORDING || itr->second->Status() == RS_TUNING)
+          {
+            XBMC->Log(LOG_DEBUG, "%s - Stop recording %s", __FUNCTION__, itr->second->UID().c_str());
+            m_con.StopRecording(*(itr->second));
+          }
+        }
+        XBMC->Log(LOG_DEBUG, "%s - Delete recording rule %u (modifier of rule %u)", __FUNCTION__, ito->RecordID(), node->m_rule.RecordID());
+        if (!m_db.DeleteRecordingRule(*ito))
+          XBMC->Log(LOG_ERROR, "%s - Delete recording rule failed", __FUNCTION__);
+      }
+    }
+
+    // Delete main rule
+    ScheduleList rec = this->FindUpComingByRuleId(node->m_rule.RecordID());
+    for (ScheduleList::iterator itr = rec.begin(); itr != rec.end(); ++itr)
+    {
+      XBMC->Log(LOG_DEBUG, "%s - %u : Found recording %s status %d", __FUNCTION__, index, itr->second->UID().c_str(), itr->second->Status());
+      if (itr->second->Status() == RS_RECORDING || itr->second->Status() == RS_TUNING)
+      {
+        XBMC->Log(LOG_DEBUG, "%s - Stop recording %s", __FUNCTION__, itr->second->UID().c_str());
+        m_con.StopRecording(*(itr->second));
+      }
+    }
+    XBMC->Log(LOG_DEBUG, "%s - Delete recording rule %u", __FUNCTION__, node->m_rule.RecordID());
+    if (!m_db.DeleteRecordingRule(node->m_rule))
+      XBMC->Log(LOG_ERROR, "%s - Delete recording rule failed", __FUNCTION__);
+
+    if (!m_con.UpdateSchedules(-1))
+      return MSM_ERROR_FAILED;
+
+    // Another client could delete the rule at the same time. Therefore always SUCCESS even if database delete fails.
+    return MSM_ERROR_SUCCESS;
+  }
+  else
+  {
+    XBMC->Log(LOG_DEBUG, "%s - %u : No rule for recording %s status %d", __FUNCTION__, index, recording->UID().c_str(), recording->Status());
+    if (recording->Status() == RS_RECORDING || recording->Status() == RS_TUNING)
+    {
+      XBMC->Log(LOG_DEBUG, "%s - Stop recording %s", __FUNCTION__, recording->UID().c_str());
+      m_con.StopRecording(*recording);
+      return MSM_ERROR_SUCCESS;
+    }
+  }
+
+  return MSM_ERROR_NOT_IMPLEMENTED;
+}
+
+MythScheduleManager::MSM_ERROR MythScheduleManager::DisableRecording(unsigned int index)
+{
+  CLockObject lock(m_lock);
+
+  boost::shared_ptr<MythProgramInfo> recording = this->FindUpComingByIndex(index);
+  if (!recording)
+    return MSM_ERROR_FAILED;
+
+  if (recording->Status() == RS_INACTIVE || recording->Status() == RS_DONT_RECORD)
+    return MSM_ERROR_SUCCESS;
+
+  boost::shared_ptr<MythRecordingRuleNode> node = this->FindRuleById(recording->RecordID());
+  if (node)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - %u : Found rule %u type %d", __FUNCTION__, index, node->m_rule.RecordID(), node->m_rule.Type());
+    int method = METHOD_UNKNOWN;
+    MythRecordingRule handle = node->m_rule.DuplicateRecordingRule();
+
+    // Not recording. Simply inactivate the rule
+    if (recording->Status() == RS_UNKNOWN)
+    {
+      method = METHOD_UPDATE_INACTIVE;
+    }
+    else
+    {
+      // Method depends of its rule type
+      switch (node->m_rule.Type())
+      {
+      case MythRecordingRule::RT_SingleRecord:
+        if (recording->Status() == RS_RECORDING || recording->Status() == RS_TUNING)
+          method = METHOD_DELETE;
+        else
+          method = METHOD_UPDATE_INACTIVE;
+        break;
+      case MythRecordingRule::RT_NotRecording:
+        method = METHOD_UPDATE_INACTIVE;
+        break;
+      case MythRecordingRule::RT_OneRecord:
+      case MythRecordingRule::RT_ChannelRecord:
+      case MythRecordingRule::RT_AllRecord:
+      case MythRecordingRule::RT_DailyRecord:
+      case MythRecordingRule::RT_WeeklyRecord:
+      case MythRecordingRule::RT_FindDailyRecord:
+      case MythRecordingRule::RT_FindWeeklyRecord:
+        method = METHOD_CREATE_OVERRIDE;
+        break;
+      case MythRecordingRule::RT_OverrideRecord:
+        method = METHOD_DELETE;
+        break;
+      default:
+        break;
+      }
+    }
+
+    if (method == METHOD_UNKNOWN)
+    {
+      return MSM_ERROR_NOT_IMPLEMENTED;
+    }
+    if (method == METHOD_UPDATE_INACTIVE)
+    {
+      handle.SetInactive(true);
+      if (!m_db.UpdateRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_rule = handle; // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+    if (method == METHOD_CREATE_OVERRIDE)
+    {
+      handle.SetRecordID(0);
+      handle.SetInactive(false);
+      handle.SetType(MythRecordingRule::RT_DontRecord);
+      handle.SetStartTime(recording->StartTime());
+      handle.SetEndTime(recording->EndTime());
+      handle.SetParentID(node->m_rule.RecordID());
+      if (!m_db.AddRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_overrideRules.push_back(handle); // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+    if (method == METHOD_DELETE)
+    {
+      return this->DeleteRecording(index);
+    }
+  }
+
+  return MSM_ERROR_NOT_IMPLEMENTED;
+}
+
+MythScheduleManager::MSM_ERROR MythScheduleManager::EnableRecording(unsigned int index)
+{
+  CLockObject lock(m_lock);
+
+  boost::shared_ptr<MythProgramInfo> recording = this->FindUpComingByIndex(index);
+  if (!recording)
+    return MSM_ERROR_FAILED;
+
+  boost::shared_ptr<MythRecordingRuleNode> node = this->FindRuleById(recording->RecordID());
+  if (node)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - %u : Found rule %u type %d", __FUNCTION__, index, node->m_rule.RecordID(), node->m_rule.Type());
+    int method = METHOD_UNKNOWN;
+    MythRecordingRule handle = node->m_rule.DuplicateRecordingRule();
+
+    if (recording->Status() == RS_UNKNOWN)
+    {
+      // Not recording. Simply activate the rule
+      method = METHOD_UPDATE_INACTIVE;
+    }
+    else if (recording->Status() == RS_NEVER_RECORD)
+    {
+      // Add override to record anyway
+      method = METHOD_CREATE_OVERRIDE;
+    }
+    else
+    {
+      // Method depends of its rule type
+      switch (node->m_rule.Type())
+      {
+      case MythRecordingRule::RT_DontRecord:
+      case MythRecordingRule::RT_OverrideRecord:
+        method = METHOD_DELETE;
+        break;
+      case MythRecordingRule::RT_SingleRecord:
+      case MythRecordingRule::RT_NotRecording:
+      case MythRecordingRule::RT_OneRecord:
+      case MythRecordingRule::RT_ChannelRecord:
+      case MythRecordingRule::RT_AllRecord:
+      case MythRecordingRule::RT_DailyRecord:
+      case MythRecordingRule::RT_WeeklyRecord:
+      case MythRecordingRule::RT_FindDailyRecord:
+      case MythRecordingRule::RT_FindWeeklyRecord:
+        // Is it inactive ? Try to enable rule
+        method = METHOD_UPDATE_INACTIVE;
+        break;
+      default:
+        break;
+      }
+    }
+
+    if (method == METHOD_UNKNOWN)
+    {
+      return MSM_ERROR_NOT_IMPLEMENTED;
+    }
+    if (method == METHOD_UPDATE_INACTIVE)
+    {
+      handle.SetInactive(false);
+      if (!m_db.UpdateRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_rule = handle; // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+    if (method == METHOD_CREATE_OVERRIDE)
+    {
+      handle.SetRecordID(0);
+      handle.SetInactive(false);
+      handle.SetType(MythRecordingRule::RT_OverrideRecord);
+      handle.SetStartTime(recording->StartTime());
+      handle.SetEndTime(recording->EndTime());
+      handle.SetParentID(node->m_rule.RecordID());
+      if (!m_db.AddRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_overrideRules.push_back(handle); // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+    if (method == METHOD_DELETE)
+    {
+      return this->DeleteRecording(index);
+    }
+  }
+
+  return MSM_ERROR_NOT_IMPLEMENTED;
+}
+
+MythScheduleManager::MSM_ERROR MythScheduleManager::UpdateRecording(unsigned int index, MythRecordingRule &newrule)
+{
+  CLockObject lock(m_lock);
+
+  boost::shared_ptr<MythProgramInfo> recording = this->FindUpComingByIndex(index);
+  if (!recording)
+    return MSM_ERROR_FAILED;
+
+  boost::shared_ptr<MythRecordingRuleNode> node = this->FindRuleById(recording->RecordID());
+  if (node)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - %u : Found rule %u type %d", __FUNCTION__, index, node->m_rule.RecordID(), node->m_rule.Type());
+    int method = METHOD_UNKNOWN;
+    MythRecordingRule handle = node->m_rule.DuplicateRecordingRule();
+
+    // Rule update method depends of current rule type:
+    // - Updating override rule is limited.
+    // - Enabled repeating rule must to be overriden.
+    // - All others could be fully updated until it is recording.
+    switch (node->m_rule.Type())
+    {
+    case MythRecordingRule::RT_DontRecord:
+    case MythRecordingRule::RT_NotRecording:
+    case MythRecordingRule::RT_TemplateRecord:
+      // Deny update
+      method = METHOD_UNKNOWN;
+      break;
+    case MythRecordingRule::RT_AllRecord:
+    case MythRecordingRule::RT_ChannelRecord:
+    case MythRecordingRule::RT_OneRecord:
+    case MythRecordingRule::RT_FindDailyRecord:
+    case MythRecordingRule::RT_FindWeeklyRecord:
+    case MythRecordingRule::RT_DailyRecord:
+    case MythRecordingRule::RT_WeeklyRecord:
+      // When inactive we can replace with the new rule
+      if (handle.Inactive())
+      {
+        method = METHOD_FULL_UPDATE;
+      }
+      // When active we create override rule
+      else
+      {
+        // Only priority can be overriden
+        if (newrule.Priority() != handle.Priority())
+        {
+          handle.SetPriority(newrule.Priority());
+          method = METHOD_CREATE_OVERRIDE;
+        }
+        else
+          method = METHOD_UNKNOWN;
+      }
+      break;
+    case MythRecordingRule::RT_OverrideRecord:
+      // Only priority can be overriden
+      handle.SetPriority(newrule.Priority());
+      method = METHOD_DISCREET_UPDATE;
+        break;
+      case MythRecordingRule::RT_SingleRecord:
+        if (recording->Status() == RS_RECORDING || recording->Status() == RS_TUNING)
+        {
+          // Discreet update
+          handle.SetEndTime(newrule.EndTime());
+          handle.SetEndOffset(newrule.EndOffset());
+          method = METHOD_DISCREET_UPDATE;
+        }
+        else
+        {
+          method = METHOD_FULL_UPDATE;
+        }
+        break;
+      default:
+        break;
+    }
+
+    if (method == METHOD_UNKNOWN)
+    {
+      return MSM_ERROR_NOT_IMPLEMENTED;
+    }
+    if (method == METHOD_DISCREET_UPDATE)
+    {
+      if (!m_db.UpdateRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_rule = handle; // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+    if (method == METHOD_CREATE_OVERRIDE)
+    {
+      handle.SetRecordID(0);
+      handle.SetInactive(false);
+      handle.SetType(MythRecordingRule::RT_OverrideRecord);
+      handle.SetStartTime(recording->StartTime());
+      handle.SetEndTime(recording->EndTime());
+      handle.SetParentID(node->m_rule.RecordID());
+      if (!m_db.AddRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_overrideRules.push_back(handle); // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+    if (method == METHOD_FULL_UPDATE)
+    {
+      handle = newrule;
+      handle.SetRecordID(node->m_rule.RecordID());
+      if (!m_db.UpdateRecordingRule(handle))
+        return MSM_ERROR_FAILED;
+      node->m_rule = handle; // sync node
+      if (!m_con.UpdateSchedules(handle.RecordID()))
+        return MSM_ERROR_FAILED;
+      return MSM_ERROR_SUCCESS;
+    }
+  }
+
+  return MSM_ERROR_NOT_IMPLEMENTED;
+}
+
+boost::shared_ptr<MythRecordingRuleNode> MythScheduleManager::FindRuleById(unsigned int recordID) const
+{
+  CLockObject lock(m_lock);
+
+  NodeById::const_iterator it = m_rulesById.find(recordID);
+  if (it != m_rulesById.end())
+    return it->second;
+  return boost::shared_ptr<MythRecordingRuleNode>();
+}
+
+ScheduleList MythScheduleManager::FindUpComingByRuleId(unsigned int recordID) const
+{
+  CLockObject lock(m_lock);
+
+  ScheduleList found;
+  std::pair<RecordingIndexByRuleId::const_iterator, RecordingIndexByRuleId::const_iterator> range = m_recordingIndexByRuleId.equal_range(recordID);
+  if (range.first != m_recordingIndexByRuleId.end())
+  {
+    for (RecordingIndexByRuleId::const_iterator it = range.first; it != range.second; ++it)
+    {
+      RecordingList::const_iterator recordingIt = m_recordings.find(it->second);
+      if (recordingIt != m_recordings.end())
+        found.push_back(std::make_pair(it->second, recordingIt->second));
+    }
+  }
+  return found;
+}
+
+boost::shared_ptr<MythProgramInfo> MythScheduleManager::FindUpComingByIndex(unsigned int index) const
+{
+  CLockObject lock(m_lock);
+
+  RecordingList::const_iterator it = m_recordings.find(index);
+  if (it != m_recordings.end())
+    return it->second;
+  else
+    return boost::shared_ptr<MythProgramInfo>();
+}
+
+void MythScheduleManager::Update()
+{
+  CLockObject lock(m_lock);
+
+  // Setup VersionHelper for the new set
+  this->Setup();
+  RecordingRuleMap rules = m_db.GetRecordingRules();
+  m_rules.clear();
+  m_rulesById.clear();
+  for (RecordingRuleMap::iterator it = rules.begin(); it != rules.end(); ++it)
+  {
+    boost::shared_ptr<MythRecordingRuleNode> node = boost::shared_ptr<MythRecordingRuleNode>(new MythRecordingRuleNode(it->second));
+    m_rules.push_back(node);
+    m_rulesById.insert(NodeById::value_type(it->second.RecordID(), node));
+  }
+
+  for (NodeList::iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+    // Is override rule ? Then find main rule and link to it
+    if ((*it)->IsOverrideRule())
+    {
+      // First check parentid. Then fallback searching the same timeslot
+      NodeById::iterator itp = m_rulesById.find((*it)->m_rule.ParentID());
+      if (itp != m_rulesById.end())
+      {
+        itp->second->m_overrideRules.push_back((*it)->m_rule);
+        (*it)->m_mainRule = itp->second->m_rule;
+      }
+      else
+      {
+        for (NodeList::iterator itm = m_rules.begin(); itm != m_rules.end(); ++itm)
+          if (!(*itm)->IsOverrideRule() && m_versionHelper->SameTimeslot((*it)->m_rule, (*itm)->m_rule))
+          {
+            (*itm)->m_overrideRules.push_back((*it)->m_rule);
+            (*it)->m_mainRule = (*itm)->m_rule;
+          }
+
+      }
+    }
+
+  // Add pending programs to upcoming recordings
+  ProgramInfoMap pending = m_con.GetPendingPrograms();
+  m_recordings.clear();
+  m_recordingIndexByRuleId.clear();
+  for (ProgramInfoMap::iterator it = pending.begin(); it != pending.end(); ++it)
+  {
+    boost::shared_ptr<MythProgramInfo> rec = boost::shared_ptr<MythProgramInfo>(new MythProgramInfo());
+    *rec = it->second;
+    unsigned int index = MakeIndex(it->second);
+    m_recordings.insert(RecordingList::value_type(index, rec));
+    m_recordingIndexByRuleId.insert(std::make_pair(it->second.RecordID(), index));
+  }
+
+  // Add missed programs (NOT RECORDING) to upcoming recordings. User could delete them as needed.
+  //ProgramInfoMap schedule = m_con.GetScheduledPrograms();
+  //for (ProgramInfoMap::iterator it = schedule.begin(); it != schedule.end(); ++it)
+  //{
+  //  if (m_recordingIndexByRuleId.count(it->second.RecordID()) == 0)
+  //  {
+  //    NodeById::const_iterator itr = m_rulesById.find(it->second.RecordID());
+  //    if (itr != m_rulesById.end() && !itr->second->HasOverrideRules())
+  //    {
+  //      boost::shared_ptr<MythProgramInfo> rec = boost::shared_ptr<MythProgramInfo>(new MythProgramInfo());
+  //      *rec = it->second;
+  //      unsigned int index = MakeIndex(it->second);
+  //      m_recordings.insert(RecordingList::value_type(index, rec));
+  //      m_recordingIndexByRuleId.insert(std::make_pair(it->second.RecordID(), index));
+  //    }
+  //  }
+  //}
+
+  if (g_bExtraDebug)
+  {
+    for (NodeList::iterator it = m_rules.begin(); it != m_rules.end(); ++it)
+      XBMC->Log(LOG_DEBUG, "%s - Rule node - recordid: %u, parentid: %u, type: %d, overriden: %s", __FUNCTION__, (*it)->m_rule.RecordID(), (*it)->m_rule.ParentID(), (*it)->m_rule.Type(), ((*it)->HasOverrideRules() ? "Yes" : "No"));
+    for (RecordingList::iterator it = m_recordings.begin(); it != m_recordings.end(); ++it)
+      XBMC->Log(LOG_DEBUG, "%s - Recording - recordid: %u, index: %d, status: %d, title: %s", __FUNCTION__, it->second->RecordID(), it->first, it->second->Status(), it->second->Title().c_str());
+  }
+}
+
+MythRecordingRule MythScheduleManager::NewFromTemplate(MythEPGInfo &epgInfo)
+{
+  return m_versionHelper->NewFromTemplate(epgInfo);
+}
+
+MythRecordingRule MythScheduleManager::NewSingleRecord(MythEPGInfo &epgInfo)
+{
+  return m_versionHelper->NewSingleRecord(epgInfo);
+}
+
+MythRecordingRule MythScheduleManager::NewDailyRecord(MythEPGInfo &epgInfo)
+{
+  return m_versionHelper->NewDailyRecord(epgInfo);
+}
+
+MythRecordingRule MythScheduleManager::NewWeeklyRecord(MythEPGInfo &epgInfo)
+{
+  return m_versionHelper->NewWeeklyRecord(epgInfo);
+}
+
+MythRecordingRule MythScheduleManager::NewChannelRecord(const CStdString &searchTitle)
+{
+  return m_versionHelper->NewChannelRecord(searchTitle);
+}
+
+MythRecordingRule MythScheduleManager::NewOneRecord(const CStdString &searchTitle)
+{
+  return m_versionHelper->NewOneRecord(searchTitle);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// Version Helper for unknown version (no helper)
+////
+
+bool MythScheduleHelperNoHelper::SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const
+{
+  (void)first;
+  (void)second;
+  return false;
+}
+
+MythRecordingRule MythScheduleHelperNoHelper::NewFromTemplate(MythEPGInfo& epgInfo)
+{
+  (void)epgInfo;
+  return MythRecordingRule();
+}
+
+MythRecordingRule MythScheduleHelperNoHelper::NewSingleRecord(MythEPGInfo &epgInfo)
+{
+  (void)epgInfo;
+  return MythRecordingRule();
+}
+
+MythRecordingRule MythScheduleHelperNoHelper::NewDailyRecord(MythEPGInfo &epgInfo)
+{
+  (void)epgInfo;
+  return MythRecordingRule();
+}
+
+MythRecordingRule MythScheduleHelperNoHelper::NewWeeklyRecord(MythEPGInfo &epgInfo)
+{
+  (void)epgInfo;
+  return MythRecordingRule();
+}
+
+MythRecordingRule MythScheduleHelperNoHelper::NewChannelRecord(const CStdString &searchTitle)
+{
+  (void)searchTitle;
+  return MythRecordingRule();
+}
+
+MythRecordingRule MythScheduleHelperNoHelper::NewOneRecord(const CStdString &searchTitle)
+{
+  (void)searchTitle;
+  return MythRecordingRule();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// Version Helper for database up to 1226 (0.24))
+////
+
+bool MythScheduleHelper1226::SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const
+{
+  time_t first_st = first.StartTime();
+  time_t second_st = second.StartTime();
+
+  switch (first.Type())
+  {
+  case MythRecordingRule::RT_NotRecording:
+  case MythRecordingRule::RT_SingleRecord:
+  case MythRecordingRule::RT_OverrideRecord:
+  case MythRecordingRule::RT_DontRecord:
+    return
+    second_st == first_st &&
+            second.EndTime() == first.EndTime() &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_OneRecord: // FindOneRecord
+    return
+    second.Title() == first.Title() &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_DailyRecord: // TimeslotRecord
+    return
+    second.Title() == first.Title() &&
+            daytime(&first_st) == daytime(&second_st) &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_WeeklyRecord: // WeekslotRecord
+    return
+    second.Title() == first.Title() &&
+            daytime(&first_st) == daytime(&second_st) &&
+            weekday(&first_st) == weekday(&second_st) &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_FindDailyRecord:
+    return
+    second.Title() == first.Title() &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_FindWeeklyRecord:
+    return
+    second.Title() == first.Title() &&
+            weekday(&first_st) == weekday(&second_st) &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_ChannelRecord:
+    return
+    second.Title() == first.Title() &&
+            second.ChannelID() == first.ChannelID();
+
+  case MythRecordingRule::RT_AllRecord:
+    return
+    second.Title() == first.Title();
+
+  default:
+    break;
+  }
+  return false;
+}
+
+MythRecordingRule MythScheduleHelper1226::NewFromTemplate(MythEPGInfo &epgInfo)
+{
+  MythRecordingRule rule;
+  // Load rule template from selected provider
+  switch (g_iRecTemplateType)
+  {
+  case 1: // Template provider is 'MythTV', then load the template from backend.
+    rule = m_db.LoadRecordingRuleTemplate("", "");
+    break;
+  case 0: // Template provider is 'Internal', then set rule with settings
+    rule.SetAutoCommFlag(g_bRecAutoCommFlag);
+    rule.SetAutoTranscode(g_bRecAutoTranscode);
+    rule.SetUserJob(1, g_bRecAutoRunJob1);
+    rule.SetUserJob(2, g_bRecAutoRunJob2);
+    rule.SetUserJob(3, g_bRecAutoRunJob3);
+    rule.SetUserJob(4, g_bRecAutoRunJob4);
+    rule.SetAutoExpire(g_bRecAutoExpire);
+    rule.SetTranscoder(g_iRecTranscoder);
+  }
+
+  // Category override
+  if (!epgInfo.IsNull())
+  {
+    CStdString overTimeCategory = m_db.GetSetting("OverTimeCategory");
+    if (!overTimeCategory.IsEmpty() && (overTimeCategory.Equals(epgInfo.Category()) || overTimeCategory.Equals(epgInfo.CategoryType())))
+    {
+      CStdString categoryOverTime = m_db.GetSetting("CategoryOverTime");
+      XBMC->Log(LOG_DEBUG, "Overriding end offset for category %s: +%s", overTimeCategory.c_str(), categoryOverTime.c_str());
+      rule.SetEndOffset(atoi(categoryOverTime));
+    }
+  }
+  return rule;
+}
+
+MythRecordingRule MythScheduleHelper1226::NewSingleRecord(MythEPGInfo &epgInfo)
+{
+  MythRecordingRule rule = this->NewFromTemplate(epgInfo);
+
+  rule.SetType(MythRecordingRule::RT_SingleRecord);
+
+  if (!epgInfo.IsNull())
+  {
+    rule.SetChannelID(epgInfo.ChannelID());
+    rule.SetStartTime(epgInfo.StartTime());
+    rule.SetEndTime(epgInfo.EndTime());
+    rule.SetSearchType(MythRecordingRule::ST_NoSearch);
+    rule.SetTitle(epgInfo.Title());
+    rule.SetSubtitle(epgInfo.Subtitle());
+    rule.SetCategory(epgInfo.Category());
+    rule.SetDescription(epgInfo.Description());
+    rule.SetCallsign(epgInfo.Callsign());
+  }
+  else
+  {
+    // kManualSearch = http://www.gossamer-threads.com/lists/mythtv/dev/155150?search_string=kManualSearch;#155150
+    rule.SetSearchType(MythRecordingRule::ST_ManualSearch);
+  }
+  rule.SetDuplicateControlMethod(MythRecordingRule::DM_CheckNone);
+  rule.SetCheckDuplicatesInType(MythRecordingRule::DI_InAll);
+  rule.SetInactive(false);
+  return rule;
+}
+
+MythRecordingRule MythScheduleHelper1226::NewDailyRecord(MythEPGInfo& epgInfo)
+{
+  MythRecordingRule rule = this->NewFromTemplate(epgInfo);
+
+  rule.SetType(MythRecordingRule::RT_DailyRecord);
+
+  if (!epgInfo.IsNull())
+  {
+    rule.SetSearchType(MythRecordingRule::ST_NoSearch);
+    rule.SetChannelID(epgInfo.ChannelID());
+    rule.SetStartTime(epgInfo.StartTime());
+    rule.SetEndTime(epgInfo.EndTime());
+    rule.SetTitle(epgInfo.Title());
+    rule.SetSubtitle(epgInfo.Subtitle());
+    rule.SetCategory(epgInfo.Category());
+    rule.SetDescription(epgInfo.Description());
+    rule.SetCallsign(epgInfo.Callsign());
+  }
+  else
+  {
+    // kManualSearch = http://www.gossamer-threads.com/lists/mythtv/dev/155150?search_string=kManualSearch;#155150
+    rule.SetSearchType(MythRecordingRule::ST_ManualSearch);
+  }
+  rule.SetDuplicateControlMethod(MythRecordingRule::DM_CheckSubtitleAndDescription);
+  rule.SetCheckDuplicatesInType(MythRecordingRule::DI_InAll);
+  rule.SetInactive(false);
+  return rule;
+}
+
+MythRecordingRule MythScheduleHelper1226::NewWeeklyRecord(MythEPGInfo& epgInfo)
+{
+  MythRecordingRule rule = this->NewFromTemplate(epgInfo);
+
+  rule.SetType(MythRecordingRule::RT_WeeklyRecord);
+
+  if (!epgInfo.IsNull())
+  {
+    rule.SetSearchType(MythRecordingRule::ST_NoSearch);
+    rule.SetChannelID(epgInfo.ChannelID());
+    rule.SetStartTime(epgInfo.StartTime());
+    rule.SetEndTime(epgInfo.EndTime());
+    rule.SetTitle(epgInfo.Title());
+    rule.SetSubtitle(epgInfo.Subtitle());
+    rule.SetCategory(epgInfo.Category());
+    rule.SetDescription(epgInfo.Description());
+    rule.SetCallsign(epgInfo.Callsign());
+  }
+  else
+  {
+    // kManualSearch = http://www.gossamer-threads.com/lists/mythtv/dev/155150?search_string=kManualSearch;#155150
+    rule.SetSearchType(MythRecordingRule::ST_ManualSearch);
+  }
+  rule.SetDuplicateControlMethod(MythRecordingRule::DM_CheckSubtitleAndDescription);
+  rule.SetCheckDuplicatesInType(MythRecordingRule::DI_InAll);
+  rule.SetInactive(false);
+  return rule;
+}
+
+MythRecordingRule MythScheduleHelper1226::NewChannelRecord(const CStdString &searchTitle)
+{
+  // Backend use the description to find program by keywords or title
+  MythEPGInfo epgInfo;
+  MythRecordingRule rule = this->NewFromTemplate(epgInfo);
+  rule.SetType(MythRecordingRule::RT_ChannelRecord);
+  rule.SetSearchType(MythRecordingRule::ST_TitleSearch);
+  rule.SetSubtitle("");
+  rule.SetDescription(searchTitle);
+  rule.SetDuplicateControlMethod(MythRecordingRule::DM_CheckSubtitleAndDescription);
+  rule.SetCheckDuplicatesInType(MythRecordingRule::DI_InAll);
+  rule.SetInactive(false);
+  return rule;
+}
+
+MythRecordingRule MythScheduleHelper1226::NewOneRecord(const CStdString &searchTitle)
+{
+  // Backend use the description to find program by keywords or title
+  MythEPGInfo epgInfo;
+  MythRecordingRule rule = this->NewFromTemplate(epgInfo);
+  rule.SetType(MythRecordingRule::RT_OneRecord);
+  rule.SetSearchType(MythRecordingRule::ST_TitleSearch);
+  rule.SetSubtitle("");
+  rule.SetDescription(searchTitle);
+  rule.SetDuplicateControlMethod(MythRecordingRule::DM_CheckSubtitleAndDescription);
+  rule.SetCheckDuplicatesInType(MythRecordingRule::DI_InAll);
+  rule.SetInactive(false);
+  return rule;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// Version Helper for database up to 1278 (0.25)
+////
+//// New filter mask (1276)
+//// New autometadata flag (1278)
+////
+
+bool MythScheduleHelper1278::SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const
+{
+  time_t first_st = first.StartTime();
+  time_t second_st = second.StartTime();
+
+  switch (first.Type())
+  {
+  case MythRecordingRule::RT_NotRecording:
+  case MythRecordingRule::RT_SingleRecord:
+  case MythRecordingRule::RT_OverrideRecord:
+  case MythRecordingRule::RT_DontRecord:
+    return
+    second_st == first_st &&
+            second.EndTime() == first.EndTime() &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_OneRecord: // FindOneRecord
+    return
+    second.Title() == first.Title() &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_DailyRecord: // TimeslotRecord
+    return
+    second.Title() == first.Title() &&
+            daytime(&first_st) == daytime(&second_st) &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_WeeklyRecord: // WeekslotRecord
+    return
+    second.Title() == first.Title() &&
+            daytime(&first_st) == daytime(&second_st) &&
+            weekday(&first_st) == weekday(&second_st) &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_FindDailyRecord:
+    return
+    second.Title() == first.Title() &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_FindWeeklyRecord:
+    return
+    second.Title() == first.Title() &&
+            weekday(&first_st) == weekday(&second_st) &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_ChannelRecord:
+    return
+    second.Title() == first.Title() &&
+            second.ChannelID() == first.ChannelID() &&
+            second.Filter() == first.Filter();
+
+  case MythRecordingRule::RT_AllRecord:
+    return
+    second.Title() == first.Title() &&
+            second.Filter() == first.Filter();
+
+  default:
+    break;
+  }
+  return false;
+}
+
+MythRecordingRule MythScheduleHelper1278::NewFromTemplate(MythEPGInfo &epgInfo)
+{
+  MythRecordingRule rule;
+  // Load rule template from selected provider
+  switch (g_iRecTemplateType)
+  {
+    case 1: // Template provider is 'MythTV', then load the template from backend.
+      rule = m_db.LoadRecordingRuleTemplate("", "");
+      break;
+    case 0: // Template provider is 'Internal', then set rule with settings
+      rule.SetAutoCommFlag(g_bRecAutoCommFlag);
+      rule.SetAutoMetadata(g_bRecAutoMetadata);
+      rule.SetAutoTranscode(g_bRecAutoTranscode);
+      rule.SetUserJob(1, g_bRecAutoRunJob1);
+      rule.SetUserJob(2, g_bRecAutoRunJob2);
+      rule.SetUserJob(3, g_bRecAutoRunJob3);
+      rule.SetUserJob(4, g_bRecAutoRunJob4);
+      rule.SetAutoExpire(g_bRecAutoExpire);
+      rule.SetTranscoder(g_iRecTranscoder);
+  }
+
+  // Category override
+  if (!epgInfo.IsNull())
+  {
+    CStdString overTimeCategory = m_db.GetSetting("OverTimeCategory");
+    if (!overTimeCategory.IsEmpty() && (overTimeCategory.Equals(epgInfo.Category()) || overTimeCategory.Equals(epgInfo.CategoryType())))
+    {
+      CStdString categoryOverTime = m_db.GetSetting("CategoryOverTime");
+      XBMC->Log(LOG_DEBUG, "Overriding end offset for category %s: +%s", overTimeCategory.c_str(), categoryOverTime.c_str());
+      rule.SetEndOffset(atoi(categoryOverTime));
+    }
+  }
+  return rule;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// Version helper for database up to 1302 (0.26)
+////
+//// TemplateRecord replaces static settings
+////
+
+MythRecordingRule MythScheduleHelper1302::NewFromTemplate(MythEPGInfo &epgInfo)
+{
+  MythRecordingRule rule;
+  // Load rule template from selected provider
+  switch (g_iRecTemplateType)
+  {
+  case 1: // Template provider is 'MythTV', then load the template from backend.
+    if (!epgInfo.IsNull())
+      rule = m_db.LoadRecordingRuleTemplate(epgInfo.Category(), epgInfo.CategoryType());
+    else
+      rule = m_db.LoadRecordingRuleTemplate("", "");
+    break;
+  case 0: // Template provider is 'Internal', then set rule with settings
+    rule.SetAutoCommFlag(g_bRecAutoCommFlag);
+    rule.SetAutoMetadata(g_bRecAutoMetadata);
+    rule.SetAutoTranscode(g_bRecAutoTranscode);
+    rule.SetUserJob(1, g_bRecAutoRunJob1);
+    rule.SetUserJob(2, g_bRecAutoRunJob2);
+    rule.SetUserJob(3, g_bRecAutoRunJob3);
+    rule.SetUserJob(4, g_bRecAutoRunJob4);
+    rule.SetAutoExpire(g_bRecAutoExpire);
+    rule.SetTranscoder(g_iRecTranscoder);
+  }
+
+  // Category override
+  if (!epgInfo.IsNull())
+  {
+    CStdString overTimeCategory = m_db.GetSetting("OverTimeCategory");
+    if (!overTimeCategory.IsEmpty() && (overTimeCategory.Equals(epgInfo.Category()) || overTimeCategory.Equals(epgInfo.CategoryType())))
+    {
+      CStdString categoryOverTime = m_db.GetSetting("CategoryOverTime");
+      XBMC->Log(LOG_DEBUG, "Overriding end offset for category %s: +%s", overTimeCategory.c_str(), categoryOverTime.c_str());
+      rule.SetEndOffset(atoi(categoryOverTime));
+    }
+  }
+  return rule;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// Version helper for database up to 1309 (0.27)
+////
+//// Remove the Timeslot and Weekslot recording rule types. These rule
+//// types are too rigid and don't work when a broadcaster shifts the
+//// starting time of a program by a few minutes. Users should now use
+//// Channel recording rules in place of Timeslot and Weekslot rules. To
+//// approximate the old functionality, two new schedule filters have been
+//// added. In addition, the new "This time" and "This day and time"
+//// filters are less strict and match any program starting within 10
+//// minutes of the recording rule time.
+//// Restrict the use of the FindDaily? and FindWeekly? recording rule types
+//// (now simply called Daily and Weekly) to search and manual recording
+//// rules. These rule types are rarely needed and limiting their use to
+//// the most powerful cases simplifies the user interface for the more
+//// common cases. Users should now use Daily and Weekly, custom search
+//// rules in place of FindDaily? and FindWeekly? rules.
+//// Any existing recording rules using the no longer supported or allowed
+//// types are automatically converted to the suggested alternatives.
+////
+
+// TODO
+

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythScheduleManager.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythScheduleManager.h
@@ -1,0 +1,213 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MythRecordingRule.h"
+#include "MythProgramInfo.h"
+#include "MythConnection.h"
+#include "MythDatabase.h"
+#include "MythEPGInfo.h"
+
+#include <platform/threads/mutex.h>
+
+#include <vector>
+#include <list>
+#include <map>
+
+typedef std::vector<MythRecordingRule> OverrideRuleList;
+
+// Schedule element is pair < index of schedule , program info of schedule >
+typedef std::vector<std::pair<unsigned int, boost::shared_ptr<MythProgramInfo> > > ScheduleList;
+
+class MythRecordingRuleNode
+{
+public:
+  friend class MythScheduleManager;
+
+  MythRecordingRuleNode(const MythRecordingRule &rule);
+
+  bool IsOverrideRule() const;
+  MythRecordingRule GetRule() const;
+  MythRecordingRule GetMainRule() const;
+
+  bool HasOverrideRules() const;
+  OverrideRuleList GetOverrideRules() const;
+
+  bool IsInactiveRule() const;
+
+private:
+  MythRecordingRule m_rule;
+  MythRecordingRule m_mainRule;
+  std::vector<MythRecordingRule> m_overrideRules;
+};
+
+class MythScheduleManager
+{
+public:
+  enum MSM_ERROR {
+    MSM_ERROR_FAILED = -1,
+    MSM_ERROR_NOT_IMPLEMENTED = 0,
+    MSM_ERROR_SUCCESS = 1
+  };
+
+  MythScheduleManager();
+  MythScheduleManager(MythConnection &con, MythDatabase &db);
+
+  // Called by GetTimers
+  ScheduleList GetUpcomingRecordings();
+
+  // Called by AddTimer
+  MSM_ERROR ScheduleRecording(const MythRecordingRule &rule);
+
+  // Called by DeleteTimer
+  MSM_ERROR DeleteRecording(unsigned int index);
+
+  MSM_ERROR DisableRecording(unsigned int index);
+  MSM_ERROR EnableRecording(unsigned int index);
+  MSM_ERROR UpdateRecording(unsigned int index, MythRecordingRule &newrule);
+
+  boost::shared_ptr<MythRecordingRuleNode> FindRuleById(unsigned int recordID) const;
+  ScheduleList FindUpComingByRuleId(unsigned int recordID) const;
+  boost::shared_ptr<MythProgramInfo> FindUpComingByIndex(unsigned int index) const;
+
+  void Update();
+
+  class VersionHelper
+  {
+  public:
+    friend class MythScheduleManager;
+
+    VersionHelper() {}
+    virtual ~VersionHelper();
+    virtual bool SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const = 0;
+    virtual MythRecordingRule NewFromTemplate(MythEPGInfo &epgInfo) = 0;
+    virtual MythRecordingRule NewSingleRecord(MythEPGInfo &epgInfo) = 0;
+    virtual MythRecordingRule NewDailyRecord(MythEPGInfo &epgInfo) = 0;
+    virtual MythRecordingRule NewWeeklyRecord(MythEPGInfo &epgInfo) = 0;
+    virtual MythRecordingRule NewChannelRecord(const CStdString &searchTitle) = 0;
+    virtual MythRecordingRule NewOneRecord(const CStdString &searchTitle) = 0;
+  };
+
+  MythRecordingRule NewFromTemplate(MythEPGInfo &epgInfo);
+  MythRecordingRule NewSingleRecord(MythEPGInfo &epgInfo);
+  MythRecordingRule NewDailyRecord(MythEPGInfo &epgInfo);
+  MythRecordingRule NewWeeklyRecord(MythEPGInfo &epgInfo);
+  MythRecordingRule NewChannelRecord(const CStdString &searchTitle);
+  MythRecordingRule NewOneRecord(const CStdString &searchTitle);
+
+private:
+  mutable PLATFORM::CMutex m_lock;
+  MythConnection m_con;
+  MythDatabase m_db;
+
+  int m_dbSchemaVersion;
+  boost::shared_ptr<VersionHelper> m_versionHelper;
+  void Setup();
+
+  unsigned int MakeIndex(MythProgramInfo &recording) const;
+
+  // The list of rule nodes
+  typedef std::list<boost::shared_ptr<MythRecordingRuleNode> > NodeList;
+  // To find a rule node by its key (recordID)
+  typedef std::map<unsigned int, boost::shared_ptr<MythRecordingRuleNode> > NodeById;
+  // Store and find up coming recordings by index
+  typedef std::map<unsigned int, boost::shared_ptr<MythProgramInfo> > RecordingList;
+  // To find all indexes of schedule by rule Id : pair < Rule Id , index of schedule >
+  typedef std::multimap<unsigned int, unsigned int> RecordingIndexByRuleId;
+
+  NodeList m_rules;
+  NodeById m_rulesById;
+  RecordingList m_recordings;
+  RecordingIndexByRuleId m_recordingIndexByRuleId;
+};
+
+
+///////////////////////////////////////////////////////////////////////////////
+////
+//// VersionHelper
+////
+
+inline MythScheduleManager::VersionHelper::~VersionHelper() {
+}
+
+// No helper
+
+class MythScheduleHelperNoHelper : public MythScheduleManager::VersionHelper {
+public:
+  virtual bool SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const;
+  virtual MythRecordingRule NewFromTemplate(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewSingleRecord(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewDailyRecord(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewWeeklyRecord(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewChannelRecord(const CStdString &searchTitle);
+  virtual MythRecordingRule NewOneRecord(const CStdString &searchTitle);
+};
+
+// Base 0.24
+
+class MythScheduleHelper1226 : public MythScheduleHelperNoHelper {
+public:
+
+  MythScheduleHelper1226(MythDatabase &db) : m_db(db) {
+  }
+  virtual bool SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const;
+  virtual MythRecordingRule NewFromTemplate(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewSingleRecord(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewDailyRecord(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewWeeklyRecord(MythEPGInfo &epgInfo);
+  virtual MythRecordingRule NewChannelRecord(const CStdString &searchTitle);
+  virtual MythRecordingRule NewOneRecord(const CStdString &searchTitle);
+protected:
+  MythDatabase m_db;
+};
+
+// News in 0.25
+
+class MythScheduleHelper1278 : public MythScheduleHelper1226 {
+public:
+
+  MythScheduleHelper1278(MythDatabase &db) : MythScheduleHelper1226(db) {
+  }
+  virtual bool SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const;
+  virtual MythRecordingRule NewFromTemplate(MythEPGInfo &epgInfo);
+};
+
+// News in 0.26
+
+class MythScheduleHelper1302 : public MythScheduleHelper1278 {
+public:
+
+  MythScheduleHelper1302(MythDatabase &db) : MythScheduleHelper1278(db) {
+  }
+  virtual MythRecordingRule NewFromTemplate(MythEPGInfo &epgInfo);
+};
+
+// News in 0.27
+
+class MythScheduleHelper1309 : public MythScheduleHelper1302 {
+public:
+
+  MythScheduleHelper1309(MythDatabase &db) : MythScheduleHelper1302(db) {
+  }
+  //virtual bool SameTimeslot(MythRecordingRule &first, MythRecordingRule &second) const;
+  //virtual MythRecordingRule NewSingleRecord() const;
+  //virtual MythRecordingRule NewDailyRecord() const;
+  //virtual MythRecordingRule NewWeeklyRecord() const;
+};

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.cpp
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.cpp
@@ -32,19 +32,19 @@ MythTimestamp::MythTimestamp(cmyth_timestamp_t cmyth_timestamp)
   *m_timestamp_t = cmyth_timestamp;
 }
 
-MythTimestamp::MythTimestamp(CStdString time, bool datetime)
+MythTimestamp::MythTimestamp(CStdString time)
  : m_timestamp_t(new MythPointer<cmyth_timestamp_t>())
 {
-  // datetime ? DatetimeFromString(time.Buffer()) : cmyth_timestamp_from_string(time.Buffer())
-  (void)datetime;
-
   *m_timestamp_t = (cmyth_timestamp_from_string(time.Buffer()));
 }
 
-MythTimestamp::MythTimestamp(time_t time)
+MythTimestamp::MythTimestamp(time_t time, bool utc)
   : m_timestamp_t(new MythPointer<cmyth_timestamp_t>())
 {
-  *m_timestamp_t = cmyth_timestamp_from_unixtime(time);
+  if (utc)
+    *m_timestamp_t = cmyth_timestamp_utc_from_unixtime(time);
+  else
+    *m_timestamp_t = cmyth_timestamp_from_unixtime(time);
 }
 
 bool MythTimestamp::operator==(const MythTimestamp &other)
@@ -91,7 +91,7 @@ CStdString MythTimestamp::IsoString()
 CStdString MythTimestamp::DisplayString(bool use12hClock)
 {
   char time[25];
-  bool succeded=cmyth_timestamp_to_display_string(time, *m_timestamp_t, use12hClock) == 0;
+  bool succeded = cmyth_timestamp_to_display_string(time, *m_timestamp_t, use12hClock) == 0;
   return succeded ? CStdString(time) : CStdString("");
 }
 
@@ -100,4 +100,18 @@ CStdString MythTimestamp::NumString()
   char time[15];
   bool succeded = cmyth_timestamp_to_numstring(time, *m_timestamp_t) == 0;
   return succeded ? CStdString(time) : CStdString("");
+}
+
+bool MythTimestamp::IsUTC()
+{
+  if (cmyth_timestamp_isutc(*m_timestamp_t) == 1)
+    return true;
+  return false;
+}
+
+MythTimestamp MythTimestamp::ToUTC()
+{
+  if (this->IsUTC())
+    return *this;
+  return MythTimestamp(cmyth_timestamp_to_utc(*m_timestamp_t));
 }

--- a/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.h
+++ b/addons/pvr.mythtv.cmyth/src/cppmyth/MythTimestamp.h
@@ -36,8 +36,8 @@ public:
 
   MythTimestamp();
   MythTimestamp(cmyth_timestamp_t cmyth_timestamp);
-  MythTimestamp(CStdString time, bool datetime);
-  MythTimestamp(time_t time);
+  MythTimestamp(CStdString time);
+  MythTimestamp(time_t time, bool utc);
 
   bool operator==(const MythTimestamp &other);
   bool operator!=(const MythTimestamp &other) { return !(*this == other); }
@@ -53,6 +53,9 @@ public:
   CStdString IsoString();
   CStdString DisplayString(bool use12hClock);
   CStdString NumString();
+
+  bool IsUTC();
+  MythTimestamp ToUTC();
 
 private:
   boost::shared_ptr<MythPointer<cmyth_timestamp_t> > m_timestamp_t;

--- a/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.h
+++ b/addons/pvr.mythtv.cmyth/src/pvrclient-mythtv.h
@@ -25,34 +25,6 @@
 #include <xbmc_pvr_types.h>
 #include <platform/threads/mutex.h>
 
-class RecordingRule : public MythRecordingRule, public std::vector<std::pair<PVR_TIMER, MythProgramInfo> >
-{
-public:
-  RecordingRule(const MythRecordingRule &rule);
-  RecordingRule& operator=(const MythRecordingRule &rule);
-  bool operator==(const unsigned int &id);
-
-  RecordingRule* GetParent() const;
-  void SetParent(RecordingRule &parent);
-
-  bool HasOverrideRules() const;
-  std::vector<RecordingRule*> GetOverrideRules() const;
-  void AddOverrideRule(RecordingRule &overrideRule);
-
-  bool SameTimeslot(RecordingRule &rule) const;
-
-  void push_back(std::pair<PVR_TIMER, MythProgramInfo> &_val);
-
-private:
-  void SaveTimerString(PVR_TIMER &timer);
-
-  RecordingRule* m_parent;
-  std::vector<RecordingRule*> m_overrideRules;
-  std::vector<boost::shared_ptr<CStdString> > m_stringStore;
-};
-
-typedef std::vector<RecordingRule> RecordingRuleList;
-
 class PVRClientMythTV : public MythEventObserver
 {
 public:
@@ -81,6 +53,7 @@ public:
   PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
 
   // Recordings
+  void UpdateRecordings();
   int GetRecordingsAmount(void);
   PVR_ERROR GetRecordings(ADDON_HANDLE handle);
   PVR_ERROR DeleteRecording(const PVR_RECORDING &recording);
@@ -91,6 +64,7 @@ public:
   PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entries[], int *size);
 
   // Timers
+  void UpdateSchedules();
   int GetTimersAmount();
   PVR_ERROR GetTimers(ADDON_HANDLE handle);
   PVR_ERROR AddTimer(const PVR_TIMER &timer);
@@ -130,6 +104,7 @@ private:
   FileOps *m_fileOps;
   PLATFORM::CMutex m_lock;
   MythFile m_file;
+  MythScheduleManager *m_scheduleManager;
 
   CStdString m_backendName;
   CStdString m_backendVersion;
@@ -151,8 +126,19 @@ private:
   void ForceUpdateRecording(ProgramInfoMap::iterator it);
   int FillRecordings();
   int GetRecordingLastPlayedPosition(MythProgramInfo &programInfo);
+  MythChannel FindRecordingChannel(MythProgramInfo &programInfo);
+  bool IsMyLiveTVRecording(MythProgramInfo &programInfo);
+  bool KeepLiveTVRecording(MythProgramInfo &programInfo, bool keep);
 
   // Timers
-  RecordingRuleList m_recordingRules;
-  void PVRtoMythRecordingRule(const PVR_TIMER &timer, MythRecordingRule &rule);
+  MythRecordingRule PVRtoMythRecordingRule(const PVR_TIMER &timer);
+  std::map<unsigned int, boost::shared_ptr<PVR_TIMER> > m_PVRtimerMemorandum;
+
+  /**
+   * \brief Returns full title of MythTV program
+   *
+   * Make formatted title based on original title and subtitle of program.
+   * \see class MythProgramInfo , class MythEPGInfo
+   */
+  CStdString MakeProgramTitle(const CStdString &title, const CStdString &subtitle) const;
 };

--- a/addons/pvr.mythtv.cmyth/src/tools.h
+++ b/addons/pvr.mythtv.cmyth/src/tools.h
@@ -24,14 +24,14 @@
 #include <time.h>
 #endif
 
-int inline daytime(time_t *time)
+inline int daytime(time_t *time)
 {
   struct tm* ptm = localtime(time);
-  int retval = ptm->tm_sec * 60 + ptm->tm_min * 60 + ptm->tm_hour;
+  int retval = ptm->tm_sec + ptm->tm_min * 60 + ptm->tm_hour * 3600;
   return retval;
 }
 
-int inline weekday(time_t *time)
+inline int weekday(time_t *time)
 {
   struct tm* ptm = localtime(time);
   int retval = ptm->tm_wday;

--- a/lib/cmyth/libcmyth/bookmark.c
+++ b/lib/cmyth/libcmyth/bookmark.c
@@ -81,7 +81,15 @@ int cmyth_set_bookmark(cmyth_conn_t conn, cmyth_proginfo_t prog, int64_t bookmar
 	if (!buf) {
 		return -ENOMEM;
 	}
-	if (conn->conn_version >= 66) {
+	if (conn->conn_version >= 77) {
+		/*
+		 * Since protocol 77 mythbackend no longer expects the trailing 4th parameter
+		 * http://code.mythtv.org/trac/ticket/11104
+		 */
+		sprintf(buf, "SET_BOOKMARK %"PRIu32" %s %"PRId64, prog->proginfo_chanId,
+				start_ts_dt, bookmark);
+	}
+	else if (conn->conn_version >= 66) {
 		/*
 		 * Since protocol 66 mythbackend expects a single 64 bit integer rather than two 32 bit
 		 * hi and lo integers. Nevertheless the backend (at least up to 0.25) checks

--- a/lib/cmyth/libcmyth/cmyth_local.h
+++ b/lib/cmyth/libcmyth/cmyth_local.h
@@ -62,6 +62,7 @@ typedef int cmyth_socket_t;
 #define CMYTH_INT16_LEN (sizeof("-65536") - 1)
 #define CMYTH_INT8_LEN (sizeof("-256") - 1)
 #define CMYTH_TIMESTAMP_LEN (sizeof("YYYY-MM-DDTHH:MM:SS") - 1)
+#define CMYTH_TIMESTAMP_UTC_LEN (sizeof("YYYY-MM-DDTHH:MM:SSZ") - 1)
 #define CMYTH_TIMESTAMP_NUMERIC_LEN (sizeof("YYYYMMDDHHMMSS") - 1)
 #define CMYTH_DATESTAMP_LEN (sizeof("YYYY-MM-DD") - 1)
 #define CMYTH_UTC_LEN (sizeof("1240120680") - 1)
@@ -187,6 +188,7 @@ struct cmyth_timestamp {
 	unsigned long timestamp_minute;
 	unsigned long timestamp_second;
 	int timestamp_isdst;
+	int timestamp_isutc;
 };
 
 struct cmyth_proginfo {
@@ -214,7 +216,7 @@ struct cmyth_proginfo {
 	uint32_t proginfo_source_id; /* ??? in V8 */
 	uint32_t proginfo_card_id;   /* ??? in V8 */
 	uint32_t proginfo_input_id;  /* ??? in V8 */
-	int8_t proginfo_rec_priority;  /* ??? in V8 */
+	int32_t proginfo_rec_priority;  /* ??? in V8 */
 	int8_t proginfo_rec_status; /* ??? in V8 */
 	uint32_t proginfo_record_id;  /* ??? in V8 */
 	uint8_t proginfo_rec_type;   /* ??? in V8 */
@@ -240,7 +242,7 @@ struct cmyth_proginfo {
 	char *proginfo_host;
 	uint32_t proginfo_version;
 	char *proginfo_playgroup; /* new in v18 */
-	int8_t proginfo_recpriority_2;  /* new in V25 */
+	int32_t proginfo_recpriority_2;  /* new in V25 */
 	uint32_t proginfo_parentid; /* new in V31 */
 	char *proginfo_storagegroup; /* new in v32 */
 	uint16_t proginfo_audioproperties; /* new in v35 */
@@ -471,13 +473,14 @@ struct cmyth_recordingrule {
 	uint32_t maxepisodes;            //range 0,100
 	uint8_t maxnewest;               //bool
 	uint32_t transcoder;             //recordingprofiles id
+	uint32_t parentid;               //parent rule recordid
 	char* profile;
 	uint32_t prefinput;
 	uint8_t autometadata;            //DB version 1278
 	char* inetref;                   //DB version 1278
 	uint16_t season;                 //DB version 1278
 	uint16_t episode;                //DB version 1278
-	uint32_t filter;		 //DB version 1276
+	uint32_t filter;                 //DB version 1276
 	};
 
 struct cmyth_recordingrulelist {

--- a/lib/cmyth/libcmyth/commbreak.c
+++ b/lib/cmyth/libcmyth/commbreak.c
@@ -191,11 +191,11 @@ int cmyth_rcv_commbreaklist(cmyth_conn_t conn, int *err,
 	int total = 0;
 	int rows;
 	int64_t mark;
-	int64_t start_mark;
+	int64_t start_mark = 0;
 	char *failed = NULL;
 	cmyth_commbreak_t commbreak;
 	uint8_t type;
-	uint8_t start_type;
+	uint8_t start_type = -1;
 	int started = 0;
 	int i;
 

--- a/lib/cmyth/libcmyth/connection.c
+++ b/lib/cmyth/libcmyth/connection.c
@@ -255,7 +255,7 @@ cmyth_connect_addr(struct addrinfo* addr, char *server, char *service,
 	my_fd = fd;
 	if (connect(fd, addr->ai_addr, addr->ai_addrlen) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
-			  "%s: connect failed on port %s to '%s' (%d)\n",
+			  "%s: failed to connect to %s:%s (%d)\n",
 			  __FUNCTION__, server, service, errno);
 		closesocket(fd);
 #ifndef _MSC_VER
@@ -368,7 +368,7 @@ cmyth_reconnect_addr(cmyth_conn_t conn, struct addrinfo* addr)
 #endif
 	my_fd = fd;
 	if (connect(fd, addr->ai_addr, addr->ai_addrlen) < 0) {
-		cmyth_dbg(CMYTH_DBG_ERROR, "%s: connect failed on port %"PRIu16" to '%s' (%d)\n",
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: failed to connect to %s:%"PRIu16" (%d)\n",
 			  __FUNCTION__, conn->server, conn->port, errno);
 		closesocket(fd);
 #ifndef _MSC_VER

--- a/lib/cmyth/libcmyth/event.c
+++ b/lib/cmyth/libcmyth/event.c
@@ -242,7 +242,7 @@ cmyth_event_get_message(cmyth_conn_t conn, char * data, int32_t len, cmyth_progi
 
 	out:
 	while(count > 0 && err == 0) {
-		consumed = cmyth_rcv_data(conn, &err, tmp, sizeof(tmp) - 1, count);
+		consumed = cmyth_rcv_data(conn, &err, (unsigned char*)tmp, sizeof(tmp) - 1, count);
 		cmyth_dbg(CMYTH_DBG_DEBUG, "%s: leftover data: count %i, read %i, errno %i\n", __FUNCTION__, count, consumed, err);
 		count -= consumed;
 	}

--- a/lib/cmyth/libcmyth/file.c
+++ b/lib/cmyth/libcmyth/file.c
@@ -322,7 +322,7 @@ cmyth_file_get_block(cmyth_file_t file, char *buf, int32_t len)
 {
 	struct timeval tv;
 	fd_set fds;
-	int ret;
+	int32_t ret;
 
 	if (file == NULL || file->file_data == NULL)
 		return -EINVAL;

--- a/lib/cmyth/libcmyth/input.c
+++ b/lib/cmyth/libcmyth/input.c
@@ -137,7 +137,7 @@ cmyth_get_free_inputlist(cmyth_recorder_t rec)
 		goto out;
 	}
 
-	out:
+out:
 	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
 	return inputlist;
 }
@@ -162,8 +162,12 @@ int cmyth_rcv_free_inputlist(cmyth_conn_t conn, int *err,
 		count -= consumed;
 		total += consumed;
 		if (*err) {
-			failed = "cmyth_rcv_string() inputname";
+			failed = "cmyth_rcv_string()";
 			goto fail;
+		}
+		if (strncmp(tmp_str, "EMPTY_LIST", 10) == 0) {
+			ref_release(input);
+			goto out;
 		}
 		input->inputname = ref_strdup(tmp_str);
 
@@ -213,7 +217,7 @@ int cmyth_rcv_free_inputlist(cmyth_conn_t conn, int *err,
 					(++inputlist->input_count) * sizeof(cmyth_input_t));
 		inputlist->input_list[inputlist->input_count - 1] = input;
 	}
-
+	out:
 	return total;
 
 	fail:

--- a/lib/cmyth/libcmyth/proginfo.c
+++ b/lib/cmyth/libcmyth/proginfo.c
@@ -463,7 +463,7 @@ cmyth_proginfo_string(cmyth_conn_t control, cmyth_proginfo_t prog)
 	sprintf(buf + strlen(buf), "%"PRIu32"[]:[]", prog->proginfo_source_id);
 	sprintf(buf + strlen(buf), "%"PRIu32"[]:[]", prog->proginfo_card_id);
 	sprintf(buf + strlen(buf), "%"PRIu32"[]:[]", prog->proginfo_input_id);
-	sprintf(buf + strlen(buf), "%"PRId8"[]:[]", prog->proginfo_rec_priority);
+	sprintf(buf + strlen(buf), "%"PRId32"[]:[]", prog->proginfo_rec_priority);
 	sprintf(buf + strlen(buf), "%"PRId8"[]:[]", prog->proginfo_rec_status);
 	sprintf(buf + strlen(buf), "%"PRIu32"[]:[]", prog->proginfo_record_id);
 	sprintf(buf + strlen(buf), "%"PRIu8"[]:[]", prog->proginfo_rec_type);
@@ -495,7 +495,7 @@ cmyth_proginfo_string(cmyth_conn_t control, cmyth_proginfo_t prog)
 		sprintf(buf + strlen(buf), "%s[]:[]", S(prog->proginfo_playgroup));
 	}
 	if (control->conn_version >= 25) {
-		sprintf(buf + strlen(buf), "%"PRId8"[]:[]", prog->proginfo_recpriority_2);
+		sprintf(buf + strlen(buf), "%"PRId32"[]:[]", prog->proginfo_recpriority_2);
 	}
 	if (control->conn_version >= 31) {
 		sprintf(buf + strlen(buf), "%"PRIu32"[]:[]", prog->proginfo_parentid);
@@ -1812,7 +1812,7 @@ cmyth_proginfo_recordid(cmyth_proginfo_t prog)
 	return prog->proginfo_record_id;
 }
 
-int8_t
+int32_t
 cmyth_proginfo_priority(cmyth_proginfo_t prog)
 {
 	if (!prog) {

--- a/lib/cmyth/libcmyth/recorder.c
+++ b/lib/cmyth/libcmyth/recorder.c
@@ -256,7 +256,7 @@ cmyth_recorder_get_framerate(cmyth_recorder_t rec,
 	}
 
 	count = cmyth_rcv_length(rec->rec_conn);
-	if ((r=cmyth_rcv_string(rec->rec_conn, &err,
+	if ((r = cmyth_rcv_string(rec->rec_conn, &err,
 				reply, sizeof(reply), count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_string() failed (%d)\n",
@@ -336,7 +336,7 @@ cmyth_recorder_get_free_space(cmyth_recorder_t rec)
 int64_t
 cmyth_recorder_get_keyframe_pos(cmyth_recorder_t rec, uint32_t keynum)
 {
-	return (int64_t)-ENOSYS;
+	return (int64_t) -ENOSYS;
 }
 
 /*
@@ -478,7 +478,7 @@ cmyth_recorder_cancel_next_recording(cmyth_recorder_t rec, int cancel)
 
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -537,14 +537,14 @@ cmyth_recorder_pause(cmyth_recorder_t rec)
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
 	sprintf(Buffer, "QUERY_RECORDER %"PRIu32"[]:[]PAUSE", rec->rec_id);
-	if ((ret=cmyth_send_message(rec->rec_conn, Buffer)) < 0) {
+	if ((ret = cmyth_send_message(rec->rec_conn, Buffer)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message('%s') failed\n",
 			  __FUNCTION__, Buffer);
 		goto err;
 	}
 
-	if ((ret=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((ret = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: cmyth_rcv_okay() failed\n",
 			  __FUNCTION__);
 		goto err;
@@ -645,7 +645,7 @@ cmyth_recorder_change_channel(cmyth_recorder_t rec,
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
 			  __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -654,21 +654,21 @@ cmyth_recorder_change_channel(cmyth_recorder_t rec,
 		 "QUERY_RECORDER %"PRIu32"[]:[]CHANGE_CHANNEL[]:[]%d",
 		 rec->rec_id, direction);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto out;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((err = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto out;
 	}
 
-	if(rec->rec_ring)
+	if (rec->rec_ring)
 		rec->rec_ring->file_pos = 0;
 	else {
 		oldchain = rec->rec_livetv_chain;
@@ -721,7 +721,7 @@ cmyth_recorder_set_channel(cmyth_recorder_t rec, char *channame)
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
 			  __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -730,21 +730,21 @@ cmyth_recorder_set_channel(cmyth_recorder_t rec, char *channame)
 		 "QUERY_RECORDER %"PRIu32"[]:[]SET_CHANNEL[]:[]%s",
 		 rec->rec_id, channame);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto out;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((err = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto out;
 	}
 
-	if(rec->rec_ring)
+	if (rec->rec_ring)
 		rec->rec_ring->file_pos = 0;
 	else {
 		oldchain = rec->rec_livetv_chain;
@@ -924,14 +924,14 @@ cmyth_recorder_check_channel(cmyth_recorder_t rec,
 		 "QUERY_RECORDER %"PRIu32"[]:[]CHECK_CHANNEL[]:[]%s",
 		 rec->rec_id, channame);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_feedback(rec->rec_conn, "1", 1)) < 0) {
+	if ((err = cmyth_rcv_feedback(rec->rec_conn, "1", 1)) < 0) {
 		ret = 0;
 		goto fail;
 	}
@@ -1007,14 +1007,14 @@ cmyth_recorder_get_program_info(cmyth_recorder_t rec)
 	}
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
 
-	if(rec->rec_conn->conn_version >= 26)
+	if (rec->rec_conn->conn_version >= 26)
 		snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]GET_CURRENT_RECORDING",
 		 	rec->rec_id);
 	else
 		snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]GET_PROGRAM_INFO",
 		 	rec->rec_id);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1025,7 +1025,7 @@ cmyth_recorder_get_program_info(cmyth_recorder_t rec)
 
 	count = cmyth_rcv_length(rec->rec_conn);
 
-	if(rec->rec_conn->conn_version >= 26)
+	if (rec->rec_conn->conn_version >= 26)
 		ct = cmyth_rcv_proginfo(rec->rec_conn, &err, proginfo, count);
 	else
 		ct = cmyth_rcv_chaninfo(rec->rec_conn, &err, proginfo, count);
@@ -1117,7 +1117,7 @@ cmyth_recorder_get_next_program_info(cmyth_recorder_t rec,
 				     cmyth_browsedir_t direction)
 {
         int err, count;
-        int ret = -ENOSYS;
+        int ret = -1;
         char msg[256];
         char title[256], subtitle[256], desc[256], category[256];
 	char callsign[256], iconpath[256];
@@ -1130,7 +1130,7 @@ cmyth_recorder_get_next_program_info(cmyth_recorder_t rec,
         if (!rec) {
                 cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
                           __FUNCTION__);
-                return -ENOSYS;
+                return -EINVAL;
         }
 
 	control = rec->rec_conn;
@@ -1147,7 +1147,7 @@ cmyth_recorder_get_next_program_info(cmyth_recorder_t rec,
                  rec->rec_id, cur_prog->proginfo_channame,
 		 cur_prog->proginfo_chanId, direction, date);
 
-        if ((err=cmyth_send_message(control, msg)) < 0) {
+        if ((err = cmyth_send_message(control, msg)) < 0) {
                 cmyth_dbg(CMYTH_DBG_ERROR,
                           "%s: cmyth_send_message() failed (%d)\n",
                           __FUNCTION__, err);
@@ -1377,7 +1377,7 @@ cmyth_recorder_spawn_livetv(cmyth_recorder_t rec)
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
 			  __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -1385,14 +1385,14 @@ cmyth_recorder_spawn_livetv(cmyth_recorder_t rec)
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]SPAWN_LIVETV",
 		 rec->rec_id);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((err = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1421,7 +1421,7 @@ cmyth_recorder_spawn_chain_livetv(cmyth_recorder_t rec, char* channame)
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
 			  __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -1435,7 +1435,7 @@ cmyth_recorder_spawn_chain_livetv(cmyth_recorder_t rec, char* channame)
 	strftime(datestr, 32, "%Y-%m-%dT%H:%M:%S", localtime(&t));
 
 	/* Now build the SPAWN_LIVETV message */
-	if(rec->rec_conn->conn_version >= 34 && channame)
+	if (rec->rec_conn->conn_version >= 34 && channame)
 		snprintf(msg, sizeof(msg),
 			"QUERY_RECORDER %"PRIu32"[]:[]SPAWN_LIVETV[]:[]live-%s-%s[]:[]%d[]:[]%s",
 			 rec->rec_id, myhostname, datestr, 0, channame);
@@ -1444,14 +1444,14 @@ cmyth_recorder_spawn_chain_livetv(cmyth_recorder_t rec, char* channame)
 			"QUERY_RECORDER %"PRIu32"[]:[]SPAWN_LIVETV[]:[]live-%s-%s[]:[]%d",
 			 rec->rec_id, myhostname, datestr, 0);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((err = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1480,7 +1480,7 @@ cmyth_recorder_stop_livetv(cmyth_recorder_t rec)
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
 			  __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -1488,14 +1488,14 @@ cmyth_recorder_stop_livetv(cmyth_recorder_t rec)
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]STOP_LIVETV",
 		 rec->rec_id);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((err = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1520,10 +1520,10 @@ cmyth_recorder_done_ringbuf(cmyth_recorder_t rec)
 	if (!rec) {
 		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
 			  __FUNCTION__);
-		return -ENOSYS;
+		return -EINVAL;
 	}
 
-	if(rec->rec_conn->conn_version >= 26)
+	if (rec->rec_conn->conn_version >= 26)
 		return 0;
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -1531,14 +1531,14 @@ cmyth_recorder_done_ringbuf(cmyth_recorder_t rec)
 	snprintf(msg, sizeof(msg), "QUERY_RECORDER %"PRIu32"[]:[]DONE_RINGBUF",
 		 rec->rec_id);
 
-	if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+	if ((err = cmyth_send_message(rec->rec_conn, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
 		goto fail;
 	}
 
-	if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+	if ((err = cmyth_rcv_okay(rec->rec_conn)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_okay() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -1634,4 +1634,50 @@ cmyth_recorder_get_recorder_id(cmyth_recorder_t rec)
 	}
 
 	return rec->rec_id;
+}
+
+int
+cmyth_recorder_set_live_recording(cmyth_recorder_t rec, uint8_t recording)
+{
+	int err;
+	int ret = -1;
+	char msg[256];
+
+	if (!rec) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
+			  __FUNCTION__);
+		return -ENOSYS;
+	}
+
+	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
+
+	if (rec->rec_conn->conn_version >= 26)
+	{
+		snprintf(msg, sizeof(msg), "QUERY_RECORDER %d[]:[]SET_LIVE_RECORDING[]:[]%u", rec->rec_id, recording);
+
+		if ((err=cmyth_send_message(rec->rec_conn, msg)) < 0) {
+			cmyth_dbg(CMYTH_DBG_ERROR,
+				  "%s: cmyth_send_message() failed (%d)\n",
+				  __FUNCTION__, err);
+			goto fail;
+		}
+
+		if ((err=cmyth_rcv_okay(rec->rec_conn)) < 0) {
+			cmyth_dbg(CMYTH_DBG_ERROR,
+				  "%s: cmyth_rcv_okay() failed (%d)\n",
+				  __FUNCTION__, err);
+			goto fail;
+		}
+
+		ret = recording;
+	}
+	else
+	{
+		ret = -EPERM;
+	}
+
+fail:
+	pthread_mutex_unlock(&rec->rec_conn->conn_mutex);
+
+	return ret;
 }

--- a/lib/cmyth/libcmyth/recordingrule.c
+++ b/lib/cmyth/libcmyth/recordingrule.c
@@ -213,7 +213,7 @@ cmyth_recordingrule_init(void)
 	cmyth_recordingrule_set_endtime(rr, 0);
 	cmyth_recordingrule_set_title(rr, "");
 	cmyth_recordingrule_set_description(rr, "");
-	cmyth_recordingrule_set_type(rr, RRULE_DONT_RECORD);
+	cmyth_recordingrule_set_type(rr, RRULE_NOT_RECORDING);
 	cmyth_recordingrule_set_category(rr, "");
 	cmyth_recordingrule_set_subtitle(rr, "");
 	cmyth_recordingrule_set_recpriority(rr, 0);
@@ -233,13 +233,75 @@ cmyth_recordingrule_init(void)
 	cmyth_recordingrule_set_maxepisodes(rr, 0);
 	cmyth_recordingrule_set_maxnewest(rr, 0);
 	cmyth_recordingrule_set_transcoder(rr, 0);
-        cmyth_recordingrule_set_profile(rr, "Default");
+	cmyth_recordingrule_set_parentid(rr, 0);
+	cmyth_recordingrule_set_profile(rr, "Default");
 	cmyth_recordingrule_set_prefinput(rr, 0);
 	cmyth_recordingrule_set_autometadata(rr, 0);
 	cmyth_recordingrule_set_inetref(rr, "");
 	cmyth_recordingrule_set_season(rr, 0);
 	cmyth_recordingrule_set_episode(rr, 0);
 	cmyth_recordingrule_set_filter(rr, 0);
+	return rr;
+}
+/*
+ * cmyth_recordingrule_dup()
+ *
+ * Scope: PUBLIC
+ *
+ * Description
+ *
+ * Duplicate a recording rule.
+ * Before forgetting the reference to this recording schedule structure
+ * the caller must call ref_release().
+ *
+ * Return Value:
+ *
+ * Success: A non-NULL cmyth_recordingrule_t (this type is a pointer)
+ *
+ * Failure: NULL
+ */
+cmyth_recordingrule_t
+cmyth_recordingrule_dup(cmyth_recordingrule_t rule) {
+	cmyth_recordingrule_t rr = cmyth_recordingrule_create();
+	if (!rr) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: cmyth_recordingrule_create failed\n", __FUNCTION__);
+		return NULL;
+	}
+	cmyth_recordingrule_set_recordid(rr, rule->recordid);
+	cmyth_recordingrule_set_chanid(rr, rule->chanid);
+	cmyth_recordingrule_set_callsign(rr, rule->callsign);
+	cmyth_recordingrule_set_starttime(rr, cmyth_timestamp_to_unixtime(rule->starttime));
+	cmyth_recordingrule_set_endtime(rr, cmyth_timestamp_to_unixtime(rule->endtime));
+	cmyth_recordingrule_set_title(rr, rule->title);
+	cmyth_recordingrule_set_description(rr, rule->description);
+	cmyth_recordingrule_set_type(rr, rule->type);
+	cmyth_recordingrule_set_category(rr, rule->category);
+	cmyth_recordingrule_set_subtitle(rr, rule->subtitle);
+	cmyth_recordingrule_set_recpriority(rr, rule->recpriority);
+	cmyth_recordingrule_set_startoffset(rr, rule->startoffset);
+	cmyth_recordingrule_set_endoffset(rr, rule->endoffset);
+	cmyth_recordingrule_set_searchtype(rr, rule->searchtype);
+	cmyth_recordingrule_set_inactive(rr, rule->inactive);
+	cmyth_recordingrule_set_dupmethod(rr, rule->dupmethod);
+	cmyth_recordingrule_set_dupin(rr, rule->dupin);
+	cmyth_recordingrule_set_recgroup(rr, rule->recgroup);
+	cmyth_recordingrule_set_storagegroup(rr, rule->storagegroup);
+	cmyth_recordingrule_set_playgroup(rr, rule->playgroup);
+	cmyth_recordingrule_set_autotranscode(rr, rule->autotranscode);
+	cmyth_recordingrule_set_userjobs(rr, rule->userjobs);
+	cmyth_recordingrule_set_autocommflag(rr, rule->autocommflag);
+	cmyth_recordingrule_set_autoexpire(rr, rule->autoexpire);
+	cmyth_recordingrule_set_maxepisodes(rr, rule->maxepisodes);
+	cmyth_recordingrule_set_maxnewest(rr, rule->maxnewest);
+	cmyth_recordingrule_set_transcoder(rr, rule->transcoder);
+	cmyth_recordingrule_set_parentid(rr, rule->parentid);
+	cmyth_recordingrule_set_profile(rr, rule->profile);
+	cmyth_recordingrule_set_prefinput(rr, rule->prefinput);
+	cmyth_recordingrule_set_autometadata(rr, rule->autometadata);
+	cmyth_recordingrule_set_inetref(rr, rule->inetref);
+	cmyth_recordingrule_set_season(rr, rule->season);
+	cmyth_recordingrule_set_episode(rr, rule->episode);
+	cmyth_recordingrule_set_filter(rr, rule->filter);
 	return rr;
 }
 
@@ -666,6 +728,21 @@ void
 cmyth_recordingrule_set_transcoder(cmyth_recordingrule_t rr, uint32_t transcoder)
 {
 	rr->transcoder = transcoder;
+}
+
+uint32_t
+cmyth_recordingrule_parentid(cmyth_recordingrule_t rr)
+{
+	if (!rr) {
+		return 0;
+	}
+	return rr->parentid;
+}
+
+void
+cmyth_recordingrule_set_parentid(cmyth_recordingrule_t rr, uint32_t parentid)
+{
+	rr->parentid = parentid;
 }
 
 char *

--- a/lib/cmyth/libcmyth/ringbuf.c
+++ b/lib/cmyth/libcmyth/ringbuf.c
@@ -122,7 +122,7 @@ cmyth_ringbuf_create(void)
 cmyth_recorder_t
 cmyth_ringbuf_setup(cmyth_recorder_t rec)
 {
-	static const char service[]="rbuf://";
+	static const char service[] = "rbuf://";
 	cmyth_recorder_t new_rec = NULL;
 	char *host = NULL;
 	char *port = NULL;
@@ -138,8 +138,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 	cmyth_conn_t control;
 
 	if (!rec) {
-		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n",
-			  __FUNCTION__);
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
 		return NULL;
 	}
 
@@ -151,7 +150,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 		 "QUERY_RECORDER %"PRIu32"[]:[]SETUP_RING_BUFFER[]:[]0",
 		 rec->rec_id);
 
-	if ((err=cmyth_send_message(control, msg)) < 0) {
+	if ((err = cmyth_send_message(control, msg)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_send_message() failed (%d)\n",
 			  __FUNCTION__, err);
@@ -167,7 +166,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 	r = cmyth_rcv_string(control, &err, url, sizeof(url)-1, count);
 	count -= r;
 
-	if ((r=cmyth_rcv_int64(control, &err, &size, count)) < 0) {
+	if ((r = cmyth_rcv_int64(control, &err, &size, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_length() failed (%d)\n",
 			  __FUNCTION__, r);
@@ -175,7 +174,7 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 	}
 	count -= r;
 
-	if ((r=cmyth_rcv_int64(control, &err, &fill, count)) < 0) {
+	if ((r = cmyth_rcv_int64(control, &err, &fill, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_length() failed (%d)\n",
 			  __FUNCTION__, r);
@@ -245,7 +244,12 @@ cmyth_ringbuf_setup(cmyth_recorder_t rec)
 char *
 cmyth_ringbuf_pathname(cmyth_recorder_t rec)
 {
-        return ref_hold(rec->rec_ring->ringbuf_url);
+	if (!rec) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
+		return NULL;
+	}
+
+	return ref_hold(rec->rec_ring->ringbuf_url);
 }
 
 /*
@@ -261,7 +265,7 @@ cmyth_ringbuf_pathname(cmyth_recorder_t rec)
  *
  * Success: number of bytes read into buf
  *
- * Failure: -1
+ * Failure: an int containing -errno
  */
 int32_t
 cmyth_ringbuf_get_block(cmyth_recorder_t rec, char *buf, int32_t len)
@@ -269,8 +273,10 @@ cmyth_ringbuf_get_block(cmyth_recorder_t rec, char *buf, int32_t len)
 	struct timeval tv;
 	fd_set fds;
 
-	if (rec == NULL)
-		return -EINVAL;
+	if (!rec) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
+		return (int32_t) -EINVAL;
+	}
 
 	if(len > rec->rec_ring->conn_data->conn_tcp_rcvbuf)
 		len = rec->rec_ring->conn_data->conn_tcp_rcvbuf;
@@ -295,8 +301,11 @@ cmyth_ringbuf_select(cmyth_recorder_t rec, struct timeval *timeout)
 	fd_set fds;
 	int ret;
 	cmyth_socket_t fd;
-	if (rec == NULL)
+
+	if (!rec) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
 		return -EINVAL;
+	}
 
 	fd = rec->rec_ring->conn_data->conn_fd;
 
@@ -339,9 +348,8 @@ cmyth_ringbuf_request_block(cmyth_recorder_t rec, int32_t len)
 	char msg[256];
 
 	if (!rec) {
-		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no connection\n",
-			  __FUNCTION__);
-		return -EINVAL;
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
+		return (int32_t) -EINVAL;
 	}
 
 	pthread_mutex_lock(&rec->rec_conn->conn_mutex);
@@ -394,7 +402,8 @@ cmyth_ringbuf_request_block(cmyth_recorder_t rec, int32_t len)
  *
  * Failure: an int containing -errno
  */
-int32_t cmyth_ringbuf_read(cmyth_recorder_t rec, char *buf, int32_t len)
+int32_t
+cmyth_ringbuf_read(cmyth_recorder_t rec, char *buf, int32_t len)
 {
 	int err, count;
 	int ret, req, nfds;
@@ -403,11 +412,9 @@ int32_t cmyth_ringbuf_read(cmyth_recorder_t rec, char *buf, int32_t len)
 	struct timeval tv;
 	fd_set fds;
 
-	if (!rec)
-	{
-		cmyth_dbg (CMYTH_DBG_ERROR, "%s: no connection\n",
-		           __FUNCTION__);
-		return -EINVAL;
+	if (!rec) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
+		return (int32_t) -EINVAL;
 	}
 
 	pthread_mutex_lock (&rec->rec_conn->conn_mutex);
@@ -542,8 +549,10 @@ cmyth_ringbuf_seek(cmyth_recorder_t rec,
 	int64_t c, ret;
 	cmyth_ringbuf_t ring;
 
-	if (rec == NULL)
-		return -EINVAL;
+	if (!rec) {
+		cmyth_dbg(CMYTH_DBG_ERROR, "%s: no recorder connection\n", __FUNCTION__);
+		return (int64_t) -EINVAL;
+	}
 
 	ring = rec->rec_ring;
 
@@ -570,7 +579,7 @@ cmyth_ringbuf_seek(cmyth_recorder_t rec,
 	}
 
 	count = cmyth_rcv_length(rec->rec_conn);
-	if ((r=cmyth_rcv_int64(rec->rec_conn, &err, &c, count)) < 0) {
+	if ((r = cmyth_rcv_int64(rec->rec_conn, &err, &c, count)) < 0) {
 		cmyth_dbg(CMYTH_DBG_ERROR,
 			  "%s: cmyth_rcv_length() failed (%d)\n",
 			  __FUNCTION__, r);

--- a/lib/cmyth/libcmyth/socket.c
+++ b/lib/cmyth/libcmyth/socket.c
@@ -651,7 +651,7 @@ cmyth_rcv_okay(cmyth_conn_t conn)
 			  "%s: did not consume everything\n",
 			  __FUNCTION__);
 		while(count > 0 && err == 0) {
-			consumed = cmyth_rcv_data(conn, &err, tmp, sizeof(tmp) - 1, count);
+			consumed = cmyth_rcv_data(conn, &err, (unsigned char*)tmp, sizeof(tmp) - 1, count);
 			cmyth_dbg(CMYTH_DBG_DEBUG, "%s: leftover data: count %i, read %i, errno %i\n", __FUNCTION__, count, consumed, err);
 			count -= consumed;
 		}
@@ -1869,7 +1869,7 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 	/*
 	 * Get proginfo_rec_priority (byte)
 	 */
-	consumed = cmyth_rcv_int8(conn, err,
+	consumed = cmyth_rcv_int32(conn, err,
 				    &buf->proginfo_rec_priority, count);
 	count -= consumed;
 	total += consumed;
@@ -2211,7 +2211,7 @@ cmyth_rcv_proginfo(cmyth_conn_t conn, int *err, cmyth_proginfo_t buf,
 		/*
 		 * Get proginfo_recpriority_2 (byte)
 		 */
-		consumed = cmyth_rcv_int8(conn, err,
+		consumed = cmyth_rcv_int32(conn, err,
 					    &buf->proginfo_recpriority_2,
 					    count);
 		count -= consumed;
@@ -2983,7 +2983,8 @@ cmyth_rcv_data(cmyth_conn_t conn, int *err, unsigned char *buf, int buflen, int 
 		++conn->conn_pos;
 		++consumed;
 	}
-	cmyth_dbg(CMYTH_DBG_PROTO, "%s: string received '%s'\n",
+	buf[placed] = '\0';
+	cmyth_dbg(CMYTH_DBG_PROTO, "%s: data received '%s'\n",
 		  __FUNCTION__, buf);
 	return consumed;
 }


### PR DESCRIPTION
This updates the MythTV PVR addon to v1.8.13.

---

Changelog:
- Fixed crash when reconnecting to the backend  
- Fixed setting bookmarks when using MythTV 0.27 backend  
- Fixed usage of priority values (>256)  
- Fixed remaining time zone issues by using UTC based timestamps  
- Schedule management refactoring  
  - Fixed recording rule deletion  
  - Fixed handling of backend version specific varieties  
  - Fixed failed mappings due to gaps in the EPG  
  - Various smaller improvements and bug fixes  
- Provide accurate EDLs for videos with variable frame rate when using MythTV 0.27 backend
- Added 'Keep Live TV recording' functionality  
- Improved start of Live TV playback 
