### PR TITLE
Support pre- and post-recording custom rules on ARGUS TV server

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.9.171"
+  version="1.9.172"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.9.172 (23-12-2013)
+- base new timers on templates retrieved from ARGUS TV server.
 v1.9.171 (11-12-2013)
 - removed redundant notification
 v1.9.170 (28-09-2013)

--- a/addons/pvr.argustv/src/argustvrpc.h
+++ b/addons/pvr.argustv/src/argustvrpc.h
@@ -289,6 +289,11 @@ namespace ArgusTV
   int CancelUpcomingProgram(const std::string& scheduleid, const std::string& channelid, const time_t starttime, const std::string& upcomingprogramid);
 
   /**
+   * \brief Retrieve an empty schedule from the server
+   */
+  int GetEmptySchedule(Json::Value& response);
+
+  /**
    * \brief Add a xbmc timer as a one time schedule
    */
   int AddOneTimeSchedule(const std::string& channelid, const time_t starttime, const std::string& title, int prerecordseconds, int postrecordseconds, int lifetime, Json::Value& response);

--- a/addons/pvr.argustv/src/client.cpp
+++ b/addons/pvr.argustv/src/client.cpp
@@ -287,6 +287,7 @@ void ADDON_FreeSettings()
 
 void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
 {
+  (void) flag; (void) sender; (void) message; (void) data;
 }
 
 /***********************************************************


### PR DESCRIPTION
Create new timers based on default schedule retrieved from ARGUS server.

Removed warnings about unused parameters in ADDON_Announce
