### PR TITLE
Unify codec descriptor usage

### DIFF
--- a/addons/pvr.hts/src/HTSPTypes.h
+++ b/addons/pvr.hts/src/HTSPTypes.h
@@ -28,42 +28,7 @@
 #include "platform/util/StdString.h"
 #include "libXBMC_codec.h"
 #include "client.h"
-
-class CodecDescriptor
-{
-public:
-  CodecDescriptor(void)
-  {
-    m_codec.codec_id   = XBMC_INVALID_CODEC_ID;
-    m_codec.codec_type = XBMC_CODEC_TYPE_UNKNOWN;
-  }
-
-  CodecDescriptor(xbmc_codec_t codec, const char* name) :
-    m_codec(codec),
-    m_strName(name) {}
-  virtual ~CodecDescriptor(void) {}
-
-  const std::string& Name(void) const  { return m_strName; }
-  xbmc_codec_t Codec(void) const { return m_codec; }
-
-  static CodecDescriptor GetCodecByName(const char* strCodecName)
-  {
-    CodecDescriptor retVal;
-    // some of Tvheadend's and VDR's codec names don't match ffmpeg's, so translate them to something ffmpeg understands
-    if (!strcmp(strCodecName, "MPEG2AUDIO"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("MP2"), strCodecName);
-    else if (!strcmp(strCodecName, "MPEGTS"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("MPEG2VIDEO"), strCodecName);
-    else
-      retVal = CodecDescriptor(CODEC->GetCodecByName(strCodecName), strCodecName);
-
-    return retVal;
-  }
-
-private:
-  xbmc_codec_t m_codec;
-  std::string  m_strName;
-};
+#include "xbmc_codec_descriptor.hpp"
 
 typedef std::vector<CodecDescriptor> CodecVector;
 

--- a/addons/pvr.vdr.vnsi/src/tools.h
+++ b/addons/pvr.vdr.vnsi/src/tools.h
@@ -27,39 +27,4 @@ uint64_t ntohll(uint64_t a);
 uint64_t htonll(uint64_t a);
 
 #include "libXBMC_codec.h"
-
-class CodecDescriptor
-{
-public:
-  CodecDescriptor(void)
-  {
-    m_codec.codec_id   = XBMC_INVALID_CODEC_ID;
-    m_codec.codec_type = XBMC_CODEC_TYPE_UNKNOWN;
-  }
-
-  CodecDescriptor(xbmc_codec_t codec, const char* name) :
-    m_codec(codec),
-    m_strName(name) {}
-  virtual ~CodecDescriptor(void) {}
-
-  const std::string& Name(void) const  { return m_strName; }
-  xbmc_codec_t Codec(void) const { return m_codec; }
-
-  static CodecDescriptor GetCodecByName(const char* strCodecName)
-  {
-    CodecDescriptor retVal;
-    // some of Tvheadend's and VDR's codec names don't match ffmpeg's, so translate them to something ffmpeg understands
-    if (!strcmp(strCodecName, "MPEG2AUDIO"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("MP2"), strCodecName);
-    else if (!strcmp(strCodecName, "MPEGTS"))
-      retVal = CodecDescriptor(CODEC->GetCodecByName("MPEG2VIDEO"), strCodecName);
-    else
-      retVal = CodecDescriptor(CODEC->GetCodecByName(strCodecName), strCodecName);
-
-    return retVal;
-  }
-
-private:
-  xbmc_codec_t m_codec;
-  std::string  m_strName;
-};
+#include "xbmc_codec_descriptor.hpp"

--- a/xbmc/xbmc_codec_descriptor.hpp
+++ b/xbmc/xbmc_codec_descriptor.hpp
@@ -1,0 +1,65 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef XBMC_CODEC_DESCRIPTOR_HPP
+#define	XBMC_CODEC_DESCRIPTOR_HPP
+
+#include "libXBMC_codec.h"
+
+/**
+ * Adapter which converts codec names used by tvheadend and VDR into their 
+ * FFmpeg equivalents.
+ */
+class CodecDescriptor
+{
+public:
+  CodecDescriptor(void)
+  {
+    m_codec.codec_id   = XBMC_INVALID_CODEC_ID;
+    m_codec.codec_type = XBMC_CODEC_TYPE_UNKNOWN;
+  }
+
+  CodecDescriptor(xbmc_codec_t codec, const char* name) :
+    m_codec(codec),
+    m_strName(name) {}
+  virtual ~CodecDescriptor(void) {}
+
+  const std::string& Name(void) const  { return m_strName; }
+  xbmc_codec_t Codec(void) const { return m_codec; }
+
+  static CodecDescriptor GetCodecByName(const char* strCodecName)
+  {
+    CodecDescriptor retVal;
+    // some of Tvheadend's and VDR's codec names don't match ffmpeg's, so translate them to something ffmpeg understands
+    if (!strcmp(strCodecName, "MPEG2AUDIO"))
+      retVal = CodecDescriptor(CODEC->GetCodecByName("MP2"), strCodecName);
+    else if (!strcmp(strCodecName, "MPEGTS"))
+      retVal = CodecDescriptor(CODEC->GetCodecByName("MPEG2VIDEO"), strCodecName);
+    else
+      retVal = CodecDescriptor(CODEC->GetCodecByName(strCodecName), strCodecName);
+
+    return retVal;
+  }
+
+private:
+  xbmc_codec_t m_codec;
+  std::string  m_strName;
+};
+
+#endif	/* XBMC_CODEC_DESCRIPTOR_HPP */


### PR DESCRIPTION
This PR unifies codec translation for pvr.vdr.vnsi and pvr.hts into a common file. I also removed an unused iterator class from HTSPTypes.h since I didn't bother to create a separate PR for that.
