### PR TITLE
[iptvsimple] new version 1.9.3.

### DIFF
--- a/addons/pvr.iptvsimple/addon/addon.xml.in
+++ b/addons/pvr.iptvsimple/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.iptvsimple"
-  version="1.9.2"
+  version="1.9.3"
   name="PVR IPTV Simple Client"
   provider-name="nightik">
   <requires>

--- a/addons/pvr.iptvsimple/addon/changelog.txt
+++ b/addons/pvr.iptvsimple/addon/changelog.txt
@@ -1,3 +1,10 @@
+v1.9.3
+- added setting to disable cache m3u/epg
+- added support <icon src=""/> for programme in epg
+- added possibility to specify logo path as URL
+- changed tvg-logo should contains full logo filename (with extention)
+- changed don't try download xmltv if it doesn't load after 3 attempt.
+
 v1.9.2
 - add timeshift buffer functions
 

--- a/addons/pvr.iptvsimple/addon/resources/language/English/strings.po
+++ b/addons/pvr.iptvsimple/addon/resources/language/English/strings.po
@@ -20,7 +20,7 @@ msgstr ""
 #settings labels
 
 msgctxt "#30000"
-msgid "File Location"
+msgid "Location"
 msgstr ""
 
 msgctxt "#30001"
@@ -67,10 +67,22 @@ msgctxt "#30024"
 msgid "EPG Time Shift (hours)"
 msgstr ""
 
+msgctxt "#30025"
+msgid "Cache m3u at local storage"
+msgstr ""
+
+msgctxt "#30026"
+msgid "Cache XMLTV at local storage"
+msgstr ""
+
 msgctxt "#30030"
 msgid "Channels Logos"
 msgstr ""
 
 msgctxt "#30031"
 msgid "Channels Logos Folder"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Channels Logos Base URL"
 msgstr ""

--- a/addons/pvr.iptvsimple/addon/resources/settings.xml
+++ b/addons/pvr.iptvsimple/addon/resources/settings.xml
@@ -6,6 +6,7 @@
     <setting id="m3uPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
     <setting id="m3uPath" type="file" label="30011" default="" visible="eq(-1,0)"/>
     <setting id="m3uUrl" type="text" label="30012" default="" visible="eq(-2,1)"/>
+    <setting id="m3uCache" type="bool" label="30025" default="true" visible="eq(-3,1)"/>
     <setting id="startNum" type="number" label="30013" default="1" />
   </category>
 
@@ -15,14 +16,16 @@
     <setting id="epgPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
     <setting id="epgPath" type="file" label="30021" default="" visible="eq(-1,0)"/>
     <setting id="epgUrl" type="text" label="30022" default="" visible="eq(-2,1)"/>
-<!--    <setting id="epgTimeShift" type="slider" label="30024" default="0" range="-12,.5,12" option="float"/>-->
-    <setting id="epgTimeShift_" type="enum" label="30024" default="12" values="-12|-11|-10|-9|-8|-7|-6|-5|-4|-3|-2|-1|0|+1|+2|+3|+4|+5|+6|+7|+8|+9|+10|+11|+12"/>-->
+    <setting id="epgCache" type="bool" label="30026" default="true" visible="eq(-3,1)"/>
+    <setting id="epgTimeShift" type="slider" label="30024" default="0" range="-12,.5,12" option="float"/>
     <setting id="epgTSOverride" type="bool" label="30023" default="false"/>
   </category>
 
   <!-- Logos -->
   <category label="30030">
     <setting id="sep3" label="30030" type="lsep"/>
-    <setting id="logoPath" type="folder" label="30031" default="" />
+    <setting id="logoPathType" type="enum" label="30000" lvalues="30001|30002" default="1" />
+    <setting id="logoPath" type="folder" label="30031" default="" visible="eq(-1,0)"/>
+    <setting id="logoBaseUrl" type="text" label="30032" default="" visible="eq(-2,1)"/>
   </category>
 </settings>

--- a/addons/pvr.iptvsimple/src/PVRIptvData.h
+++ b/addons/pvr.iptvsimple/src/PVRIptvData.h
@@ -100,7 +100,8 @@ protected:
   virtual PVRIptvEpgChannel   *FindEpgForChannel(PVRIptvChannel &channel);
   virtual int                  ParseDateTime(CStdString strDate, bool iDateFormat = true);
   virtual bool                 GzipInflate( const std::string &compressedBytes, std::string &uncompressedBytes);
-  virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath, std::string &strContent);
+  virtual int                  GetCachedFileContents(const std::string &strCachedName, const std::string &strFilePath, 
+                                                     std::string &strContent, const bool bUseCache = false);
   virtual void                 ApplyChannelsLogos();
   virtual CStdString           ReadMarkerValue(std::string &strLine, const char * strMarkerName);
   virtual int                  GetChannelId(const char * strChannelName, const char * strStreamUrl);

--- a/addons/pvr.iptvsimple/src/client.cpp
+++ b/addons/pvr.iptvsimple/src/client.cpp
@@ -56,6 +56,8 @@ std::string g_strLogoPath   = "";
 int         g_iEPGTimeShift = 0;
 int         g_iStartNumber  = 1;
 bool        g_bTSOverride   = true;
+bool        g_bCacheM3U     = false;
+bool        g_bCacheEPG     = false;
 
 extern std::string PathCombine(const std::string &strPath, const std::string &strFileName)
 {
@@ -94,10 +96,24 @@ void ADDON_ReadSettings(void)
   {
     iPathType = 1;
   }
-  CStdString strSettingName = iPathType ? "m3uUrl" : "m3uPath";
-  if (XBMC->GetSetting(strSettingName, &buffer)) 
+  if (iPathType)
   {
-    g_strM3UPath = buffer;
+    if (XBMC->GetSetting("m3uUrl", &buffer)) 
+    {
+      g_strM3UPath = buffer;
+    }
+    if (!XBMC->GetSetting("m3uCache", &g_bCacheM3U))
+    {
+      g_bCacheM3U = true;
+    }
+  }
+  else
+  {
+    if (XBMC->GetSetting("m3uPath", &buffer)) 
+    {
+      g_strM3UPath = buffer;
+    }
+    g_bCacheM3U = false;
   }
   if (g_strM3UPath == "") 
   {
@@ -111,29 +127,39 @@ void ADDON_ReadSettings(void)
   {
     iPathType = 1;
   }
-  strSettingName = iPathType ? "epgUrl" : "epgPath";
-  if (XBMC->GetSetting(strSettingName, &buffer)) 
+  if (iPathType)
   {
-    g_strTvgPath = buffer;
+    if (XBMC->GetSetting("epgUrl", &buffer)) 
+    {
+      g_strTvgPath = buffer;
+    }
+    if (!XBMC->GetSetting("epgCache", &g_bCacheEPG))
+    {
+      g_bCacheEPG = true;
+    }
   }
-  // BUG! xbmc does not return slider value 
-  //float dTimeShift;
-  //if (XBMC->GetSetting("epgTimeShift", &dTimeShift))
-  //{
-  //  g_iEPGTimeShift = (int)(dTimeShift * 3600.0); // hours to seconds
-  //}
-  int itmpShift;
-  if (XBMC->GetSetting("epgTimeShift_", &itmpShift))
+  else
   {
-    itmpShift -= 12;
-    g_iEPGTimeShift = (int)(itmpShift * 3600.0); // hours to seconds
+    if (XBMC->GetSetting("epgPath", &buffer)) 
+    {
+      g_strTvgPath = buffer;
+    }
+    g_bCacheEPG = false;
+  }
+  float fShift;
+  if (XBMC->GetSetting("epgTimeShift", &fShift))
+  {
+    g_iEPGTimeShift = (int)(fShift * 3600.0); // hours to seconds
   }
   if (!XBMC->GetSetting("epgTSOverride", &g_bTSOverride))
   {
     g_bTSOverride = true;
   }
-    
-  if (XBMC->GetSetting("logoPath", &buffer))
+  if (!XBMC->GetSetting("logoPathType", &iPathType)) 
+  {
+    iPathType = 1;
+  }
+  if (XBMC->GetSetting(iPathType ? "logoBaseUrl" : "logoPath", &buffer)) 
   {
     g_strLogoPath = buffer;
   }

--- a/addons/pvr.iptvsimple/src/client.h
+++ b/addons/pvr.iptvsimple/src/client.h
@@ -27,7 +27,7 @@
 #include "libXBMC_pvr.h"
 #include "libXBMC_gui.h"
 
-#define PVR_CLIENT_VERSION     "1.8.1"
+#define PVR_CLIENT_VERSION     "1.9.3"
 #define M3U_FILE_NAME          "iptv.m3u.cache"
 #define TVG_FILE_NAME          "xmltv.xml.cache"
 
@@ -49,6 +49,8 @@ extern std::string g_strLogoPath;
 extern int         g_iEPGTimeShift;
 extern int         g_iStartNumber;
 extern bool        g_bTSOverride;
+extern bool        g_bCacheM3U;
+extern bool        g_bCacheEPG;
 
 extern std::string PathCombine(const std::string &strPath, const std::string &strFileName);
 extern std::string GetClientFilePath(const std::string &strFileName);


### PR DESCRIPTION
- added setting to disable cache m3u/epg
- added support &lt;icon src=""/&gt; for programme in epg
- added possibility to specify logo path as URL
- changed tvg-logo should contains full logo filename (with extention)
- changed don't try download xmltv if it doesn't load after 3 attempt.

@opdenkamp, please merge this. 
