### PR TITLE
vuplus: update addon to 1.9.10

### DIFF
--- a/addons/pvr.vuplus/Makefile.am
+++ b/addons/pvr.vuplus/Makefile.am
@@ -15,6 +15,7 @@ LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
 include ../Makefile.include.am
 
 libvuplus_addon_la_SOURCES = src/client.cpp \
-                             src/VuData.cpp 
+                             src/VuData.cpp \
+                             src/TimeshiftBuffer.cpp
 libvuplus_addon_la_LDFLAGS = @TARGET_LDFLAGS@
 

--- a/addons/pvr.vuplus/addon/changelog.txt
+++ b/addons/pvr.vuplus/addon/changelog.txt
@@ -1,3 +1,9 @@
+1.9.10
+- add: timeshift support (based on Manuel Mausz DVBViewer Timeshift support)
+- remove: implementation for lastplayedposition (XBMC handles this now)
+- remove: loading of channel data from HDD
+- change: handling of EPG 
+
 1.9.9
 - add timeshift buffer functions
 
@@ -6,6 +12,9 @@
 
 1.7.8
 - fix: typo in settings.xml
+- fix: typos in language files 
+- fix: typo in settings.xml
+- fix: (temporarily) disable the deviceinfo API call to openwebif as it is currently broken in openwebif
 
 1.7.7
 - Bump after PVR API version bump

--- a/addons/pvr.vuplus/addon/resources/language/English/strings.po
+++ b/addons/pvr.vuplus/addon/resources/language/English/strings.po
@@ -65,18 +65,6 @@ msgctxt "#30013"
 msgid "Zap before channelswitch (i.e. for Single Tuner boxes)"
 msgstr ""
 
-msgctxt "#30014"
-msgid "Folder for channeldata"
-msgstr ""
-
-msgctxt "#30015"
-msgid "Check for bouquett updates"
-msgstr ""
-
-msgctxt "#30016"
-msgid "Check for channel updates"
-msgstr ""
-
 msgctxt "#30017"
 msgid "Use only the DVB boxes' current recording path"
 msgstr ""
@@ -119,6 +107,18 @@ msgstr ""
 
 msgctxt "#30027"
 msgid "Fetch picons from webinterface"
+msgstr ""
+
+msgctxt "#30028"
+msgid "Use https"
+msgstr ""
+
+msgctxt "#30100"
+msgid "Enable Timeshift"
+msgstr ""
+
+msgctxt "#30101"
+msgid "Timeshift buffer path"
 msgstr ""
 
 #empty strings from id 30028 to 30499

--- a/addons/pvr.vuplus/addon/resources/language/German/strings.po
+++ b/addons/pvr.vuplus/addon/resources/language/German/strings.po
@@ -57,18 +57,6 @@ msgctxt "#30013"
 msgid "Zap before channelswitch (i.e. for Single Tuner boxes)"
 msgstr "Umschalten auf Receiver (z.B. bei SingleTuner Receivern)"
 
-msgctxt "#30014"
-msgid "Folder for channeldata"
-msgstr "Speicherort für Kanaldaten"
-
-msgctxt "#30015"
-msgid "Check for bouquett updates"
-msgstr "Überprüfe auf Bouquettaktualisierungen"
-
-msgctxt "#30016"
-msgid "Check for channel updates"
-msgstr "Überprüfe auf Kanalaktualisierungen"
-
 msgctxt "#30017"
 msgid "Use only the DVB boxes' current recording path"
 msgstr "Aktuellen Box-Aufnahmenpfad nutzen"
@@ -112,6 +100,14 @@ msgstr "TV-Bouquet"
 msgctxt "#30027"
 msgid "Fetch picons from webinterface"
 msgstr "Lade Picons vom Web-Interface"
+
+msgctxt "#30100"
+msgid "Enable Timeshift"
+msgstr "Aktiviere Timeshift"
+
+msgctxt "#30101"
+msgid "Timeshift buffer path"
+msgstr "Kompletter Pfad zur Timeshift-Buffer-Datei"
 
 #empty strings from id 30028 to 30499
 #notifications

--- a/addons/pvr.vuplus/addon/resources/settings.xml
+++ b/addons/pvr.vuplus/addon/resources/settings.xml
@@ -6,15 +6,14 @@
     <setting id="onlinepicons" type="bool" default="true" label="30027" />
     <setting id="iconpath" type="folder" label="30008" enable="eq(-1,false)" default="" />
     <setting id="updateint" type="number" label="30010" default="2" />
+    <setting id="usetimeshift"  type="bool" label="30100" default="false" />
+    <setting id="timeshiftpath" type="text" label="30101" enable="eq(-1,true)" default="special://userdata/addon_data/pvr.vuplus/tsbuffer" />
   </category>
 
   <!-- Channels -->
   <category label="30019">
-    <setting id="channeldatapath" type="folder" label="30014" default="" />
     <setting label="30025" type="bool" id="onlyonegroup" default="false"/>
     <setting label="30026" type="text" id="onegroup" default="" enable="eq(-1,true)" />
-    <setting label="30015" type="bool" id="checkgroups" default="true"/>
-    <setting label="30016" type="bool" id="checkchannels" default="true"/>
     <setting label="30013" type="bool" id="zap" default="false"/>
   </category>
 
@@ -22,6 +21,7 @@
   <category label="30020">
     <setting id="streamport" type="number" label="30002" default="8001" />
     <setting id="webport" type="number" label="30012" default="80" />
+    <setting label="30028" type="bool" id="use_secure" default="false"/>
     <setting id="user" type="text" label="30003" default="" />
     <setting id="pass" type="text" label="30004" option="hidden" default="" />
     <setting id="recordingpath" type="text" label="30023" default="" />

--- a/addons/pvr.vuplus/project/VS2010Express/pvr.vuplus.vcxproj
+++ b/addons/pvr.vuplus/project/VS2010Express/pvr.vuplus.vcxproj
@@ -83,10 +83,12 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\client.cpp" />
     <ClCompile Include="..\..\src\VuData.cpp" />
+    <ClCompile Include="..\..\src\TimeshiftBuffer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\client.h" />
     <ClInclude Include="..\..\src\VuData.h" />
+    <ClInclude Include="..\..\src\TimeshiftBuffer.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\project\VS2010Express\platform\platform.vcxproj">

--- a/addons/pvr.vuplus/project/VS2010Express/pvr.vuplus.vcxproj.filters
+++ b/addons/pvr.vuplus/project/VS2010Express/pvr.vuplus.vcxproj.filters
@@ -21,12 +21,18 @@
     <ClCompile Include="..\..\src\VuData.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\TimeshiftBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\client.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\VuData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\TimeshiftBuffer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/addons/pvr.vuplus/src/TimeshiftBuffer.cpp
+++ b/addons/pvr.vuplus/src/TimeshiftBuffer.cpp
@@ -1,0 +1,96 @@
+#include "TimeshiftBuffer.h"
+#include "client.h"
+
+TimeshiftBuffer::TimeshiftBuffer(std::string streampath, std::string bufferpath)
+  : m_bufferPath(bufferpath)
+{
+  m_streamHandle = XBMC->OpenFile(streampath.c_str(), 0);
+  m_filebufferWriteHandle = XBMC->OpenFileForWrite(m_bufferPath.c_str(), true);
+  Sleep(100);
+  m_filebufferReadHandle = XBMC->OpenFile(m_bufferPath.c_str(), 0);
+  m_shifting = true;
+  CreateThread();
+}
+
+TimeshiftBuffer::~TimeshiftBuffer(void)
+{
+  Stop();
+  if (IsRunning())
+    StopThread();
+
+  if (m_filebufferWriteHandle)
+    XBMC->CloseFile(m_filebufferWriteHandle);
+  if (m_filebufferReadHandle)
+    XBMC->CloseFile(m_filebufferReadHandle);
+  if (m_streamHandle)
+    XBMC->CloseFile(m_streamHandle);
+}
+
+bool TimeshiftBuffer::IsValid()
+{
+  return (m_streamHandle != NULL);
+}
+
+void TimeshiftBuffer::Stop()
+{
+  m_shifting = false;
+}
+
+void *TimeshiftBuffer::Process()
+{
+  XBMC->Log(LOG_DEBUG, "TimeShiftProcess:: thread started");
+  byte buffer[STREAM_READ_BUFFER_SIZE];
+  int bytesRead = STREAM_READ_BUFFER_SIZE;
+
+  while (m_shifting)
+  {
+    bytesRead = XBMC->ReadFile(m_streamHandle, buffer, sizeof(buffer));
+    XBMC->WriteFile(m_filebufferWriteHandle,buffer,bytesRead);
+  }
+  XBMC->Log(LOG_DEBUG, "TimeShiftProcess:: thread stopped");
+  return NULL;
+}
+
+long long TimeshiftBuffer::Seek(long long iPosition, int iWhence)
+{
+  if (m_filebufferReadHandle)
+    return XBMC->SeekFile(m_filebufferReadHandle,iPosition,iWhence);
+  return 0;
+}
+
+long long TimeshiftBuffer::Position()
+{
+  if (m_filebufferReadHandle)
+    return XBMC->GetFilePosition(m_filebufferReadHandle);
+  return 0;
+}
+
+long long TimeshiftBuffer::Length()
+{
+  if (m_filebufferReadHandle)
+    return XBMC->GetFileLength(m_filebufferReadHandle);
+  return 0;
+}
+
+int TimeshiftBuffer::ReadData(unsigned char *pBuffer, unsigned int iBufferSize)
+{
+  unsigned int totalReadBytes = 0;
+  unsigned int totalTimeWaited = 0;
+  if (m_filebufferReadHandle)
+  {
+    unsigned int read = XBMC->ReadFile(m_filebufferReadHandle, pBuffer,iBufferSize);
+    totalReadBytes += read;
+
+    while (read < iBufferSize && totalTimeWaited < BUFFER_READ_TIMEOUT)
+    {
+      Sleep(BUFFER_READ_WAITTIME);
+      totalTimeWaited += BUFFER_READ_WAITTIME;
+      read = XBMC->ReadFile(m_filebufferReadHandle, pBuffer,iBufferSize - totalReadBytes);
+      totalReadBytes += read;
+    }
+
+    if (totalTimeWaited > BUFFER_READ_TIMEOUT)
+      XBMC->Log(LOG_DEBUG, "Timeshifterbuffer timed out, waited : %d", totalTimeWaited);
+  }
+  return totalReadBytes;
+}  

--- a/addons/pvr.vuplus/src/TimeshiftBuffer.h
+++ b/addons/pvr.vuplus/src/TimeshiftBuffer.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "libXBMC_addon.h"
+#include "platform/util/StdString.h"
+#include "platform/threads/threads.h"
+#include "platform/util/util.h"
+
+using namespace ADDON;
+
+#define STREAM_READ_BUFFER_SIZE   8192
+#define BUFFER_READ_TIMEOUT       10000
+#define BUFFER_READ_WAITTIME      50
+
+class TimeshiftBuffer : public PLATFORM::CThread
+{
+public:
+  TimeshiftBuffer(std::string streampath, std::string bufferpath);
+  ~TimeshiftBuffer(void);
+  int ReadData(unsigned char *pBuffer, unsigned int iBufferSize);
+  bool IsValid();
+  long long Seek(long long iPosition, int iWhence);
+  long long Position();
+  long long Length();
+  void Stop(void);
+
+private:
+  virtual void *Process(void);
+
+  std::string m_bufferPath;
+  void *m_streamHandle;
+  void *m_filebufferReadHandle;
+  void *m_filebufferWriteHandle;
+  bool m_shifting;
+};

--- a/addons/pvr.vuplus/src/VuData.cpp
+++ b/addons/pvr.vuplus/src/VuData.cpp
@@ -168,428 +168,6 @@ void Vu::TimerUpdates()
   }
 }
 
-bool Vu::CheckForChannelUpdate() 
-{
-  if (!g_bCheckForChannelUpdates)
-    return false;
-
-  m_bUpdating = true;
-
-  std::vector<VuChannel> oldchannels = m_channels;
-
-  LoadChannels();
-
-  for(unsigned int i=0; i< oldchannels.size(); i++)
-    oldchannels[i].iChannelState = VU_UPDATE_STATE_NONE;
-
-  for (unsigned int j=0; j<m_channels.size(); j++)
-  {
-    for (unsigned int i=0; i<oldchannels.size(); i++)
-    {
-      if (!oldchannels[i].strServiceReference.compare(m_channels[j].strServiceReference))
-      {
-        if(oldchannels[i] == m_channels[j])
-        {
-          m_channels[j].iChannelState = VU_UPDATE_STATE_FOUND;
-          oldchannels[i].iChannelState = VU_UPDATE_STATE_FOUND;
-        }
-        else
-        {
-          oldchannels[i].iChannelState = VU_UPDATE_STATE_UPDATED;
-          m_channels[j].iChannelState = VU_UPDATE_STATE_UPDATED;
-        }
-      }
-    }
-  }
-  
-  int iNewChannels = 0; 
-  for (unsigned int i=0; i<m_channels.size(); i++) 
-  {
-    if (m_channels[i].iChannelState == VU_UPDATE_STATE_NEW)
-      iNewChannels++;
-  }
-
-  int iRemovedChannels = 0;
-  int iNotUpdatedChannels = 0;
-  int iUpdatedChannels = 0;
-  for (unsigned int i=0; i<oldchannels.size(); i++) 
-  {
-    if(oldchannels[i].iChannelState == VU_UPDATE_STATE_NONE)
-      iRemovedChannels++;
-    
-    if(oldchannels[i].iChannelState == VU_UPDATE_STATE_FOUND)
-      iNotUpdatedChannels++;  
-
-    if(oldchannels[i].iChannelState == VU_UPDATE_STATE_UPDATED)
-      iUpdatedChannels++;
-  }
-
-  XBMC->Log(LOG_INFO, "%s No of channels: removed [%d], untouched [%d], updated '%d', new '%d'", __FUNCTION__, iRemovedChannels, iNotUpdatedChannels, iUpdatedChannels, iNewChannels); 
-
-  m_bUpdating = false;
-
-  if ((iRemovedChannels > 0) || (iUpdatedChannels > 0) || (iNewChannels > 0))
-  {
-    //Channels have been changed, so return "true"
-    return true;
-  }
-  else 
-  {
-    m_channels = oldchannels;
-    return false;
-  }
-}
-
-bool Vu::CheckForGroupUpdate() 
-{
-  if (!g_bCheckForGroupUpdates)
-    return false;
- 
-  m_bUpdating = true;
-
-  std::vector<VuChannelGroup> m_oldgroups = m_groups;
-
-  m_groups.clear();
-  LoadChannelGroups();
-
-  for (unsigned int i=0; i<m_oldgroups.size(); i++)
-    m_oldgroups[i].iGroupState = VU_UPDATE_STATE_NONE;
-
-  // Now compare the old group with the new one
-  for (unsigned int j=0; j<m_groups.size(); j++) 
-  {
-    for(unsigned int i=0;i<m_oldgroups.size(); i++) 
-    {
-      // we find the same service reference for the just fetched
-      // groups in the oldgroups, therefore this is either an name 
-      // update or just a persisting group
-      if (!m_oldgroups[i].strServiceReference.compare(m_groups[j].strServiceReference)) 
-      {
-        if (m_oldgroups[i] == m_groups[j]) 
-        {
-          m_groups[j].iGroupState = VU_UPDATE_STATE_FOUND;
-          m_oldgroups[i].iGroupState = VU_UPDATE_STATE_FOUND;
-        }
-        else 
-        {
-          m_oldgroups[i].iGroupState = VU_UPDATE_STATE_UPDATED;
-          m_groups[j].iGroupState = VU_UPDATE_STATE_UPDATED;
-        }
-      }
-    }
-  }
-
-  int iNewGroups = 0; 
-  for (unsigned int i=0; i<m_groups.size(); i++) 
-  {
-    if (m_groups[i].iGroupState == VU_UPDATE_STATE_NEW)
-      iNewGroups++;
-  }
-
-  int iRemovedGroups = 0;
-  int iNotUpdatedGroups = 0;
-  int iUpdatedGroups = 0;
-  for (unsigned int i=0; i<m_oldgroups.size(); i++) 
-  {
-    if(m_oldgroups[i].iGroupState == VU_UPDATE_STATE_NONE)
-      iRemovedGroups++;
-    
-    if(m_oldgroups[i].iGroupState == VU_UPDATE_STATE_FOUND)
-      iNotUpdatedGroups++;  
-
-    if(m_oldgroups[i].iGroupState == VU_UPDATE_STATE_UPDATED)
-      iUpdatedGroups++;
-  }
-
-  XBMC->Log(LOG_INFO, "%s No of groups: removed [%d], untouched [%d], updated '%d', new '%d'", __FUNCTION__, iRemovedGroups, iNotUpdatedGroups, iUpdatedGroups, iNewGroups); 
-
-  m_bUpdating = false;
-
-
-  if ((iRemovedGroups > 0) || (iUpdatedGroups > 0) || (iNewGroups > 0))
-  {
-    // groups have been changed, so return "true"
-    return true;
-  }
-  else 
-  {
-    m_groups = m_oldgroups;
-    return false;
-  }
-}
-
-void Vu::LoadChannelData()
-{
-  m_bUpdating = true;
-  XBMC->Log(LOG_DEBUG, "%s Load channel data from file: '%schanneldata.xml'", __FUNCTION__, g_strChannelDataPath.c_str());
-
-  CStdString strFileName;
-  strFileName.Format("%schanneldata.xml", g_strChannelDataPath.c_str());
-  
-  TiXmlDocument xmlDoc;
-  if (!xmlDoc.LoadFile(strFileName))
-  {
-    XBMC->Log(LOG_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
-    m_bUpdating = false;
-    return;
-  }
-
-  XBMC->Log(LOG_DEBUG, "%s Parsing channel data.", __FUNCTION__);
-
-  TiXmlHandle hDoc(&xmlDoc);
-  TiXmlElement* pElem;
-  TiXmlHandle hRoot(0);
-
-  pElem = hDoc.FirstChildElement().Element();
-  
-  if (!pElem)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not find root element", __FUNCTION__);
-    m_bUpdating = false;
-    return;
-  }
-
-  hRoot = TiXmlHandle(pElem);
-
-  pElem = hRoot.FirstChild("version").Element();
-
-  if (!pElem)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not find <version> element", __FUNCTION__);
-    m_bUpdating = false;
-    return;
-  }
-
-  // Check for the correct channeldata version
-  int iVersion = atoi(pElem->GetText());
-  
-  XBMC->Log(LOG_DEBUG, "%s Found channeldata version: '%d', current channeldata version: '%d'", __FUNCTION__, iVersion, CHANNELDATAVERSION);
-
-  if (iVersion != CHANNELDATAVERSION) 
-  {
-    XBMC->Log(LOG_NOTICE, "%s The channeldata versions do not match, we will abort loading the data from the HDD.", __FUNCTION__);
-    m_bUpdating = false;
-    return;
-  }
-
-  // Get the grouplist
-  pElem = hRoot.FirstChild("grouplist").Element(); 
-  
-  if (!pElem)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not find <grouplist> element", __FUNCTION__);
-    m_bUpdating = false;
-    return;
-  }
-
-  TiXmlElement* pNode = pElem->FirstChildElement("group");
-
-  if (!pNode)
-  {
-    XBMC->Log(LOG_DEBUG, "Could not find <group> element");
-    m_bUpdating = false;
-    return;
-  }
-
-  for (; pNode != NULL; pNode = pNode->NextSiblingElement("group"))
-  {
-    CStdString strTmp;
-
-    VuChannelGroup group; 
-    
-    if (!XMLUtils::GetString(pNode, "servicereference", strTmp))
-      continue;
-
-    group.strServiceReference = strTmp.c_str();
-    
-    if (!XMLUtils::GetString(pNode, "groupname", strTmp))
-      continue;
-
-    group.strGroupName = strTmp.c_str();
-
-    m_groups.push_back(group);
-
-    XBMC->Log(LOG_DEBUG, "%s Loaded group '%s' from HDD", __FUNCTION__, group.strGroupName.c_str());
-  }
-
-  // Get the channellist
-  pElem = hRoot.FirstChild("channellist").Element();
-
-  if (!pElem)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not find <channellist> element", __FUNCTION__);
-    m_bUpdating = false;
-    return;
-  }
-  
-  pNode = pElem->FirstChildElement("channel");
-
-  if (!pNode)
-  {
-    XBMC->Log(LOG_DEBUG, "Could not find <channel> element");
-    m_bUpdating = false;
-    return;
-  }
-
-  for (; pNode != NULL; pNode = pNode->NextSiblingElement("channel"))
-  {
-    CStdString strTmp;
-    bool bTmp;
-    int iTmp;
-
-    VuChannel channel; 
-    
-    if (XMLUtils::GetBoolean(pNode, "radio", bTmp)) 
-	{
-      channel.bRadio = bTmp;
-    }
-
-    if (!XMLUtils::GetInt(pNode, "id", iTmp))
-      continue;
-    channel.iUniqueId = iTmp;
-
-    if (!XMLUtils::GetInt(pNode, "channelnumber", iTmp))
-      continue;
-    channel.iChannelNumber = iTmp;
-
-    if (!XMLUtils::GetString(pNode, "groupname", strTmp))
-      continue;
-    channel.strGroupName = strTmp.c_str();
-
-    if (!XMLUtils::GetString(pNode, "channelname", strTmp))
-      continue;
-    channel.strChannelName = strTmp.c_str();
-
-    if (!XMLUtils::GetString(pNode, "servicereference", strTmp))
-      continue;
-
-    channel.strServiceReference = strTmp.c_str();
-     
-    if (!XMLUtils::GetString(pNode, "streamurl", strTmp))
-      continue;
-    channel.strStreamURL = strTmp.c_str();
-
-    if (!XMLUtils::GetString(pNode, "iconpath", strTmp))
-      continue;
-    channel.strIconPath = strTmp.c_str();
-
-    m_channels.push_back(channel);
-
-    XBMC->Log(LOG_DEBUG, "%s Loaded channel '%s' from HDD", __FUNCTION__, channel.strChannelName.c_str());
-  }
-  m_bUpdating = false;
-}
-
-void Vu::StoreChannelData()
-{
-  XBMC->Log(LOG_DEBUG, "%s Store channel data into file: '%schanneldata.xml'", __FUNCTION__, g_strChannelDataPath.c_str());
-
-  std::ofstream stream;
-  
-  CStdString strFileName;
-  strFileName.Format("%schanneldata.xml", g_strChannelDataPath.c_str());
-  stream.open(strFileName.c_str());
-
-  if(stream.fail())
-    XBMC->Log(LOG_ERROR, "%s Could not open channeldata file for writing!", __FUNCTION__);
-
-  stream << "<channeldata>\n";
-  stream << "\t<version>" << CHANNELDATAVERSION;
-  stream << "</version>\n";
-  stream << "\t<grouplist>\n";
-  for (unsigned int iGroupPtr = 0; iGroupPtr < m_groups.size(); iGroupPtr++)
-  {
-    VuChannelGroup &group = m_groups.at(iGroupPtr);
-    stream << "\t\t<group>\n";
-
-    CStdString strTmp = group.strServiceReference;
-    Escape(strTmp, "&", "&amp;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<servicereference>" << strTmp;
-    stream << "</servicereference>\n";
-    
-    strTmp = group.strGroupName;
-    Escape(strTmp, "&", "&quot;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<groupname>" << strTmp;
-    stream << "</groupname>\n";
-    stream << "\t\t</group>\n";
-  }
-
-  stream << "\t</grouplist>\n";
-    
-  stream << "\t<channellist>\n";
-  for (unsigned int iChannelPtr = 0; iChannelPtr < m_channels.size(); iChannelPtr++)
-  {
-    stream << "\t\t<channel>\n";
-    VuChannel &channel = m_channels.at(iChannelPtr);
-
-    // store channel properties
-    stream << "\t\t\t<radio>";
-    if (channel.bRadio)
-      stream << "true";
-    else
-      stream << "false";
-    stream << "</radio>\n";
-
-    stream << "\t\t\t<id>" << channel.iUniqueId;
-    stream << "</id>\n";
-    stream << "\t\t\t<channelnumber>" << channel.iChannelNumber;
-    stream << "</channelnumber>\n";
-    
-    CStdString strTmp = channel.strGroupName;
-    Escape(strTmp, "&", "&quot;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<groupname>" << strTmp;
-    stream << "</groupname>\n";
-    
-    strTmp = channel.strChannelName;
-    Escape(strTmp, "&", "&quot;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<channelname>" << strTmp;
-    stream << "</channelname>\n";
-
-    strTmp = channel.strServiceReference;
-    Escape(strTmp, "&", "&quot;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<servicereference>" << strTmp;
-    stream << "</servicereference>\n";
-
-    strTmp =  channel.strStreamURL;
-    Escape(strTmp, "&", "&quot;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<streamurl>" << strTmp;
-    stream << "</streamurl>\n";
-
-    strTmp = channel.strIconPath;
-    Escape(strTmp, "&", "&quot;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-
-    stream << "\t\t\t<iconpath>" << strTmp;
-    stream << "</iconpath>\n";
- 
-    stream << "\t\t</channel>\n";
-
-  }
-  stream << "\t</channellist>\n";
-  stream << "</channeldata>\n";
-  stream.close();
-}
-
 Vu::Vu() 
 {
   m_bIsConnected = false;
@@ -599,16 +177,29 @@ Vu::Vu()
   // simply add user@pass in front of the URL if username/password is set
   if ((g_strUsername.length() > 0) && (g_strPassword.length() > 0))
     strURL.Format("%s:%s@", g_strUsername.c_str(), g_strPassword.c_str());
-  strURL.Format("http://%s%s:%u/", strURL.c_str(), g_strHostname.c_str(), g_iPortWeb);
+  
+  if (!g_bUseSecureHTTP)
+    strURL.Format("http://%s%s:%u/", strURL.c_str(), g_strHostname.c_str(), g_iPortWeb);
+  else
+    strURL.Format("https://%s%s:%u/", strURL.c_str(), g_strHostname.c_str(), g_iPortWeb);
+  
   m_strURL = strURL.c_str();
+
   m_iNumRecordings = 0;
   m_iNumChannelGroups = 0;
   m_iCurrentChannel = -1;
   m_iClientIndexCounter = 1;
-  m_bInitial = false;
-  m_bUpdating = false;
 
+  m_bUpdating = false;
   m_iUpdateTimer = 0;
+  m_tsBuffer = NULL;
+  m_bInitialEPG = true;
+
+  std::string initialEPGReady = "special://userdata/addon_data/pvr.vuplus/initialEPGReady";
+  m_writeHandle = XBMC->OpenFileForWrite(initialEPGReady.c_str(), true);
+  XBMC->WriteFile(m_writeHandle, "Y", 1);
+  XBMC->CloseFile(m_writeHandle);
+  
 }
 
 bool Vu::Open()
@@ -619,8 +210,12 @@ bool Vu::Open()
   XBMC->Log(LOG_NOTICE, "%s - Hostname: '%s'", __FUNCTION__, g_strHostname.c_str());
   XBMC->Log(LOG_NOTICE, "%s - WebPort: '%d'", __FUNCTION__, g_iPortWeb);
   XBMC->Log(LOG_NOTICE, "%s - StreamPort: '%d'", __FUNCTION__, g_iPortStream);
+  if (!g_bUseSecureHTTP)
+    XBMC->Log(LOG_NOTICE, "%s Use HTTPS: 'false'", __FUNCTION__);
+  else
+    XBMC->Log(LOG_NOTICE, "%s Use HTTPS: 'true'", __FUNCTION__);
   
-  m_bIsConnected = GetDeviceInfo();
+  m_bIsConnected = true; // GetDeviceInfo();
 
   if (!m_bIsConnected)
   {
@@ -630,10 +225,8 @@ bool Vu::Open()
 
   LoadLocations();
 
-  LoadChannelData();
   if (m_channels.size() == 0) 
   {
-    XBMC->Log(LOG_DEBUG, "%s No stored channels found, fetch from webapi", __FUNCTION__);
     // Load the TV channels - close connection if no channels are found
     if (!LoadChannelGroups())
       return false;
@@ -641,8 +234,6 @@ bool Vu::Open()
     if (!LoadChannels())
       return false;
 
-    m_bInitial = true;
-    StoreChannelData();
   }
   TimerUpdates();
 
@@ -656,37 +247,49 @@ void  *Vu::Process()
 {
   XBMC->Log(LOG_DEBUG, "%s - starting", __FUNCTION__);
 
+  // Wait for the initial EPG update to complete 
+  bool bwait = true;
+  int cycles = 0;
+
+  while (bwait)
+  {
+    if (cycles == 30)
+      bwait = false;
+
+    cycles++;
+    std::string initialEPGReady = "special://userdata/addon_data/pvr.vuplus/initialEPGReady";
+    m_readHandle = XBMC->OpenFile(initialEPGReady.c_str(), 0);
+    byte buf[1];
+    XBMC->ReadFile(m_readHandle, buf, 1);
+    XBMC->CloseFile(m_readHandle);
+    char buf2[] = { "N" };
+    if (buf[0] == buf2[0])
+    {
+      XBMC->Log(LOG_DEBUG, "%s - Intial EPG update COMPLETE!", __FUNCTION__);
+    }
+    else
+    {
+      XBMC->Log(LOG_DEBUG, "%s - Intial EPG update not completed yet.", __FUNCTION__);
+      Sleep(5 * 1000);
+    }
+  }
+
+  // Trigger "Real" EPG updates 
+  for (unsigned int iChannelPtr = 0; iChannelPtr < m_channels.size(); iChannelPtr++)
+  {
+    XBMC->Log(LOG_DEBUG, "%s - Trigger EPG update for channel '%d'", __FUNCTION__, iChannelPtr);
+    PVR->TriggerEpgUpdate(m_channels.at(iChannelPtr).iUniqueId);
+  }
+
   while(!IsStopped())
   {
     Sleep(5 * 1000);
     m_iUpdateTimer += 5;
 
-    if (((int)m_iUpdateTimer > (g_iUpdateInterval * 60)) || (m_bInitial == false))
+    if ((int)m_iUpdateTimer > (g_iUpdateInterval * 60)) 
     {
       m_iUpdateTimer = 0;
  
-      if (!m_bInitial)
-      {
-        // Load the TV channels
-        bool bTriggerGroupsUpdate = CheckForGroupUpdate();
-        bool bTriggerChannelsUpdate = CheckForChannelUpdate();
-
-        m_bInitial = true;
-
-        if (bTriggerGroupsUpdate) 
-        {
-          PVR->TriggerChannelGroupsUpdate();
-          bTriggerChannelsUpdate = true;
-        }
-
-        if (bTriggerChannelsUpdate) 
-        {
-          PVR->TriggerChannelUpdate();
-          // Store the channel data on HDD
-          StoreChannelData();
-        }
-      }
-    
       // Trigger Timer and Recording updates acording to the addon settings
       CLockObject lock(m_mutex);
       XBMC->Log(LOG_INFO, "%s Perform Updates!", __FUNCTION__);
@@ -705,7 +308,7 @@ void  *Vu::Process()
 
   }
 
-  CLockObject lock(m_mutex);
+  //CLockObject lock(m_mutex);
   m_started.Broadcast();
 
   return NULL;
@@ -861,6 +464,7 @@ bool Vu::LoadChannels(CStdString strServiceReference, CStdString strGroupName)
 
     VuChannel newChannel;
     newChannel.bRadio = bRadio;
+    newChannel.bInitialEPG = true;
     newChannel.strGroupName = strGroupName;
     newChannel.iUniqueId = m_channels.size()+1;
     newChannel.iChannelNumber = m_channels.size()+1;
@@ -907,8 +511,12 @@ bool Vu::LoadChannels(CStdString strServiceReference, CStdString strGroupName)
 
     if ((g_strUsername.length() > 0) && (g_strPassword.length() > 0))
       strTmp.Format("%s:%s@", g_strUsername.c_str(), g_strPassword.c_str());
-
-    strTmp.Format("http://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
+    
+    if (!g_bUseSecureHTTP)
+      strTmp.Format("http://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
+    else
+      strTmp.Format("https://%s%s:%d/%s", strTmp.c_str(), g_strHostname, g_iPortStream, strTmp2.c_str());
+    
     newChannel.strStreamURL = strTmp;
 
     if (g_bOnlinePicons == true)
@@ -933,7 +541,7 @@ bool Vu::IsConnected()
 
 CStdString Vu::GetHttpXML(CStdString& url) 
 {
-  CLockObject lock(m_mutex);
+//  CLockObject lock(m_mutex);
 
   XBMC->Log(LOG_INFO, "%s Open webAPI with URL: '%s'", __FUNCTION__, url.c_str());
 
@@ -994,14 +602,16 @@ PVR_ERROR Vu::GetChannels(ADDON_HANDLE handle, bool bRadio)
       xbmcChannel.iChannelNumber    = channel.iChannelNumber;
       strncpy(xbmcChannel.strChannelName, channel.strChannelName.c_str(), sizeof(xbmcChannel.strChannelName));
       strncpy(xbmcChannel.strInputFormat, "", 0); // unused
-
-      CStdString strStream;
-      strStream.Format("pvr://stream/tv/%i.ts", channel.iUniqueId);
-      strncpy(xbmcChannel.strStreamURL, strStream.c_str(), sizeof(xbmcChannel.strStreamURL)); 
-      strncpy(xbmcChannel.strIconPath, channel.strIconPath.c_str(), sizeof(xbmcChannel.strIconPath));
       xbmcChannel.iEncryptionSystem = 0;
-      
       xbmcChannel.bIsHidden         = false;
+      strncpy(xbmcChannel.strIconPath, channel.strIconPath.c_str(), sizeof(xbmcChannel.strIconPath));
+
+      if (!g_bUseTimeshift)
+      {
+        CStdString strStream;
+        strStream.Format("pvr://stream/tv/%i.ts", channel.iUniqueId);
+        strncpy(xbmcChannel.strStreamURL, strStream.c_str(), sizeof(xbmcChannel.strStreamURL)); 
+      }
 
       PVR->TransferChannelEntry(handle, &xbmcChannel);
     }
@@ -1012,15 +622,180 @@ PVR_ERROR Vu::GetChannels(ADDON_HANDLE handle, bool bRadio)
 
 Vu::~Vu() 
 {
-  StoreLastPlayedPositions();
-
+  CLockObject lock(m_mutex);
+  XBMC->Log(LOG_DEBUG, "%s Stopping update thread...", __FUNCTION__);
   StopThread();
   
+  XBMC->Log(LOG_DEBUG, "%s Removing internal channels list...", __FUNCTION__);
   m_channels.clear();  
+  
+  XBMC->Log(LOG_DEBUG, "%s Removing internal timers list...", __FUNCTION__);
   m_timers.clear();
+  
+  XBMC->Log(LOG_DEBUG, "%s Removing internal recordings list...", __FUNCTION__);
   m_recordings.clear();
+  
+  XBMC->Log(LOG_DEBUG, "%s Removing internal group list...", __FUNCTION__);
   m_groups.clear();
   m_bIsConnected = false;
+  if (m_tsBuffer)
+  {
+    XBMC->Log(LOG_DEBUG, "%s Removing internal tsBuffer...", __FUNCTION__);
+    SAFE_DELETE(m_tsBuffer);
+  }
+}
+
+bool Vu::GetInitialEPGForGroup(VuChannelGroup &group)
+{
+  // is the addon is currently updating the channels, then delay the call
+  unsigned int iTimer = 0;
+  while(m_bUpdating == true && iTimer < 120)
+  {
+    Sleep(1000);
+    iTimer++;
+  }
+
+  CStdString url;
+  url.Format("%s%s%s",  m_strURL.c_str(), "web/epgnownext?bRef=",  URLEncodeInline(group.strServiceReference.c_str())); 
+ 
+  CStdString strXML;
+  strXML = GetHttpXML(url);
+
+  int iNumEPG = 0;
+  
+  TiXmlDocument xmlDoc;
+  if (!xmlDoc.Parse(strXML.c_str()))
+  {
+    XBMC->Log(LOG_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
+    return false;
+  }
+
+  TiXmlHandle hDoc(&xmlDoc);
+  TiXmlElement* pElem;
+  TiXmlHandle hRoot(0);
+
+  pElem = hDoc.FirstChildElement("e2eventlist").Element();
+ 
+  if (!pElem)
+  {
+    XBMC->Log(LOG_DEBUG, "%s could not find <e2eventlist> element!", __FUNCTION__);
+    // Return "NO_ERROR" as the EPG could be empty for this channel
+    return false;
+  }
+
+  hRoot=TiXmlHandle(pElem);
+
+  TiXmlElement* pNode = hRoot.FirstChildElement("e2event").Element();
+
+  if (!pNode)
+  {
+    XBMC->Log(LOG_DEBUG, "Could not find <e2event> element");
+    // RETURN "NO_ERROR" as the EPG could be empty for this channel
+    return false;
+  }
+  
+  for (; pNode != NULL; pNode = pNode->NextSiblingElement("e2event"))
+  {
+    CStdString strTmp;
+
+    int iTmpStart;
+    int iTmp;
+
+    // check and set event starttime and endtimes
+    if (!XMLUtils::GetInt(pNode, "e2eventstart", iTmpStart)) 
+      continue;
+
+    if (!XMLUtils::GetInt(pNode, "e2eventduration", iTmp))
+      continue;
+
+    VuEPGEntry entry;
+    entry.startTime = iTmpStart;
+    entry.endTime = iTmpStart + iTmp;
+
+    if (!XMLUtils::GetInt(pNode, "e2eventid", entry.iEventId))  
+      continue;
+
+    
+    if(!XMLUtils::GetString(pNode, "e2eventtitle", strTmp))
+      continue;
+
+    entry.strTitle = strTmp;
+
+    if(!XMLUtils::GetString(pNode, "e2eventservicereference", strTmp))
+      continue;
+
+    entry.strServiceReference = strTmp;
+    
+    entry.iChannelId = GetChannelNumber(entry.strServiceReference.c_str());
+
+    if (XMLUtils::GetString(pNode, "e2eventdescriptionextended", strTmp))
+      entry.strPlot = strTmp;
+
+    if (XMLUtils::GetString(pNode, "e2eventdescription", strTmp))
+       entry.strPlotOutline = strTmp;
+
+    iNumEPG++; 
+    
+    group.initialEPG.push_back(entry);
+  }
+
+  XBMC->Log(LOG_INFO, "%s Loaded %u EPG Entries for group '%s'", __FUNCTION__, iNumEPG, group.strGroupName.c_str());
+  return true;
+}
+
+PVR_ERROR Vu::GetInitialEPGForChannel(ADDON_HANDLE handle, const VuChannel &channel, time_t iStart, time_t iEnd)
+{
+  if (m_iNumChannelGroups < 1)
+    return PVR_ERROR_SERVER_ERROR;
+
+  XBMC->Log(LOG_DEBUG, "%s Fetch information for group '%s'", __FUNCTION__, channel.strGroupName.c_str());
+
+  VuChannelGroup &myGroup = m_groups.at(0);
+  for (int i = 0;i<m_iNumChannelGroups;  i++) 
+  {
+    myGroup = m_groups.at(i);
+    if (!myGroup.strGroupName.compare(channel.strGroupName))
+      if (myGroup.initialEPG.size() == 0)
+      {
+        GetInitialEPGForGroup(myGroup);
+        break;
+      }
+  }
+
+  XBMC->Log(LOG_DEBUG, "%s initialEPG size is now '%d'", __FUNCTION__, myGroup.initialEPG.size());
+  
+  for (unsigned int i = 0;i<myGroup.initialEPG.size();  i++) 
+  {
+    VuEPGEntry &entry = myGroup.initialEPG.at(i);
+    if (!channel.strServiceReference.compare(entry.strServiceReference)) 
+    {
+      EPG_TAG broadcast;
+      memset(&broadcast, 0, sizeof(EPG_TAG));
+
+      broadcast.iUniqueBroadcastId  = entry.iEventId;
+      broadcast.strTitle            = entry.strTitle.c_str();
+      broadcast.iChannelNumber      = channel.iChannelNumber;
+      broadcast.startTime           = entry.startTime;
+      broadcast.endTime             = entry.endTime;
+      broadcast.strPlotOutline      = entry.strPlotOutline.c_str();
+      broadcast.strPlot             = entry.strPlot.c_str();
+      broadcast.strIconPath         = ""; // unused
+      broadcast.iGenreType          = 0; // unused
+      broadcast.iGenreSubType       = 0; // unused
+      broadcast.strGenreDescription = "";
+      broadcast.firstAired          = 0;  // unused
+      broadcast.iParentalRating     = 0;  // unused
+      broadcast.iStarRating         = 0;  // unused
+      broadcast.bNotify             = false;
+      broadcast.iSeriesNumber       = 0;  // unused
+      broadcast.iEpisodeNumber      = 0;  // unused
+      broadcast.iEpisodePartNumber  = 0;  // unused
+      broadcast.strEpisodeName      = ""; // unused
+
+      PVR->TransferEpgEntry(handle, &broadcast);
+    }
+  }
+  return PVR_ERROR_NO_ERROR;
 }
 
 PVR_ERROR Vu::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)
@@ -1041,6 +816,31 @@ PVR_ERROR Vu::GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, 
 
   VuChannel myChannel;
   myChannel = m_channels.at(channel.iUniqueId-1);
+
+  // Check if the initial short import has already been done for this channel
+  if (m_channels.at(channel.iUniqueId-1).bInitialEPG == true)
+  {
+    m_channels.at(channel.iUniqueId-1).bInitialEPG = false;
+  
+    // Check if all channels have completed the initial EPG import
+    m_bInitialEPG = false;
+    for (unsigned int iChannelPtr = 0; iChannelPtr < m_channels.size(); iChannelPtr++)
+    {
+      if (m_channels.at(iChannelPtr).bInitialEPG == true) 
+      {
+        m_bInitialEPG = true;
+      }
+    }
+
+    if (!m_bInitialEPG)
+    {
+      std::string initialEPGReady = "special://userdata/addon_data/pvr.vuplus/initialEPGReady";
+      m_writeHandle = XBMC->OpenFileForWrite(initialEPGReady.c_str(), true);
+      XBMC->WriteFile(m_writeHandle, "N", 1);
+      XBMC->CloseFile(m_writeHandle);
+    }
+    return GetInitialEPGForChannel(handle, myChannel, iStart, iEnd);
+  }
 
   CStdString url;
   url.Format("%s%s%s",  m_strURL.c_str(), "web/epgservice?sRef=",  URLEncodeInline(myChannel.strServiceReference.c_str())); 
@@ -1466,9 +1266,6 @@ PVR_ERROR Vu::GetRecordings(ADDON_HANDLE handle)
     iTimer++;
   }
 
-  if (m_iNumRecordings != 0)
-    StoreLastPlayedPositions();
-
   m_iNumRecordings = 0;
   m_recordings.clear();
 
@@ -1481,8 +1278,6 @@ PVR_ERROR Vu::GetRecordings(ADDON_HANDLE handle)
   }
 
   TransferRecordings(handle);
-
-  RestoreLastPlayedPositions();
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -1851,33 +1646,83 @@ bool Vu::OpenLiveStream(const PVR_CHANNEL &channelinfo)
   if ((int)channelinfo.iUniqueId == m_iCurrentChannel)
     return true;
 
-  return SwitchChannel(channelinfo);
+  if (!g_bUseTimeshift)
+    return SwitchChannel(channelinfo);
+
+  if (m_tsBuffer)
+    SAFE_DELETE(m_tsBuffer);
+
+  XBMC->Log(LOG_INFO, "%s ts buffer starts url=%s", __FUNCTION__, GetLiveStreamURL(channelinfo));
+  m_tsBuffer = new TimeshiftBuffer(GetLiveStreamURL(channelinfo), g_strTimeshiftBufferPath);
+  return m_tsBuffer->IsValid();
 }
 
 void Vu::CloseLiveStream(void) 
 {
   m_iCurrentChannel = -1;
+  if (m_tsBuffer)
+    SAFE_DELETE(m_tsBuffer);
+}
+
+int Vu::ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize)
+{
+  if (!m_tsBuffer)
+    return 0;
+  return m_tsBuffer->ReadData(pBuffer, iBufferSize);
+}
+
+long long Vu::SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */)
+{
+  if (!m_tsBuffer)
+    return 0;
+  return m_tsBuffer->Seek(iPosition, iWhence);
+}
+
+long long Vu::PositionLiveStream(void)
+{
+  if (!m_tsBuffer)
+    return 0;
+  return m_tsBuffer->Position();
+}
+
+long long Vu::LengthLiveStream(void)
+{
+  if (!m_tsBuffer)
+    return 0;
+  return m_tsBuffer->Length();
 }
 
 bool Vu::SwitchChannel(const PVR_CHANNEL &channel)
 {
+  XBMC->Log(LOG_DEBUG, "%s Switching channels", __FUNCTION__);
+
   if ((int)channel.iUniqueId == m_iCurrentChannel)
     return true;
 
-  if (!g_bZap)
-    return true;
+  m_iCurrentChannel = (int)channel.iUniqueId;
 
-  // Zapping is set to true, so send the zapping command to the PVR box 
-  CStdString strServiceReference = m_channels.at(channel.iUniqueId-1).strServiceReference.c_str();
+  if (g_bZap)
+  {
+    // Zapping is set to true, so send the zapping command to the PVR box 
+    CStdString strServiceReference = m_channels.at(channel.iUniqueId-1).strServiceReference.c_str();
 
-  CStdString strTmp;
-  strTmp.Format("web/zap?sRef=%s", URLEncodeInline(strServiceReference));
+    CStdString strTmp;
+    strTmp.Format("web/zap?sRef=%s", URLEncodeInline(strServiceReference));
 
-  CStdString strResult;
-  if(!SendSimpleCommand(strTmp, strResult))
-    return false;
+    CStdString strResult;
+    if(!SendSimpleCommand(strTmp, strResult))
+      return false;
+  
+    if (!g_bUseTimeshift)
+      return true;
+  }
 
-  return true;
+  if (m_tsBuffer)
+    SAFE_DELETE(m_tsBuffer);
+
+  XBMC->Log(LOG_INFO, "%s ts buffer starts url=%s", __FUNCTION__, GetLiveStreamURL(channel));
+  m_tsBuffer = new TimeshiftBuffer(GetLiveStreamURL(channel), g_strTimeshiftBufferPath);
+  return m_tsBuffer->IsValid();
 }
 
 void Vu::SendPowerstate()
@@ -2023,180 +1868,5 @@ int Vu::GetRecordingIndex(CStdString strStreamURL)
       return i;
   }
   return -1;
-}
-
-PVR_ERROR Vu::SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition)
-{
-  // is the addon is currently updating the channels, then delay the call
-  unsigned int iTimer = 0;
-  while(m_bUpdating == true && iTimer < 120)
-  {
-    Sleep(1000);
-    iTimer++;
-  }
-
-  int iRecordId = GetRecordingIndex(recording.strStreamURL);
-
-  if (iRecordId == -1)
-  {
-    XBMC->Log(LOG_ERROR, "%s Could not set lastplayedposition for recording!", __FUNCTION__);
-    return PVR_ERROR_SERVER_ERROR;
-  }
-
-  m_recordings.at(iRecordId).iLastPlayedPosition = lastplayedposition;
-
-  return PVR_ERROR_NO_ERROR;
-}
-
-bool Vu::SetRecordingLastPlayedPosition(CStdString strStreamURL, int lastplayedposition)
-{
-  // is the addon is currently updating the channels, then delay the call
-  unsigned int iTimer = 0;
-  while(m_bUpdating == true && iTimer < 120)
-  {
-    Sleep(1000);
-    iTimer++;
-  }
-
-  XBMC->Log(LOG_DEBUG, "%s Set lastplayedposition '%d' for recording '%s'", __FUNCTION__, lastplayedposition, strStreamURL.c_str());  
-  int iRecordId = GetRecordingIndex(strStreamURL);
-
-  if (iRecordId == -1)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not set lastplayedposition for recording!", __FUNCTION__);
-    return false;
-  }
-
-  m_recordings.at(iRecordId).iLastPlayedPosition = lastplayedposition;
-
-  return PVR_ERROR_NO_ERROR;
-}
-
-int Vu::GetRecordingLastPlayedPosition(const PVR_RECORDING &recording)
-{
-  // is the addon is currently updating the channels, then delay the call
-  unsigned int iTimer = 0;
-  while(m_bUpdating == true && iTimer < 120)
-  {
-    Sleep(1000);
-    iTimer++;
-  }
-
-  int iRecordId = GetRecordingIndex(recording.strStreamURL);
-
-  if (iRecordId == -1)
-  {
-    XBMC->Log(LOG_ERROR, "%s Could not get lastplayedposition for recording!", __FUNCTION__);
-    return PVR_ERROR_SERVER_ERROR;
-  }
-
-  return m_recordings.at(iRecordId).iLastPlayedPosition;
-}
-
-bool Vu::StoreLastPlayedPositions()
-{
-  std::ofstream stream;
-  
-  CStdString strFileName;
-  strFileName.Format("%srecordings.xml", g_strChannelDataPath.c_str());
-  stream.open(strFileName.c_str());
-
-  if(stream.fail())
-  {
-    return false;
-  }
-
-  stream << "<recordingsdata>\n";
-  stream << "\t<recordingslist>\n";
-  for (unsigned int iRecordingsPtr = 0; iRecordingsPtr < m_recordings.size(); iRecordingsPtr++)
-  {
-    VuRecording &recording = m_recordings.at(iRecordingsPtr);
-    stream << "\t\t<recording>\n";
-
-    CStdString strTmp = recording.strStreamURL;
-    Escape(strTmp, "&", "&amp;");
-    Escape(strTmp, "<", "&lt;");
-    Escape(strTmp, ">", "&gt;");
-
-    stream << "\t\t\t<streamurl>" << strTmp;
-    stream << "</streamurl>\n";
-    
-    int i = recording.iLastPlayedPosition;
-
-    stream << "\t\t\t<lastplayedposition>" << i;
-    stream << "</lastplayedposition>\n";
-    stream << "\t\t</recording>\n";
-  }
-
-  stream << "\t</recordingslist>\n";
-    
-  stream << "</recordingsdata>\n";
-  stream.close();
-
-  return true;
-}
-
-bool Vu::RestoreLastPlayedPositions()
-{
-  XBMC->Log(LOG_DEBUG, "%s Load recording data from file: '%srecordings.xml'", __FUNCTION__, g_strChannelDataPath.c_str());
-
-  CStdString strFileName;
-  strFileName.Format("%srecordings.xml", g_strChannelDataPath.c_str());
-  
-  TiXmlDocument xmlDoc;
-  if (!xmlDoc.LoadFile(strFileName))
-  {
-    XBMC->Log(LOG_DEBUG, "Unable to parse XML: %s at line %d", xmlDoc.ErrorDesc(), xmlDoc.ErrorRow());
-    return false;
-  }
-
-  XBMC->Log(LOG_DEBUG, "%s Parsing recording data.", __FUNCTION__);
-
-  TiXmlHandle hDoc(&xmlDoc);
-  TiXmlElement* pElem;
-  TiXmlHandle hRoot(0);
-
-  pElem = hDoc.FirstChildElement().Element();
-  
-  if (!pElem)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not find root element", __FUNCTION__);
-    return false;
-  }
-
-  hRoot = TiXmlHandle(pElem);
-
-  // Get the recordingslist
-  pElem = hRoot.FirstChild("recordingslist").Element(); 
-  
-  if (!pElem)
-  {
-    XBMC->Log(LOG_DEBUG, "%s Could not find <recordingslist> element", __FUNCTION__);
-    return false;
-  }
-
-  TiXmlElement* pNode = pElem->FirstChildElement("recording");
-
-  if (!pNode)
-  {
-    XBMC->Log(LOG_DEBUG, "Could not find <recording> element");
-    return false;
-  }
-
-  for (; pNode != NULL; pNode = pNode->NextSiblingElement("recording"))
-  {
-    CStdString strTmp;
-    int iTmp;
-
-    if (!XMLUtils::GetInt(pNode, "lastplayedposition", iTmp))
-      continue;
-
-    if (!XMLUtils::GetString(pNode, "streamurl", strTmp))
-      continue;
-
-    SetRecordingLastPlayedPosition(strTmp, iTmp);
-  }
-
-  return true;
 }
 

--- a/addons/pvr.vuplus/src/VuData.h
+++ b/addons/pvr.vuplus/src/VuData.h
@@ -2,6 +2,7 @@
 
 #include "platform/util/StdString.h"
 #include "client.h"
+#include "TimeshiftBuffer.h"
 #include "platform/threads/threads.h"
 #include "tinyxml/tinyxml.h"
     
@@ -25,57 +26,6 @@ typedef enum VU_UPDATE_STATE
     VU_UPDATE_STATE_NEW
 } VU_UPDATE_STATE;
 
-struct VuChannelGroup {
-  std::string strServiceReference;
-  std::string strGroupName;
-  int iGroupState;
-
-  VuChannelGroup() 
-  { 
-    iGroupState = VU_UPDATE_STATE_NEW;
-  }
-
-  bool operator==(const VuChannelGroup &right) const
-  {
-    return (! strServiceReference.compare(right.strServiceReference)) && (! strGroupName.compare(right.strGroupName));
-  }
-
-};
-
-struct VuChannel
-{
-  bool bRadio;
-  int iUniqueId;
-  int iChannelNumber;
-  std::string strGroupName;
-  std::string strChannelName;
-  std::string strServiceReference;
-  std::string strStreamURL;
-  std::string strIconPath;
-  int iChannelState;
-
-  VuChannel()
-  {
-    iChannelState = VU_UPDATE_STATE_NEW;
-  }
-  
-  bool operator==(const VuChannel &right) const
-  {
-    bool bChanged = true;
-    bChanged = bChanged && (bRadio == right.bRadio); 
-    bChanged = bChanged && (iUniqueId == right.iUniqueId); 
-    bChanged = bChanged && (iChannelNumber == right.iChannelNumber); 
-    bChanged = bChanged && (! strGroupName.compare(right.strGroupName));
-    bChanged = bChanged && (! strChannelName.compare(right.strChannelName));
-    bChanged = bChanged && (! strServiceReference.compare(right.strServiceReference));
-    bChanged = bChanged && (! strStreamURL.compare(right.strStreamURL));
-    bChanged = bChanged && (! strIconPath.compare(right.strIconPath));
-
-    return bChanged;
-  }
-
-};
-
 struct VuEPGEntry 
 {
   int iEventId;
@@ -86,6 +36,27 @@ struct VuEPGEntry
   time_t endTime;
   std::string strPlotOutline;
   std::string strPlot;
+};
+
+struct VuChannelGroup 
+{
+  std::string strServiceReference;
+  std::string strGroupName;
+  int iGroupState;
+  std::vector<VuEPGEntry> initialEPG;
+};
+
+struct VuChannel
+{
+  bool bRadio;
+  bool bInitialEPG;
+  int iUniqueId;
+  int iChannelNumber;
+  std::string strGroupName;
+  std::string strChannelName;
+  std::string strServiceReference;
+  std::string strStreamURL;
+  std::string strIconPath;
 };
 
 struct VuTimer
@@ -157,6 +128,8 @@ class Vu  : public PLATFORM::CThread
 private:
 
   // members
+  void *m_writeHandle;
+  void *m_readHandle;
   std::string m_strEnigmaVersion;
   std::string m_strImageVersion;
   std::string m_strWebIfVersion;
@@ -172,8 +145,8 @@ private:
   std::vector<VuRecording> m_recordings;
   std::vector<VuChannelGroup> m_groups;
   std::vector<std::string> m_locations;
-  bool m_bInitial;
   unsigned int m_iClientIndexCounter;
+  TimeshiftBuffer *m_tsBuffer;
 
   PLATFORM::CMutex m_mutex;
   PLATFORM::CCondition<bool> m_started;
@@ -181,10 +154,6 @@ private:
   bool m_bUpdating;
 
   // functions
-  void StoreChannelData();
-  void LoadChannelData();
-  bool StoreLastPlayedPositions();
-  bool RestoreLastPlayedPositions();
   CStdString GetHttpXML(CStdString& url);
   int GetChannelNumber(CStdString strServiceReference);
   CStdString GetChannelIconPath(CStdString strChannelName);
@@ -221,13 +190,12 @@ public:
   int GetChannelsAmount(void);
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
   PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd);
+  PVR_ERROR GetInitialEPGForChannel(ADDON_HANDLE handle, const VuChannel &channel, time_t iStart, time_t iEnd);
+  bool GetInitialEPGForGroup(VuChannelGroup &group);
   int GetCurrentClientChannel(void);
   int GetTimersAmount(void);
   PVR_ERROR GetTimers(ADDON_HANDLE handle);
   PVR_ERROR AddTimer(const PVR_TIMER &timer);
-  PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int lastplayedposition);
-  bool SetRecordingLastPlayedPosition(CStdString strStreamURL, int lastplayedposition);
-  int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording);
   PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
   PVR_ERROR DeleteTimer(const PVR_TIMER &timer);
   bool GetRecordingFromLocation(CStdString strRecordingFolder);
@@ -244,5 +212,10 @@ public:
   bool SwitchChannel(const PVR_CHANNEL &channel);
   bool Open();
   void Action();
+  int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize);
+  long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */);
+  long long PositionLiveStream(void);
+  long long LengthLiveStream(void);
+  bool m_bInitialEPG;
 };
 

--- a/addons/pvr.vuplus/src/client.h
+++ b/addons/pvr.vuplus/src/client.h
@@ -20,6 +20,16 @@
  *
  */
 
+#ifndef UNUSED
+#if defined(__GNUC__)
+# define UNUSED(x) UNUSED_ ## x __attribute__((unused))
+#elif defined(__LCLINT__)
+# define UNUSED(x) /*@unused@*/ x
+#else
+# define UNUSED(x) x
+#endif
+#endif
+
 #include "libXBMC_addon.h"
 #include "libXBMC_pvr.h"
 #include "libXBMC_gui.h"
@@ -29,6 +39,7 @@
 #define DEFAULT_STREAM_PORT      8001 
 #define DEFAULT_WEB_PORT         80
 #define DEFAULT_UPDATE_INTERVAL  2
+#define DEFAULT_TSBUFFERPATH     "special://userdata/addon_data/pvr.vuplus/tsbuffer"
 
 extern bool                      m_bCreated;
 extern std::string               g_strHostname;
@@ -39,13 +50,10 @@ extern std::string               g_strPassword;
 extern std::string               g_strIconPath;
 extern std::string               g_strRecordingPath;
 extern int 			 g_iUpdateInterval;
-//extern int                       g_iClientId;
 extern unsigned int              g_iPacketSequence;
 extern bool                      g_bShowTimerNotifications;
 extern bool			 g_bZap;
 extern bool                      g_bAutomaticTimerlistCleanup;
-extern bool                      g_bCheckForGroupUpdates;
-extern bool                      g_bCheckForChannelUpdates;
 extern bool                      g_bOnlyCurrentLocation;
 extern bool			 g_bSetPowerstate;
 extern bool			 g_bOnlyOneGroup;
@@ -54,5 +62,8 @@ extern std::string               g_strOneGroup;
 extern std::string               g_szUserPath;
 extern std::string               g_szClientPath;
 extern std::string               g_strChannelDataPath;
+extern bool                      g_bUseTimeshift;
+extern bool                      g_bUseSecureHTTP;
+extern std::string               g_strTimeshiftBufferPath;
 extern ADDON::CHelper_libXBMC_addon *   XBMC;
 extern CHelper_libXBMC_pvr *     PVR;


### PR DESCRIPTION
This adds basic time shift support, also the initial EPG import will be much faster. 
- add: timeshift support (based on Manuel Mausz DVBViewer Timeshift support)
- remove: implementation for lastplayedposition (XBMC handles this now)
- remove: loading of channel data from HDD
- change: handling of EPG 
