### PR TITLE
Fixes non-automatic updates of Timers and Recordings

### DIFF
--- a/addons/pvr.argustv/Makefile.am
+++ b/addons/pvr.argustv/Makefile.am
@@ -23,6 +23,7 @@ libargustv_addon_la_SOURCES = src/activerecording.cpp \
                                    src/argustvrpc.cpp \
                                    src/guideprogram.cpp \
                                    src/KeepAliveThread.cpp \
+                                   src/EventsThread.cpp \
                                    src/pvrclient-argustv.cpp \
                                    src/recording.cpp \
                                    src/recordinggroup.cpp \

--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.9.172"
+  version="1.9.173"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,5 +1,7 @@
+v1.9.173 (30-01-2014)
+- added service events monitor
 v1.9.172 (23-12-2013)
-- base new timers on templates retrieved from ARGUS TV server.
+- base new timers on templates retrieved from ARGUS TV server
 v1.9.171 (11-12-2013)
 - removed redundant notification
 v1.9.170 (28-09-2013)

--- a/addons/pvr.argustv/project/VS2010Express/pvr.argustv.vcxproj
+++ b/addons/pvr.argustv/project/VS2010Express/pvr.argustv.vcxproj
@@ -84,6 +84,7 @@
     <ClCompile Include="..\..\src\client.cpp" />
     <ClCompile Include="..\..\src\epg.cpp" />
     <ClCompile Include="..\..\src\argustvrpc.cpp" />
+    <ClCompile Include="..\..\src\EventsThread.cpp" />
     <ClCompile Include="..\..\src\guideprogram.cpp" />
     <ClCompile Include="..\..\src\KeepAliveThread.cpp" />
     <ClCompile Include="..\..\src\lib\tsreader\FileReader.cpp" />
@@ -103,6 +104,7 @@
     <ClInclude Include="..\..\src\client.h" />
     <ClInclude Include="..\..\src\epg.h" />
     <ClInclude Include="..\..\src\argustvrpc.h" />
+    <ClInclude Include="..\..\src\EventsThread.h" />
     <ClInclude Include="..\..\src\guideprogram.h" />
     <ClInclude Include="..\..\src\KeepAliveThread.h" />
     <ClInclude Include="..\..\src\lib\tsreader\FileReader.h" />

--- a/addons/pvr.argustv/project/VS2010Express/pvr.argustv.vcxproj.filters
+++ b/addons/pvr.argustv/project/VS2010Express/pvr.argustv.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="..\..\src\pvrclient-argustv.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\EventsThread.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\activerecording.h">
@@ -123,6 +126,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\pvrclient-argustv.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\EventsThread.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/addons/pvr.argustv/src/EventsThread.cpp
+++ b/addons/pvr.argustv/src/EventsThread.cpp
@@ -1,0 +1,132 @@
+/*
+ *      Copyright (C) 2014 Fred Hoogduin
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+
+#include "client.h" //for XBMC->Log
+#include "argustvrpc.h"
+#include "EventsThread.h"
+
+using namespace ADDON;
+
+CEventsThread::CEventsThread(void)
+{
+  XBMC->Log(LOG_DEBUG, "CEventsThread:: constructor");
+}
+
+
+CEventsThread::~CEventsThread(void)
+{
+  XBMC->Log(LOG_DEBUG, "CEventsThread:: destructor");
+  if (m_subscribed)
+  {
+    int retval = ArgusTV::UnsubscribeServiceEvents(m_monitorId);
+    if (retval < 0)
+    {
+      XBMC->Log(LOG_NOTICE, "CEventsThread:: unsubscribe from events failed");
+    }
+  }
+}
+
+void CEventsThread::Connect()
+{
+  XBMC->Log(LOG_DEBUG, "CEventsThread::Connect");
+  // Subscribe to service events
+  Json::Value response;
+  int retval = ArgusTV::SubscribeServiceEvents(ArgusTV::AllEvents, response);
+  if (retval >= 0)
+  {
+    m_monitorId = response.asString();
+    m_subscribed = true;
+    XBMC->Log(LOG_DEBUG, "CEventsThread:: monitorId = %s", m_monitorId.c_str());
+  }
+  else
+  {
+    m_subscribed = false;
+    XBMC->Log(LOG_NOTICE, "CEventsThread:: subscribe to events failed");
+  }
+}
+
+void *CEventsThread::Process()
+{
+  XBMC->Log(LOG_DEBUG, "CEventsThread:: thread started");
+  while (!IsStopped() && m_subscribed)
+  {
+    // Get service events
+    Json::Value response;
+    int retval = ArgusTV::GetServiceEvents(m_monitorId, response);
+    if (retval >= 0)
+    {
+      if (response["Expired"].asBool())
+      {
+        // refresh subscription
+        Connect();
+      }
+      else
+      {
+        // Process service events
+        Json::Value events = response["Events"];
+        if (events.size() > 0u) HandleEvents(events);
+      }
+    }
+    // The new PLATFORM:: thread library has a problem with stopping a thread that is doing a long sleep
+    for (int i = 0; i < 100; i++)
+    {
+      if (Sleep(100)) break;
+    }
+  }
+  XBMC->Log(LOG_DEBUG, "CEventsThread:: thread stopped");
+  return NULL;
+}
+
+void CEventsThread::HandleEvents(Json::Value events)
+{
+  XBMC->Log(LOG_DEBUG, "CEventsThread::HandleEvents");
+  int size = events.size();
+  bool mustUpdateTimers = false;
+  bool mustUpdateRecordings = false;
+  // Aggregate events
+  for (int i = 0; i < size; i++)
+  {
+    Json::Value event = events[i];
+    std::string eventName = event["Name"].asString();
+    XBMC->Log(LOG_DEBUG, "CEventsThread:: ARGUS TV reports event %s", eventName.c_str());
+    if (eventName == "UpcomingRecordingsChanged")
+    {
+      XBMC->Log(LOG_DEBUG, "Timers changed");
+      mustUpdateTimers = true;
+    }
+    else if (eventName == "RecordingStarted" || eventName == "RecordingEnded")
+    {
+      XBMC->Log(LOG_DEBUG, "Recordings changed");
+      mustUpdateRecordings = true;
+    }
+  }
+  // Handle aggregated events
+  if (mustUpdateTimers)
+  {
+    XBMC->Log(LOG_DEBUG, "CEventsThread:: Timers update triggered");
+    PVR->TriggerTimerUpdate();
+  }
+  if (mustUpdateRecordings)
+  {
+    XBMC->Log(LOG_DEBUG, "CEventsThread:: Recordings update triggered");
+    PVR->TriggerRecordingUpdate();
+  }
+}

--- a/addons/pvr.argustv/src/EventsThread.h
+++ b/addons/pvr.argustv/src/EventsThread.h
@@ -1,0 +1,38 @@
+#pragma once
+/*
+ *      Copyright (C) 2014 Fred Hoogduin
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "platform/threads/threads.h"
+
+class CEventsThread : public PLATFORM::CThread
+{
+public:
+  CEventsThread(void);
+  ~CEventsThread(void);
+  void Connect(void);
+private:
+  virtual void *Process(void);
+
+  void HandleEvents(Json::Value events);
+
+  bool m_subscribed;
+  std::string m_monitorId;
+};
+

--- a/addons/pvr.argustv/src/argustvrpc.cpp
+++ b/addons/pvr.argustv/src/argustvrpc.cpp
@@ -1293,6 +1293,81 @@ namespace ArgusTV
     return retval;
   }
 
+  /*
+   * \brief Subscribe to ARGUS TV service events
+   */
+  int SubscribeServiceEvents(int eventGroups, Json::Value& response)
+  {
+    XBMC->Log(LOG_DEBUG, "SubscribeServiceEvents");
+    int retval = E_FAILED;
+
+    char command[256];
+    snprintf(command, 256, "ArgusTV/Core/SubscribeServiceEvents/%d" , eventGroups);
+    retval = ArgusTVJSONRPC(command, "", response);
+
+    if(retval >= 0)
+    {           
+      if (response.type() != Json::stringValue)
+      {
+        retval = E_FAILED;
+        XBMC->Log(LOG_NOTICE, "SubscribeServiceEvents did not return a Json::stringValue [%d].", response.type());
+      }
+    }
+    else
+    {
+      XBMC->Log(LOG_ERROR, "SubscribeServiceEvents remote call failed.");
+    }
+    return retval;
+  }
+
+  /*
+   * \brief Unsubscribe from ARGUS TV service events
+   */
+  int UnsubscribeServiceEvents(const std::string& monitorId)
+  {
+    XBMC->Log(LOG_DEBUG, "UnsubscribeServiceEvents from %s", monitorId.c_str());
+    int retval = E_FAILED;
+
+    char command[256];
+    snprintf(command, 256, "ArgusTV/Core/UnsubscribeServiceEvents/%s" , monitorId.c_str());
+    std::string dummy;
+    retval = ArgusTVRPC(command, "", dummy);
+
+    if (retval < 0)
+    {
+      XBMC->Log(LOG_ERROR, "UnsubscribeServiceEvents remote call failed.");
+    }
+    return retval;
+  }
+
+  /*
+   * \brief Retrieve the ARGUS TV service events
+   */
+  int GetServiceEvents(const std::string& monitorId, Json::Value& response)
+  {
+    XBMC->Log(LOG_DEBUG, "GetServiceEvents");
+    int retval = E_FAILED;
+
+    char command[256];
+    snprintf(command, 256, "ArgusTV/Core/GetServiceEvents/%s" , monitorId.c_str());
+    retval = ArgusTVJSONRPC(command, "", response);
+
+    if(retval >= 0)
+    {           
+      if (response.type() != Json::objectValue)
+      {
+        retval = E_FAILED;
+        XBMC->Log(LOG_NOTICE, "GetServiceEvents did not return a Json::objectValue [%d].", response.type());
+      }
+    }
+    else
+    {
+      XBMC->Log(LOG_ERROR, "GetServiceEvents remote call failed.");
+    }
+    return retval;
+  }
+
+
   /**
    * \brief Convert a XBMC Lifetime value to the 4TR keepUntilMode setting
    * \param lifetime the XBMC lifetime value (in days) 

--- a/addons/pvr.argustv/src/argustvrpc.h
+++ b/addons/pvr.argustv/src/argustvrpc.h
@@ -83,6 +83,14 @@ namespace ArgusTV
     NotSupported = 99
   };
 
+  enum ServiceEventGroups {
+    SystemEvents = 0x01,
+    GuideEvents = 0x02,
+    ScheduleEvents = 0x04,
+    RecordingEvents = 0x08,
+    AllEvents = 0x0F
+  };
+
   /**
    * \brief Do some internal housekeeping at the start
    */
@@ -318,7 +326,7 @@ namespace ArgusTV
    */
   int RequestTVChannelGroups(Json::Value& response);
 
-    /*
+  /*
    * \brief Get the list with Radio channel groups from 4TR
    */
   int RequestRadioChannelGroups(Json::Value& response);
@@ -334,6 +342,21 @@ namespace ArgusTV
    * \param channelGUID GUID of the channel
    */
   std::string GetChannelLogo(const std::string& channelGUID);
+
+  /*
+   * \brief Subscribe to ARGUS TV service events
+   */
+  int SubscribeServiceEvents(int eventGroups, Json::Value& response);
+
+  /*
+   * \brief Unsubscribe from ARGUS TV service events
+   */
+  int UnsubscribeServiceEvents(const std::string& monitorId);
+
+  /*
+   * \brief Retrieve the ARGUS TV service events
+   */
+  int GetServiceEvents(const std::string& monitorId, Json::Value& response);
 
   /*
    * \brief Convert a XBMC Lifetime value to the 4TR keepUntilMode setting

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -133,6 +133,15 @@ bool cPVRClientArgusTV::Connect()
 //    XBMC->QueueNotification(QUEUE_ERROR, "Share errors: see xbmc.log");
 //  }
 
+  // Start service events monitor
+  m_eventmonitor.Connect();
+  if (!m_eventmonitor.IsRunning()) 
+  {
+    if(!m_eventmonitor.CreateThread()) 
+    {
+      XBMC->Log(LOG_ERROR, "Start service monitor thread failed.");
+    }
+  }
   m_bConnected = true;
   return true;
 }
@@ -142,6 +151,15 @@ void cPVRClientArgusTV::Disconnect()
   string result;
 
   XBMC->Log(LOG_INFO, "Disconnect");
+
+  // Stop service events monitor
+  if (m_eventmonitor.IsRunning()) 
+  {
+    if (!m_eventmonitor.StopThread())
+    {
+      XBMC->Log(LOG_ERROR, "Stop service monitor thread failed.");
+    }
+  }
 
   if (m_bTimeShiftStarted)
   {

--- a/addons/pvr.argustv/src/pvrclient-argustv.h
+++ b/addons/pvr.argustv/src/pvrclient-argustv.h
@@ -29,6 +29,7 @@
 #include "guideprogram.h"
 
 #include "KeepAliveThread.h"
+#include "EventsThread.h"
 
 class CTsReader;
 
@@ -128,6 +129,7 @@ private:
   int                     m_signalqualityInterval;
   CTsReader*              m_tsreader;
   CKeepAliveThread        m_keepalive;
+  CEventsThread           m_eventmonitor;
 #if defined(ATV_DUMPTS)
   char ofn[25];
   int ofd;


### PR DESCRIPTION
This is a long standing fix. 

A new thread is monitoring the ARGUS TV server service events. XBMC gets triggered when new timers or recordings are detected after analysis of these events.
