### PR TITLE
FIX: conflict detection for Timers, Threads on OS X

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.9.175"
+  version="1.9.176"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,6 @@
+v1.9.176 (22-04-2014)
+- improved timer conflicts detection
+- fix threads on OS X
 v1.9.175 (17-03-2014)
 - Updated language files from Transifex
 v1.9.174 (03-03-2014)

--- a/addons/pvr.argustv/src/argustvrpc.cpp
+++ b/addons/pvr.argustv/src/argustvrpc.cpp
@@ -258,7 +258,7 @@ namespace ArgusTV
   }
 
   /*
-   * \brief Get the list with channel groups from 4TR
+   * \brief Get the list with channel groups from ARGUS
    * \param channelType The channel type (Television or Radio)
    */
   int RequestChannelGroups(enum ChannelType channelType, Json::Value& response)
@@ -296,7 +296,7 @@ namespace ArgusTV
   }
 
   /*
-   * \brief Get the list with channels for the given channel group from 4TR
+   * \brief Get the list with channels for the given channel group from ARGUS
    * \param channelGroupId GUID of the channel group
    */
   int RequestChannelGroupMembers(const std::string& channelGroupId, Json::Value& response)
@@ -328,7 +328,7 @@ namespace ArgusTV
   }
     
   /*
-   * \brief Get the list with TV channel groups from 4TR
+   * \brief Get the list with TV channel groups from ARGUS
    */
   int RequestTVChannelGroups(Json::Value& response)
   {
@@ -336,7 +336,7 @@ namespace ArgusTV
   }
     
   /*
-   * \brief Get the list with Radio channel groups from 4TR
+   * \brief Get the list with Radio channel groups from ARGUS
    */
   int RequestRadioChannelGroups(Json::Value& response)
   {
@@ -344,7 +344,7 @@ namespace ArgusTV
   }
 
   /*
-   * \brief Get the list with channels from 4TR
+   * \brief Get the list with channels from ARGUS
    * \param channelType The channel type (Television or Radio)
    */
   int GetChannelList(enum ChannelType channelType, Json::Value& response)
@@ -1107,7 +1107,6 @@ namespace ArgusTV
     CStdString modifiedtitle = title;
     modifiedtitle.Replace("\"", "\\\"");
 
-    newSchedule["IsOneTime"] = Json::Value(true);
     newSchedule["KeepUntilMode"] = Json::Value(lifetimeToKeepUntilMode(lifetime));
     newSchedule["KeepUntilValue"] = Json::Value(lifetimeToKeepUntilValue(lifetime));
     newSchedule["Name"] = Json::Value(modifiedtitle.c_str());
@@ -1369,7 +1368,42 @@ namespace ArgusTV
 
 
   /**
-   * \brief Convert a XBMC Lifetime value to the 4TR keepUntilMode setting
+   * \brief Get the upcoming recordings for a given schedule
+   */
+  int GetUpcomingRecordingsForSchedule(const std::string& scheduleid, Json::Value& response)
+  {
+    int retval = -1;
+
+    XBMC->Log(LOG_DEBUG, "GetUpcomingRecordingsForSchedule");
+
+    char command[256];
+    snprintf(command, 256, "ArgusTV/Control/UpcomingRecordingsForSchedule/%s?includeCancelled=true" , scheduleid.c_str());
+
+    retval = ArgusTVJSONRPC(command, "", response);
+
+    if (retval < 0)
+    {
+      XBMC->Log(LOG_DEBUG, "GetUpcomingRecordingsForSchedule failed. Return value: %i\n", retval);
+    }
+    else
+    {
+      if( response.type() == Json::arrayValue)
+      {
+        int size = response.size();
+        return size;
+      }
+      else
+      {
+        XBMC->Log(LOG_DEBUG, "Unknown response format %d. Expected Json::arrayValue\n", response.type());
+        return -1;
+      }
+    }
+
+    return retval;
+  }
+
+  /**
+   * \brief Convert a XBMC Lifetime value to the ARGUS keepUntilMode setting
    * \param lifetime the XBMC lifetime value (in days) 
    */
   int lifetimeToKeepUntilMode(int lifetime)
@@ -1384,7 +1418,7 @@ namespace ArgusTV
   }
 
   /**
-   * \brief Convert a XBMC Lifetime value to the 4TR keepUntilValue setting
+   * \brief Convert a XBMC Lifetime value to the ARGUS keepUntilValue setting
    * \param lifetime the XBMC lifetime value (in days) 
    */
   int lifetimeToKeepUntilValue(int lifetime)

--- a/addons/pvr.argustv/src/argustvrpc.h
+++ b/addons/pvr.argustv/src/argustvrpc.h
@@ -97,7 +97,7 @@ namespace ArgusTV
   void Initialize(void);
 
   /**
-   * \brief Send a REST command to 4TR and return the JSON response string
+   * \brief Send a REST command to ARGUS and return the JSON response string
    * \param command       The command string url (starting from "ArgusTV/")
    * \param json_response Reference to a std::string used to store the json response string
    * \return 0 on ok, -1 on a failure
@@ -105,7 +105,7 @@ namespace ArgusTV
   int ArgusTVRPC(const std::string& command, const std::string& arguments, std::string& json_response);
 
   /**
-   * \brief Send a REST command to 4TR and return the JSON response 
+   * \brief Send a REST command to ARGUS and return the JSON response 
    * \param command       The command string url (starting from "ArgusTV/")
    * \param json_response Reference to a Json::Value used to store the parsed Json value
    * \return 0 on ok, -1 on a failure
@@ -113,7 +113,7 @@ namespace ArgusTV
   int ArgusTVJSONRPC(const std::string& command, const std::string& arguments, Json::Value& json_response);
 
   /**
-   * \brief Send a REST command to 4TR, write the response to a file and return the filename
+   * \brief Send a REST command to ARGUS, write the response to a file and return the filename
    * \param command       The command string url (starting from "ArgusTV/")
    * \param newfilename   Reference to a std::string used to store the output file name
    * \param htt_presponse Reference to a long used to store the HTTP response code
@@ -190,7 +190,7 @@ namespace ArgusTV
 
   /**
    * \brief Fetch the EPG data for the given guidechannel id
-   * \param guidechannel_id  String containing the 4TR guidechannel_id (not the channel_id)
+   * \param guidechannel_id  String containing the ARGUS guidechannel_id (not the channel_id)
    * \param epg_start        Start from this date
    * \param epg_stop         Until this date
    */
@@ -321,18 +321,23 @@ namespace ArgusTV
    */
   int GetUpcomingProgramsForSchedule(const Json::Value& schedule, Json::Value& response);
 
+  /**
+   * \brief Get the upcoming recordings for a given schedule
+   */
+  int GetUpcomingRecordingsForSchedule(const std::string& scheduleid, Json::Value& response);
+
   /*
-   * \brief Get the list with TV channel groups from 4TR
+   * \brief Get the list with TV channel groups from ARGUS
    */
   int RequestTVChannelGroups(Json::Value& response);
 
   /*
-   * \brief Get the list with Radio channel groups from 4TR
+   * \brief Get the list with Radio channel groups from ARGUS
    */
   int RequestRadioChannelGroups(Json::Value& response);
 
   /*
-   * \brief Get the list with channels for the given channel group from 4TR
+   * \brief Get the list with channels for the given channel group from ARGUS
    * \param channelGroupId GUID of the channel group
    */
   int RequestChannelGroupMembers(const std::string& channelGroupId, Json::Value& response);
@@ -359,13 +364,13 @@ namespace ArgusTV
   int GetServiceEvents(const std::string& monitorId, Json::Value& response);
 
   /*
-   * \brief Convert a XBMC Lifetime value to the 4TR keepUntilMode setting
+   * \brief Convert a XBMC Lifetime value to the ARGUS keepUntilMode setting
    * \param lifetime the XBMC lifetime value (in days) 
    */
   int lifetimeToKeepUntilMode(int lifetime);
 
   /*
-   * \brief Convert a XBMC Lifetime value to the 4TR keepUntilValue setting
+   * \brief Convert a XBMC Lifetime value to the ARGUS keepUntilValue setting
    * \param lifetime the XBMC lifetime value (in days) 
    */
   int lifetimeToKeepUntilValue(int lifetime);

--- a/addons/pvr.argustv/src/pvrclient-argustv.h
+++ b/addons/pvr.argustv/src/pvrclient-argustv.h
@@ -128,8 +128,8 @@ private:
   int                     m_epg_id_offset;
   int                     m_signalqualityInterval;
   CTsReader*              m_tsreader;
-  CKeepAliveThread        m_keepalive;
-  CEventsThread           m_eventmonitor;
+  CKeepAliveThread*       m_keepalive;
+  CEventsThread*          m_eventmonitor;
 #if defined(ATV_DUMPTS)
   char ofn[25];
   int ofd;


### PR DESCRIPTION
- use EPG data to retrieve original title before creating a new ARGUS TV schedule, this improves timer conflict detection (much!)
- renamed some left-over from ForTheRecord to ARGUS
