### PR TITLE
check for gl2 header when checking for GLES

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ if test "$have_gl" = "yes"; then
 fi
 echo "GL: $have_gl"
 
-AC_CHECK_LIB([GLESv2],[main],have_gles2=yes, have_gles2=no)
+AC_CHECK_LIB([GLESv2],[main],[AC_CHECK_HEADER([GLES2/gl2.h], have_gles2=yes, have_gles2=no, )], have_gles2=no)
 if test "$have_gles2" = "yes"; then
   AC_DEFINE([HAVE_GLES2],[1],["Define to 1 if we have gles2"])
   AM_CONDITIONAL(HAVE_GLES2, true)


### PR DESCRIPTION
newer NVidia drivers install GLES libs which caused build to fail.
