### PR TITLE
FIX iLastPlayedPosition was not set for recordings;

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.9.176"
+  version="1.9.177"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.9.177 (01-05-2014)
+- fill initial last played position for recordings
 v1.9.176 (22-04-2014)
 - improved timer conflicts detection
 - fix threads on OS X

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -689,6 +689,7 @@ PVR_ERROR cPVRClientArgusTV::GetRecordings(ADDON_HANDLE handle)
               tag.iDuration      = recording.RecordingStopTime() - recording.RecordingStartTime();
               strncpy(tag.strPlot, recording.Description(), sizeof(tag.strPlot));
               tag.iPlayCount     = recording.FullyWatchedCount();
+              tag.iLastPlayedPosition = recording.LastWatchedPosition();
               if (nrOfRecordings > 1)
               {
                 recording.Transform(true);


### PR DESCRIPTION
Noticed on RC1 this field was not filled for recordings, thereby not showing progress indicators on the recordings overview lists
