### PR TITLE
[pvr.vdr.vnsi] Fix segfault when showing scan dialog if VDR is not connected

### DIFF
--- a/addons/pvr.vdr.vnsi/src/VNSIChannelScan.cpp
+++ b/addons/pvr.vdr.vnsi/src/VNSIChannelScan.cpp
@@ -58,6 +58,25 @@
 using namespace ADDON;
 
 cVNSIChannelScan::cVNSIChannelScan()
+ : m_running(false),
+   m_stopped(false),
+   m_Canceled(false),
+   m_window(NULL),
+   m_spinSourceType(NULL),
+   m_spinCountries(NULL),
+   m_spinSatellites(NULL),
+   m_spinDVBCInversion(NULL),
+   m_spinDVBCSymbolrates(NULL),
+   m_spinDVBCqam(NULL),
+   m_spinDVBTInversion(NULL),
+   m_spinATSCType(NULL),
+   m_radioButtonTV(NULL),
+   m_radioButtonRadio(NULL),
+   m_radioButtonFTA(NULL),
+   m_radioButtonScrambled(NULL),
+   m_radioButtonHD(NULL),
+   m_progressDone(NULL),
+   m_progressSignal(NULL)
 {
 }
 


### PR DESCRIPTION
If vdr fails to read countries, then m_spinSatellites is never initialized. Easily fixed by a proper initialization list.
