### PR TITLE
Replace AC_PROG_LIBTOOL by LT_INIT in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_PREFIX_DEFAULT($PREFIX_DEFAULT)
 
 AC_PROG_CXX
 AC_PROG_CPP
-AC_PROG_LIBTOOL
+LT_INIT
 
 AC_SEARCH_LIBS([pthread_create],[pthread],, AC_MSG_ERROR([required library 'pthread' is missing]))
 


### PR DESCRIPTION
AC_PROG_LIBTOOL macro in configure.ac is deprecated and should be replaced by LT_INIT (see http://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html)
