### PR TITLE
Fixed bug that could cause connection to close prematurely (gotham backport)

### DIFF
--- a/addons/pvr.nextpvr/addon/addon.xml.in
+++ b/addons/pvr.nextpvr/addon/addon.xml.in
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="1.9.7"
+  version="1.9.8"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>

--- a/addons/pvr.nextpvr/addon/changelog.txt
+++ b/addons/pvr.nextpvr/addon/changelog.txt
@@ -1,3 +1,6 @@
+v1.9.8
+- fixed bug that could cause connection to close prematurely 
+
 v1.9.7
 - updated language files from Transifex
 

--- a/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
+++ b/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
@@ -1345,11 +1345,14 @@ int cPVRClientNextPVR::ReadLiveStream(unsigned char *pBuffer, unsigned int iBuff
       }
 
       // is it taking too long?
-      if (read_timeouts > 100)
+      if (read_timeouts > 200)
       {
-        m_streamingclient->close();
+        char *str = XBMC->GetLocalizedString(30053);
         bufferMore = false;
-        XBMC->QueueNotification(QUEUE_ERROR, XBMC->GetLocalizedString(30053));
+        if (str != NULL)
+        {
+          XBMC->QueueNotification(QUEUE_ERROR, str);
+        }
         return -1;
       }
     }


### PR DESCRIPTION
Fixed bug that could cause connection to close prematurely.

Fixed an segmentation fault in case of exiting XBMC.

Corrected version number
