### PR TITLE
[Cosmetics] - Makefile/configure - Sort alphabetically for clarity

### DIFF
--- a/addons/Makefile.am
+++ b/addons/Makefile.am
@@ -1,23 +1,24 @@
-if ADDON_MYTHTV
-          ADDON_MYTHTV_SUBDIRS = pvr.mythtv.cmyth
-endif
 if ADDON_IPTVSIMPLE
           ADDON_IPTVSIMPLE_SUBDIRS = pvr.iptvsimple
 endif
+if ADDON_MYTHTV
+          ADDON_MYTHTV_SUBDIRS = pvr.mythtv.cmyth
+endif
 
-SUBDIRS = pvr.demo \
+### Keep this in alphabetical order
+SUBDIRS = pvr.argustv \
+          pvr.demo \
+          pvr.dvblink \
           pvr.dvbviewer \
           pvr.hts \
           pvr.mediaportal.tvserver \
           pvr.nextpvr \
-          pvr.vdr.vnsi \
           pvr.njoy \
+          pvr.vdr.vnsi \
           pvr.vuplus \
-          pvr.argustv \
-          pvr.dvblink \
           pvr.wmc \
-          $(ADDON_MYTHTV_SUBDIRS) \
-          $(ADDON_IPTVSIMPLE_SUBDIRS)
+          $(ADDON_IPTVSIMPLE_SUBDIRS) \
+          $(ADDON_MYTHTV_SUBDIRS)
 
 clean:
 	-rm -f *.zip

--- a/configure.ac
+++ b/configure.ac
@@ -263,42 +263,43 @@ else
 fi
 AC_SUBST(DATADIR)
 
+### Keep this in alphabetical order
 AC_CONFIG_FILES([Makefile \
                  lib/Makefile \
-                 lib/jsoncpp/Makefile \
-                 lib/libhts/Makefile \
-                 lib/tinyxml/Makefile \
                  lib/cmyth/Makefile \
                  lib/cmyth/libcmyth/Makefile \
                  lib/cmyth/librefmem/Makefile \
-                 lib/tinyxml2/Makefile \
+                 lib/jsoncpp/Makefile \
                  lib/libdvblinkremote/Makefile \
+                 lib/libhts/Makefile \
+                 lib/tinyxml/Makefile \
+                 lib/tinyxml2/Makefile \
                  addons/Makefile \
-                 addons/pvr.demo/Makefile \
-                 addons/pvr.dvbviewer/Makefile \
                  addons/pvr.argustv/Makefile \
+                 addons/pvr.demo/Makefile \
+                 addons/pvr.dvblink/Makefile \
+                 addons/pvr.dvbviewer/Makefile \
                  addons/pvr.hts/Makefile \
+                 addons/pvr.iptvsimple/Makefile \
                  addons/pvr.mediaportal.tvserver/Makefile \
+                 addons/pvr.mythtv.cmyth/Makefile \
                  addons/pvr.nextpvr/Makefile \
                  addons/pvr.njoy/Makefile \
-                 addons/pvr.vuplus/Makefile \
                  addons/pvr.vdr.vnsi/Makefile \
-                 addons/pvr.mythtv.cmyth/Makefile \
-                 addons/pvr.dvblink/Makefile \
+                 addons/pvr.vuplus/Makefile \
                  addons/pvr.wmc/Makefile \
-                 addons/pvr.iptvsimple/Makefile \
                  addons/pvr.argustv/addon/addon.xml
                  addons/pvr.demo/addon/addon.xml
+                 addons/pvr.dvblink/addon/addon.xml
                  addons/pvr.dvbviewer/addon/addon.xml
                  addons/pvr.hts/addon/addon.xml
+                 addons/pvr.iptvsimple/addon/addon.xml
                  addons/pvr.mediaportal.tvserver/addon/addon.xml
                  addons/pvr.mythtv.cmyth/addon/addon.xml
                  addons/pvr.nextpvr/addon/addon.xml
                  addons/pvr.njoy/addon/addon.xml
                  addons/pvr.vdr.vnsi/addon/addon.xml
                  addons/pvr.vuplus/addon/addon.xml
-                 addons/pvr.dvblink/addon/addon.xml
-                 addons/pvr.wmc/addon/addon.xml
-                 addons/pvr.iptvsimple/addon/addon.xml])
+                 addons/pvr.wmc/addon/addon.xml])
 
 AC_OUTPUT


### PR DESCRIPTION
For clarity sake, keep Makefile and configure in alphabetical order. Makes life easier to everyone.

Build tested under Ubuntu 64.
