### PR TITLE
Fix clang build

### DIFF
--- a/addons/pvr.wmc/src/pvr2wmc.cpp
+++ b/addons/pvr.wmc/src/pvr2wmc.cpp
@@ -203,7 +203,7 @@ void Pvr2Wmc::TriggerUpdates(vector<CStdString> results)
 				return;
 			}
 
-			XBMC->Log(LOG_INFO, "Received message from backend: %s", response);
+			XBMC->Log(LOG_INFO, "Received message from backend: %s", response->c_str());
 			CStdString infoStr;
 
 			// Get notification level


### PR DESCRIPTION
Without it I will get:

```
src/pvr2wmc.cpp:206:61: error: cannot pass object of non-POD type 'std::vector<CStdString>::iterator' (aka '__normal_iterator<pointer, vector_type>') through variadic
  method; call will abort at runtime [-Wnon-pod-varargs]
                    XBMC->Log(LOG_INFO, "Received message from backend: %s", response);
                                                                             ^
```

building on Mac with clang.
