### PR TITLE
[addon] adds the missing imports of xbmc.gui

### DIFF
--- a/addons/pvr.hts/addon/addon.xml.in
+++ b/addons/pvr.hts/addon/addon.xml.in
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="1.9.31"
+  version="1.9.32"
   name="Tvheadend HTSP Client"
   provider-name="Lars Op den Kamp, Team XBMC">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.2"/>
     <import addon="xbmc.codec" version="1.0.0"/>
+    <import addon="xbmc.gui" version="5.3.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/addons/pvr.mediaportal.tvserver/addon/addon.xml.in
+++ b/addons/pvr.mediaportal.tvserver/addon/addon.xml.in
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="1.9.16"
+  version="1.9.17"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.2"/>
+    <import addon="xbmc.gui" version="5.3.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/addons/pvr.mythtv/addon/addon.xml.in
+++ b/addons/pvr.mythtv/addon/addon.xml.in
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mythtv"
-  version="1.9.22"
+  version="1.9.23"
   name="MythTV PVR Client"
   provider-name="Christian Fetzer, Jean-Luc Barrière">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.2"/>
+    <import addon="xbmc.gui" version="5.3.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/addons/pvr.nextpvr/addon/addon.xml.in
+++ b/addons/pvr.nextpvr/addon/addon.xml.in
@@ -1,12 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="1.9.11"
+  version="1.9.12"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.2"/>
+    <import addon="xbmc.gui" version="5.3.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"

--- a/addons/pvr.wmc/addon/addon.xml.in
+++ b/addons/pvr.wmc/addon/addon.xml.in
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc-@OS@-@ARCHITECTURE@"
-  version="0.3.102"
+  version="0.3.103"
   name="Windows Media Center Client - @OS@ @ARCHITECTURE@ Edition"
   provider-name="KrustyReturns">
   <requires>
     <c-pluff version="0.1"/>
     <import addon="xbmc.pvr" version="1.9.2"/>
+    <import addon="xbmc.gui" version="5.3.0"/>
   </requires>
   <extension
     point="xbmc.pvrclient"


### PR DESCRIPTION
@opdenkamp adds the missing import we talked about yesterday.

@FernetMenta we should merge this before we merge the PVR addon bump https://github.com/xbmc/xbmc/pull/5519
