### PR TITLE
[pvr.hts] Backported GetPlayingTime from pvr.tvh.

### DIFF
--- a/addons/pvr.hts/src/HTSPData.cpp
+++ b/addons/pvr.hts/src/HTSPData.cpp
@@ -1488,7 +1488,7 @@ PVR_ERROR CHTSPData::GetEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entrie
           htsmsg_get_u32(edl, "end", &end) != 0 ||
           htsmsg_get_u32(edl, "type", &type) != 0) 
       {
-	continue;
+        continue;
       }
       
       PVR_EDL_ENTRY entry;
@@ -1528,4 +1528,11 @@ PVR_ERROR CHTSPData::GetEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entrie
   *size = index;
   
   return PVR_ERROR_NO_ERROR;
+}
+
+double CHTSPData::DemuxGetTimeshiftTime(void)
+{
+  return m_demux ?
+      m_demux->GetTimeshiftTime() :
+      0;
 }

--- a/addons/pvr.hts/src/HTSPData.h
+++ b/addons/pvr.hts/src/HTSPData.h
@@ -94,6 +94,8 @@ public:
   bool         SeekTime(int time,bool backward,double *startpts);
   void         SetSpeed(int speed);
   PVR_ERROR    GetEdl(const PVR_RECORDING &recinfo, PVR_EDL_ENTRY entries[], int *size);
+  double       DemuxGetTimeshiftTime(void);
+
 private:
   SChannels GetChannels();
   SChannels GetChannels(int tag);

--- a/addons/pvr.hts/src/HTSPDemux.cpp
+++ b/addons/pvr.hts/src/HTSPDemux.cpp
@@ -598,11 +598,18 @@ bool CHTSPDemux::ParseSignalStatus(htsmsg_t* msg)
 
 bool CHTSPDemux::ParseTimeshiftStatus(htsmsg_t *msg)
 {
-  // TODO: placeholder for processing timeshiftStatus message when
-  //       we're ready to use the information.
-  //
-  //       For now this just ensures we don't spam logs with unecessary
-  //       info about unhandled messages.
+  uint32_t u32;
+  int64_t s64;
+
+  if (!htsmsg_get_u32(msg, "full", &u32))
+    m_timeshiftStatus.full = (bool)u32;
+  if (!htsmsg_get_s64(msg, "shift", &s64))
+    m_timeshiftStatus.shift = s64;
+  if (!htsmsg_get_s64(msg, "start", &s64))
+    m_timeshiftStatus.start = s64;
+  if (!htsmsg_get_s64(msg, "end", &s64))
+    m_timeshiftStatus.end = s64;
+
   return true;
 }
 

--- a/addons/pvr.hts/src/HTSPDemux.h
+++ b/addons/pvr.hts/src/HTSPDemux.h
@@ -40,7 +40,8 @@ public:
   void         Abort();
   DemuxPacket* Read();
   bool         SwitchChannel(const PVR_CHANNEL &channelinfo);
-  int         CurrentChannel() { return m_channel; }
+  int          CurrentChannel() { return m_channel; }
+  double       GetTimeshiftTime() const { return m_timeshiftStatus.shift; }
   bool         GetSignalStatus(PVR_SIGNAL_STATUS &qualityinfo);
   bool         SeekTime(int time, bool backward, double *startpts);
   void         SetSpeed(int speed);
@@ -74,6 +75,7 @@ private:
   SChannels                            m_channels;
   SQueueStatus                         m_QueueStatus;
   SQuality                             m_Quality;
+  STimeshiftStatus                     m_timeshiftStatus;
   SSourceInfo                          m_SourceInfo;
   PLATFORM::SyncedBuffer<DemuxPacket*> m_demuxPacketBuffer;
   bool                                 m_bIsOpen;

--- a/addons/pvr.hts/src/HTSPTypes.h
+++ b/addons/pvr.hts/src/HTSPTypes.h
@@ -164,6 +164,23 @@ struct SQueueStatus
   }
 };
 
+struct STimeshiftStatus
+{
+  bool    full;
+  int64_t shift;
+  int64_t start;
+  int64_t end;
+
+  STimeshiftStatus() { Clear(); }
+  void Clear()
+  {
+    full  = 0;
+    shift = 0;
+    start = 0;
+    end   = 0;
+  }
+};
+
 struct SQuality
 {
   std::string fe_status;

--- a/addons/pvr.hts/src/client.cpp
+++ b/addons/pvr.hts/src/client.cpp
@@ -737,6 +737,16 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING &recording, PVR_EDL_ENTRY entries[
   return HTSPData->GetEdl(recording, &*entries, size);
 }
 
+time_t GetPlayingTime()
+{
+  int seconds = 0;
+
+  if (HTSPData)
+    seconds = HTSPData->DemuxGetTimeshiftTime() / 1000000;
+
+  return (time(NULL) - seconds);
+}
+
 /** UNUSED API FUNCTIONS */
 PVR_ERROR DialogChannelScan(void) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteChannel(const PVR_CHANNEL &channel) { return PVR_ERROR_NOT_IMPLEMENTED; }
@@ -755,7 +765,6 @@ PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int las
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 unsigned int GetChannelSwitchDelay(void) { return 0; }
 void PauseStream(bool bPaused) {}
-time_t GetPlayingTime() { return 0; }
 time_t GetBufferTimeStart() { return 0; }
 time_t GetBufferTimeEnd() { return 0; }
 }


### PR DESCRIPTION
Backported GetPlayingTime from pvr.tvh. Implementation of this PVR API function is essential for proper timeshifting support in kodi.
