### PR TITLE
[filmon] Fix harmless -Wformat-security warning

### DIFF
--- a/addons/pvr.filmon/src/client.cpp
+++ b/addons/pvr.filmon/src/client.cpp
@@ -282,7 +282,7 @@ PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle,
 
 PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus) {
 	snprintf(signalStatus.strAdapterName, sizeof(signalStatus.strAdapterName),
-			m_data->GetBackendName());
+			"%s", m_data->GetBackendName());
 	snprintf(signalStatus.strAdapterStatus,
 			sizeof(signalStatus.strAdapterStatus), "OK");
 


### PR DESCRIPTION
Filmon addon contains a call to snprintf with a format string coming
directly from a function call, hitting "format not a string literal and
no format arguments" warning with -Wformat-security (and thus fails to
build if -Werror=format-security is used as some Linux distributions do).

There does not seem to be a security issue in this case, but modify the
snprintf() call to avoid the warning anyway.
