### PR TITLE
pvr-addons: fix the mime type for mpegts

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.9.185"
+  version="1.9.186"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.9.186 (27-12-2014)
+- Fixed mime-type for MPEG-TS
 v1.9.185 (02-12-2014)
 - Updated language files from Transifex
 v1.9.183 (12-26-2014)

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -465,7 +465,7 @@ PVR_ERROR cPVRClientArgusTV::GetChannels(ADDON_HANDLE handle, bool bRadio)
         tag.bIsHidden = false;
         //Use OpenLiveStream to read from the timeshift .ts file or an rtsp stream
         memset(tag.strStreamURL, 0, sizeof(tag.strStreamURL));
-        strncpy(tag.strInputFormat, "video/x-mpegts", sizeof(tag.strInputFormat));
+        strncpy(tag.strInputFormat, "video/mp2t", sizeof(tag.strInputFormat));
         tag.iChannelNumber = channel->LCN();
 
         if (!tag.bIsRadio)

--- a/addons/pvr.dvbviewer/addon/addon.xml.in
+++ b/addons/pvr.dvbviewer/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.9.23"
+  version="1.9.24"
   name="DVBViewer Client"
   provider-name="jdembski, A600, Manuel Mausz, Portisch">
   <requires>

--- a/addons/pvr.dvbviewer/addon/changelog.txt
+++ b/addons/pvr.dvbviewer/addon/changelog.txt
@@ -1,3 +1,6 @@
+1.9.24
+[fixed] mime-type for MPEG-TS
+
 1.9.23
 
 [updated] Language files from Transifex

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -155,7 +155,7 @@ PVR_ERROR Dvb::GetChannels(ADDON_HANDLE handle, bool bRadio)
     PVR_STRCPY(xbmcChannel.strIconPath,    channel->logoURL.c_str());
 
     if (!channel->radio && !g_useRTSP)
-      PVR_STRCPY(xbmcChannel.strInputFormat, "video/x-mpegts");
+      PVR_STRCPY(xbmcChannel.strInputFormat, "video/mp2t");
     else
       PVR_STRCPY(xbmcChannel.strInputFormat, "");
 

--- a/addons/pvr.mediaportal.tvserver/addon/addon.xml.in
+++ b/addons/pvr.mediaportal.tvserver/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.mediaportal.tvserver"
-  version="1.9.22"
+  version="1.9.23"
   name="MediaPortal PVR Client"
   provider-name="Marcel Groothuis">
   <requires>

--- a/addons/pvr.mediaportal.tvserver/addon/changelog.txt
+++ b/addons/pvr.mediaportal.tvserver/addon/changelog.txt
@@ -1,3 +1,6 @@
+v1.9.23
+- Fixed mime-type for MPEG-TS
+
 v1.9.22
 - Updated language files from Transifex
 

--- a/addons/pvr.mediaportal.tvserver/src/pvrclient-mediaportal.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/pvrclient-mediaportal.cpp
@@ -43,7 +43,7 @@ using namespace ADDON;
 int g_iTVServerXBMCBuild = 0;
 
 /* PVR client version (don't forget to update also the addon.xml and the Changelog.txt files) */
-#define PVRCLIENT_MEDIAPORTAL_VERSION_STRING    "1.9.15"
+#define PVRCLIENT_MEDIAPORTAL_VERSION_STRING    "1.9.23"
 
 /* TVServerXBMC plugin supported versions */
 #define TVSERVERXBMC_MIN_VERSION_STRING         "1.1.7.107"
@@ -707,7 +707,7 @@ PVR_ERROR cPVRClientMediaPortal::GetChannels(ADDON_HANDLE handle, bool bRadio)
           //Use OpenLiveStream to read from the timeshift .ts file or an rtsp stream
           PVR_STRCLR(tag.strStreamURL);
           if (!bRadio)
-            PVR_STRCPY(tag.strInputFormat, "video/x-mpegts");
+            PVR_STRCPY(tag.strInputFormat, "video/mp2t");
           else
             PVR_STRCLR(tag.strInputFormat);
         }

--- a/addons/pvr.nextpvr/addon/addon.xml.in
+++ b/addons/pvr.nextpvr/addon/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="1.9.17"
+  version="1.9.18"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>

--- a/addons/pvr.nextpvr/addon/changelog.txt
+++ b/addons/pvr.nextpvr/addon/changelog.txt
@@ -1,3 +1,6 @@
+v1.9.18
+- Fixed mime-type for MPEG-TS
+
 v1.9.17
 - updated language files from Transifex
 

--- a/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
+++ b/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
@@ -559,7 +559,7 @@ PVR_ERROR cPVRClientNextPVR::GetChannels(ADDON_HANDLE handle, bool bRadio)
           }
         }
 
-        PVR_STRCPY(tag.strInputFormat, "video/x-mpegts");
+        PVR_STRCPY(tag.strInputFormat, "video/mp2t");
 
         // check if it's a radio channel
         tag.bIsRadio = false;


### PR DESCRIPTION
The changes from this PR are needed to prevent streaming problems for multiple pvr-addons when https://github.com/xbmc/xbmc/pull/6036 is merged.

See also https://github.com/FFmpeg/FFmpeg/commit/fdcb2873e1c898cf26216f7e80d95d03387ba55b for the related ffmpeg change.
