### PR TITLE
[pvr.dvblink] version 1.9.13

### DIFF
--- a/addons/pvr.dvblink/addon/addon.xml.in
+++ b/addons/pvr.dvblink/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="1.9.12"
+  version="1.9.13"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>

--- a/addons/pvr.dvblink/addon/changelog.txt
+++ b/addons/pvr.dvblink/addon/changelog.txt
@@ -1,3 +1,6 @@
+[B]Version 1.9.13[/B]
+Fixed: no timers are added from EPG of DVBLink TV Adviser product
+
 [B]Version 1.9.12[/B]
 Added: Grouping recordings by series
 Added: Year to the episode title

--- a/addons/pvr.dvblink/src/DVBLinkClient.h
+++ b/addons/pvr.dvblink/src/DVBLinkClient.h
@@ -84,6 +84,7 @@ private:
   int GetInternalUniqueIdFromChannelId(const std::string& channelId);
   virtual void * Process(void);
   bool build_recording_series_map(std::map<std::string, std::string>& rec_id_to_series_name);
+  bool get_dvblink_program_id(std::string& channelId, int start_time, std::string& dvblink_program_id);
 
   std::string make_timer_hash(const std::string& timer_id, const std::string& schedule_id);
   bool parse_timer_hash(const char* timer_hash, std::string& timer_id, std::string& schedule_id);


### PR DESCRIPTION
Fixed: no timers are added from EPG of DVBLink TV Adviser product