### PR TITLE
[c++11/osx] - fix compilation with osx and enabled c++11 standard

### DIFF
--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,5 +1,6 @@
 v1.9.189 (21-01-2015)
 - Updated language files from Transifex
+- Minor changes to conform with C++11
 v1.9.188 (13-01-2015)
 - Updated language files from Transifex
 v1.9.187 (28-12-2014)

--- a/addons/pvr.demo/addon/addon.xml.in
+++ b/addons/pvr.demo/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.demo"
-  version="1.9.15"
+  version="1.9.16"
   name="PVR Demo Client"
   provider-name="Pulse-Eight Ltd.">
   <requires>

--- a/addons/pvr.dvblink/addon/changelog.txt
+++ b/addons/pvr.dvblink/addon/changelog.txt
@@ -1,5 +1,6 @@
 [B]Version 1.9.15[/B]
 Updated: language files from Transifex
+Fixed: Minor changes to conform with C++11
 
 [B]Version 1.9.14[/B]
 Updated: language files from Transifex

--- a/addons/pvr.dvbviewer/addon/changelog.txt
+++ b/addons/pvr.dvbviewer/addon/changelog.txt
@@ -1,6 +1,7 @@
 1.9.26
 
 [updated] Language files from Transifex
+[fixed] Minor changes to conform with C++11
 
 1.9.25
 

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -180,7 +180,7 @@ PVR_ERROR Dvb::GetEPGForChannel(ADDON_HANDLE handle,
 {
   DvbChannel *myChannel = m_channels[channel.iUniqueId - 1];
 
-  CStdString url = BuildURL("api/epg.html?lvl=2&channel=%"PRIu64"&start=%f&end=%f",
+  CStdString url = BuildURL("api/epg.html?lvl=2&channel=%" PRIu64 "&start=%f&end=%f",
       myChannel->epgId, iStart/86400.0 + DELPHI_DATE, iEnd/86400.0 + DELPHI_DATE);
   CStdString req = GetHttpXML(url);
 
@@ -1054,12 +1054,12 @@ void Dvb::GenerateTimer(const PVR_TIMER& timer, bool newTimer)
   uint64_t iChannelId = m_channels[timer.iClientChannelUid - 1]->backendIds.front();
   CStdString url;
   if (newTimer)
-    url = BuildURL("api/timeradd.html?ch=%"PRIu64"&dor=%u&enable=1&start=%u&stop=%u&prio=%d&days=%s&title=%s&encoding=255",
+    url = BuildURL("api/timeradd.html?ch=%" PRIu64 "&dor=%u&enable=1&start=%u&stop=%u&prio=%d&days=%s&title=%s&encoding=255",
         iChannelId, date, start, stop, timer.iPriority, repeat, URLEncodeInline(timer.strTitle).c_str());
   else
   {
     short enabled = (timer.state == PVR_TIMER_STATE_CANCELLED) ? 0 : 1;
-    url = BuildURL("api/timeredit.html?id=%d&ch=%"PRIu64"&dor=%u&enable=%d&start=%u&stop=%u&prio=%d&days=%s&title=%s&encoding=255",
+    url = BuildURL("api/timeredit.html?id=%d&ch=%" PRIu64 "&dor=%u&enable=%d&start=%u&stop=%u&prio=%d&days=%s&title=%s&encoding=255",
         GetTimerId(timer), iChannelId, date, enabled, start, stop, timer.iPriority, repeat, URLEncodeInline(timer.strTitle).c_str());
   }
 

--- a/addons/pvr.hts/addon/changelog.txt
+++ b/addons/pvr.hts/addon/changelog.txt
@@ -1,3 +1,7 @@
+2.0.2
+- language files from Transifex
+- minor changes to conform with C++11
+
 2.0.0
 - replaced by the newer pvr.tvh implementation
 

--- a/addons/pvr.iptvsimple/addon/changelog.txt
+++ b/addons/pvr.iptvsimple/addon/changelog.txt
@@ -1,3 +1,7 @@
+v1.9.14
+- language files from Transifex
+- minor changes to conform with C++11
+
 v1.9.12
 - added getBackendHostname function
 

--- a/addons/pvr.mediaportal.tvserver/addon/changelog.txt
+++ b/addons/pvr.mediaportal.tvserver/addon/changelog.txt
@@ -1,5 +1,6 @@
 v1.9.26
 - Updated language files from Transifex
+- Minor changes to conform with C++11
 
 v1.9.25
 - Updated language files from Transifex

--- a/addons/pvr.mediaportal.tvserver/src/Cards.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/Cards.cpp
@@ -24,6 +24,7 @@
 #include "client.h"
 #include "DateTime.h"
 
+using namespace std;
 using namespace ADDON;
 
 bool CCards::ParseLines(vector<string>& lines)

--- a/addons/pvr.mediaportal.tvserver/src/Cards.h
+++ b/addons/pvr.mediaportal.tvserver/src/Cards.h
@@ -22,7 +22,6 @@
 #include <string>
 #include "DateTime.h"
 
-using namespace std;
 
 /**
  * MediaPortal TVServer card settings ("card" table in the database)
@@ -30,18 +29,18 @@ using namespace std;
 typedef struct Card
 {
   int       IdCard;
-  string    DevicePath;
-  string    Name;
+  std::string    DevicePath;
+  std::string    Name;
   int       Priority;
   bool      GrabEPG;
   MPTV::CDateTime LastEpgGrab;
-  string    RecordingFolder;
-  string    RecordingFolderUNC;
+  std::string    RecordingFolder;
+  std::string    RecordingFolderUNC;
   int       IdServer;
   bool      Enabled;
   int       CamType;
-  string    TimeshiftFolder;
-  string    TimeshiftFolderUNC;
+  std::string    TimeshiftFolder;
+  std::string    TimeshiftFolderUNC;
   int       RecordingFormat;
   int       DecryptLimit;
   bool      Preload;
@@ -50,7 +49,7 @@ typedef struct Card
   bool      StopGraph;
 } Card;
 
-class CCards: public vector<Card>
+class CCards: public std::vector<Card>
 {
   public:
 
@@ -61,7 +60,7 @@ class CCards: public vector<Card>
      * \param lines Vector with response lines
      * \return True on success, False on failure
      */
-    bool ParseLines(vector<string>& lines);
+    bool ParseLines(std::vector<std::string>& lines);
 
     /**
      * \brief Return the data for the card with the given id

--- a/addons/pvr.mediaportal.tvserver/src/Socket.h
+++ b/addons/pvr.mediaportal.tvserver/src/Socket.h
@@ -18,9 +18,6 @@
  */
 #pragma once
 
-namespace MPTV //Prevent name clash with Live555 Socket
-{
-
 //Include platform specific datatypes, header files, defines and constants:
 #if defined TARGET_WINDOWS
   #define WIN32_LEAN_AND_MEAN           // Enable LEAN_AND_MEAN support
@@ -73,6 +70,9 @@ namespace MPTV //Prevent name clash with Live555 Socket
 using namespace std;
 
 #include <vector>
+
+namespace MPTV //Prevent name clash with Live555 Socket
+{
 
 #define MAXCONNECTIONS 1  ///< Maximum number of pending connections before "Connection refused"
 #define MAXRECV 1500      ///< Maximum packet size

--- a/addons/pvr.mediaportal.tvserver/src/Socket.h
+++ b/addons/pvr.mediaportal.tvserver/src/Socket.h
@@ -67,7 +67,6 @@
   #error Platform specific socket support is not yet available on this platform!
 #endif
 
-using namespace std;
 
 #include <vector>
 
@@ -270,7 +269,7 @@ class Socket
 
     bool set_non_blocking ( const bool );
 
-    bool ReadLine (string& line);
+    bool ReadLine (std::string& line);
 
     bool is_valid() const;
 

--- a/addons/pvr.mediaportal.tvserver/src/channels.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/channels.cpp
@@ -38,7 +38,7 @@ cChannel::~cChannel()
 
 bool cChannel::Parse(const std::string& data)
 {
-  vector<string> fields;
+  std::vector<std::string> fields;
 
   Tokenize(data, fields, "|");
 

--- a/addons/pvr.mediaportal.tvserver/src/epg.h
+++ b/addons/pvr.mediaportal.tvserver/src/epg.h
@@ -31,25 +31,24 @@
 #include "GenreTable.h"
 #include "DateTime.h"
 
-using namespace std;
 
 class cEpg
 {
 private:
   unsigned int m_uid;
-  string m_title;
-  string m_shortText;
-  string m_description;
+  std::string m_title;
+  std::string m_shortText;
+  std::string m_description;
   MPTV::CDateTime m_startTime;
   MPTV::CDateTime m_endTime;
   MPTV::CDateTime m_originalAirDate;
   int m_duration;
-  string m_genre;
+  std::string m_genre;
   int m_genre_type;
   int m_genre_subtype;
   int m_episodeNumber;
-  string m_episodePart;
-  string m_episodeName;
+  std::string m_episodePart;
+  std::string m_episodeName;
   int m_seriesNumber;
   int m_starRating;
   int m_parentalRating;
@@ -60,7 +59,7 @@ public:
   virtual ~cEpg();
   void Reset();
 
-  bool ParseLine(string& data);
+  bool ParseLine(std::string& data);
   int UniqueId(void) const { return m_uid; }
   time_t StartTime(void) const;
   time_t EndTime(void) const;

--- a/addons/pvr.mediaportal.tvserver/src/lib/tsreader/DeMultiplexer.h
+++ b/addons/pvr.mediaportal.tvserver/src/lib/tsreader/DeMultiplexer.h
@@ -39,7 +39,6 @@
 #include "PatParser.h"
 #include "platform/threads/mutex.h"
 
-using namespace std;
 class CTsReader;
 
 class CDeMultiplexer : public CPacketSync, public IPatParserCallback

--- a/addons/pvr.mediaportal.tvserver/src/lib/tsreader/PatParser.h
+++ b/addons/pvr.mediaportal.tvserver/src/lib/tsreader/PatParser.h
@@ -25,7 +25,6 @@
 #include "PmtParser.h"
 #include "ChannelInfo.h"
 #include <vector>
-using namespace std;
 
 class IPatParserCallback
 {
@@ -54,7 +53,7 @@ public:
 private:
   void        CleanUp();
   IPatParserCallback* m_pCallback;
-  vector<CPmtParser*> m_pmtParsers;
+  std::vector<CPmtParser*> m_pmtParsers;
   int64_t     m_packetsReceived;
   int64_t     m_packetsToSkip;
   int          m_iPatTableVersion;

--- a/addons/pvr.mediaportal.tvserver/src/lib/tsreader/PmtParser.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/lib/tsreader/PmtParser.cpp
@@ -85,7 +85,7 @@ void CPmtParser::OnNewSection(CSection& section)
       pointer += (descriptorLen+2);
     }
     // loop 2
-    vector<TempPid> tempPids;
+    std::vector<TempPid> tempPids;
 
     m_pidInfo.Reset();
     m_pidInfo.PmtPid = GetPid();

--- a/addons/pvr.mediaportal.tvserver/src/lib/tsreader/PmtParser.h
+++ b/addons/pvr.mediaportal.tvserver/src/lib/tsreader/PmtParser.h
@@ -24,7 +24,6 @@
 #include "TSHeader.h"
 #include "PidTable.h"
 #include <map>
-using namespace std;
 
 #define SERVICE_TYPE_VIDEO_UNKNOWN  -1
 #define SERVICE_TYPE_VIDEO_MPEG1    0x01

--- a/addons/pvr.mediaportal.tvserver/src/lib/tsreader/TSReader.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/lib/tsreader/TSReader.cpp
@@ -40,6 +40,7 @@
 #endif
 #include "FileUtils.h"
 
+using namespace std;
 using namespace ADDON;
 
 CTsReader::CTsReader(): m_demultiplexer( *this )

--- a/addons/pvr.mediaportal.tvserver/src/lib/tsreader/TSReader.h
+++ b/addons/pvr.mediaportal.tvserver/src/lib/tsreader/TSReader.h
@@ -68,7 +68,7 @@ public:
    * \brief Override the search directory for timeshift buffer files
    * \param the new search directory
    */
-  void SetDirectory( string& directory );
+  void SetDirectory( std::string& directory );
   void SetCardId( int id );
   bool IsTimeShifting();
   bool IsSeeking();
@@ -98,7 +98,7 @@ private:
 #endif
   CCards*         m_cardSettings;     ///< Pointer to the MediaPortal card settings. Will be used to determine the base path of the timeshift buffer
   int             m_cardId;           ///< Card id for the current Card used for this timeshift buffer
-  string          m_basePath;         ///< The base path shared by all timeshift buffers (to be determined from the Card settings)
+  std::string     m_basePath;         ///< The base path shared by all timeshift buffers (to be determined from the Card settings)
   TsReaderState   m_State;            ///< The current state of the TsReader
   unsigned long   m_lastPause;        ///< Last time instance at which the playback was paused
   int             m_WaitForSeekToEof;

--- a/addons/pvr.mediaportal.tvserver/src/recordings.h
+++ b/addons/pvr.mediaportal.tvserver/src/recordings.h
@@ -24,7 +24,6 @@
 #include "GenreTable.h"
 #include "DateTime.h"
 
-using namespace std;
 
 #define DEFAULTFRAMESPERSECOND 25.0
 #define MAXPRIORITY 99
@@ -35,27 +34,27 @@ class cRecording
 private:
   int m_Index;
   int m_channelID;
-  string m_channelName;
-  string m_filePath;          ///< The full recording path as returned by the backend
-  string m_basePath;          ///< The base path shared by all recordings (to be determined from the Card settings)
-  string m_directory;         ///< An optional subdirectory below the basePath
-  string m_fileName;          ///< The recording filename without path
-  string m_stream;
-  string m_originalurl;
+  std::string m_channelName;
+  std::string m_filePath;          ///< The full recording path as returned by the backend
+  std::string m_basePath;          ///< The base path shared by all recordings (to be determined from the Card settings)
+  std::string m_directory;         ///< An optional subdirectory below the basePath
+  std::string m_fileName;          ///< The recording filename without path
+  std::string m_stream;
+  std::string m_originalurl;
   MPTV::CDateTime m_startTime;
   MPTV::CDateTime m_endTime;
   int m_duration;
-  string m_title;             // Title of this event
-  string m_description;       // Description of this event
-  string m_episodeName;       // Short description of this event (typically the episode name in case of a series)
-  string m_seriesNumber;
-  string m_episodeNumber;
-  string m_episodePart;
+  std::string m_title;             // Title of this event
+  std::string m_description;       // Description of this event
+  std::string m_episodeName;       // Short description of this event (typically the episode name in case of a series)
+  std::string m_seriesNumber;
+  std::string m_episodeNumber;
+  std::string m_episodePart;
   int m_scheduleID;
   int m_keepUntil;
   MPTV::CDateTime m_keepUntilDate; ///< MediaPortal keepUntilDate
   CCards* m_cardSettings;          ///< Pointer to the MediaPortal card settings. Will be used to determine the base path of the recordings
-  string m_genre;
+  std::string m_genre;
   int m_genre_type;
   int m_genre_subtype;
   bool m_isRecording;
@@ -104,7 +103,7 @@ public:
   /**
    * \brief Override the directory where this recording is stored
    */
-  //void SetDirectory( string& directory );
+  //void SetDirectory( std::string& directory );
 
   /**
    * \brief The RTSP stream URL for this recording (hostname resolved to IP-address)

--- a/addons/pvr.mediaportal.tvserver/src/utils.h
+++ b/addons/pvr.mediaportal.tvserver/src/utils.h
@@ -27,13 +27,12 @@
 #include "windows/WindowsUtils.h"
 #endif
 
-using namespace std;
 
 /**
  * String tokenize
  * Split string using the given delimiter into a vector of substrings
  */
-void Tokenize(const string& str, vector<string>& tokens, const string& delimiters);
+void Tokenize(const std::string& str, std::vector<std::string>& tokens, const std::string& delimiters);
 
 std::wstring StringToWString(const std::string& s);
 std::string WStringToString(const std::wstring& s);

--- a/addons/pvr.mythtv/addon/changelog.txt
+++ b/addons/pvr.mythtv/addon/changelog.txt
@@ -1,5 +1,6 @@
 v1.11.4
 - Updated language files from Transifex
+- Minor changes to conform with C++11
 
 v1.11.3
 - Updated language files from Transifex

--- a/addons/pvr.mythtv/src/demux.cpp
+++ b/addons/pvr.mythtv/src/demux.cpp
@@ -287,7 +287,7 @@ bool Demux::SeekTime(int time, bool backwards, double* startpts)
   int64_t desired = m_curTime + offset;
 
   if (g_bExtraDebug)
-    XBMC->Log(LOG_DEBUG, LOGTAG"%s: bw:%d tm:%d tm_pts:%"PRId64" c_pts:%"PRIu64" offset:%+6.3f c_tm:%+6.3f n_tm:%+6.3f", __FUNCTION__,
+    XBMC->Log(LOG_DEBUG, LOGTAG"%s: bw:%d tm:%d tm_pts:%" PRId64 " c_pts:%" PRIu64 " offset:%+6.3f c_tm:%+6.3f n_tm:%+6.3f", __FUNCTION__,
             backwards, time, pts, m_PTS, (double)offset / PTS_TIME_BASE, (double)m_curTime / PTS_TIME_BASE, (double)desired / PTS_TIME_BASE);
 
   CLockObject lock(m_mutex);
@@ -301,7 +301,7 @@ bool Demux::SeekTime(int time, bool backwards, double* startpts)
     int64_t new_time = it->first;
     uint64_t new_pos = it->second.av_pos;
     uint64_t new_pts = it->second.av_pts;
-    XBMC->Log(LOG_DEBUG, LOGTAG"seek to %"PRId64" pts=%"PRIu64, new_time, new_pts);
+    XBMC->Log(LOG_DEBUG, LOGTAG"seek to %" PRId64 " pts=%" PRIu64, new_time, new_pts);
 
     Flush();
     m_AVContext->GoPosition(new_pos);

--- a/addons/pvr.nextpvr/addon/changelog.txt
+++ b/addons/pvr.nextpvr/addon/changelog.txt
@@ -1,5 +1,6 @@
 v1.9.20
 - updated language files from Transifex
+- minor changes to conform with C++11
 
 v1.9.19
 - added getBackendHostname function

--- a/addons/pvr.nextpvr/src/Socket.h
+++ b/addons/pvr.nextpvr/src/Socket.h
@@ -18,9 +18,6 @@
  */
 #pragma once
 
-namespace NextPVR 
-{
-
 //Include platform specific datatypes, header files, defines and constants:
 #if defined TARGET_WINDOWS
   #define WIN32_LEAN_AND_MEAN           // Enable LEAN_AND_MEAN support
@@ -70,6 +67,9 @@ namespace NextPVR
 using namespace std;
 
 #include <vector>
+
+namespace NextPVR
+{
 
 #define MAXCONNECTIONS 1  ///< Maximum number of pending connections before "Connection refused"
 #define MAXRECV 1500      ///< Maximum packet size

--- a/addons/pvr.nextpvr/src/Socket.h
+++ b/addons/pvr.nextpvr/src/Socket.h
@@ -64,7 +64,6 @@
   #error Platform specific socket support is not yet available on this platform!
 #endif
 
-using namespace std;
 
 #include <vector>
 
@@ -278,7 +277,7 @@ class Socket
 
     bool set_non_blocking ( const bool );
 
-    bool ReadResponse (int &code, vector<string> &lines);
+    bool ReadResponse (int &code, std::vector<std::string> &lines);
 
     bool is_valid() const;
 

--- a/addons/pvr.njoy/addon/addon.xml.in
+++ b/addons/pvr.njoy/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.njoy"
-  version="1.9.14"
+  version="1.9.15"
   name="Njoy N7 PVR Client"
   provider-name="Team XBMC">
   <requires>

--- a/addons/pvr.vdr.vnsi/addon/addon.xml.in
+++ b/addons/pvr.vdr.vnsi/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="1.9.26"
+  version="1.9.27"
   name="VDR VNSI Client"
   provider-name="FernetMenta, Team XBMC">
   <requires>

--- a/addons/pvr.vuplus/addon/changelog.txt
+++ b/addons/pvr.vuplus/addon/changelog.txt
@@ -1,5 +1,6 @@
 1.9.22
 - updated language files from Transifex
+- minor changes to conform with C++11
 
 1.9.21
 - added getBackendHostname function

--- a/addons/pvr.wmc/addon/changelog.txt
+++ b/addons/pvr.wmc/addon/changelog.txt
@@ -1,5 +1,6 @@
 0.4.2
 - Updated Language files from Transifex
+- Minor changes to conform with C++11
 
 0.4.001
 - Kodi 15 versions will now be numbered 0.4.*

--- a/addons/pvr.wmc/src/Socket.h
+++ b/addons/pvr.wmc/src/Socket.h
@@ -68,7 +68,6 @@
   #error Platform specific socket support is not yet available on this platform!
 #endif
 
-using namespace std;
 
 #include <vector>
 
@@ -230,7 +229,7 @@ class Socket
 
     bool set_non_blocking ( const bool );
 
-    bool ReadResponses(int &code, vector<CStdString> &lines);
+    bool ReadResponses(int &code, std::vector<CStdString> &lines);
 
     bool is_valid() const;
 

--- a/addons/pvr.wmc/src/pvr2wmc.h
+++ b/addons/pvr.wmc/src/pvr2wmc.h
@@ -80,8 +80,8 @@ public:
 	PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus);
 	
 	bool CheckErrorOnServer();
-	void TriggerUpdates(vector<CStdString> results);
-	void ExtractDriveSpace(vector<CStdString> results);
+	void TriggerUpdates(std::vector<CStdString> results);
+	void ExtractDriveSpace(std::vector<CStdString> results);
 
 private:
 	int _serverBuild;

--- a/lib/libhts/htsmsg.c
+++ b/lib/libhts/htsmsg.c
@@ -397,7 +397,7 @@ htsmsg_field_get_string(htsmsg_field_t *f)
   case HMF_STR:
     break;
   case HMF_S64:
-    snprintf(buf, sizeof(buf), "%"PRId64, f->hmf_s64);
+    snprintf(buf, sizeof(buf), "%" PRId64, f->hmf_s64);
     f->hmf_str = strdup(buf);
     f->hmf_type = HMF_STR;
     break;

--- a/lib/platform/sockets/tcp.h
+++ b/lib/platform/sockets/tcp.h
@@ -34,7 +34,6 @@
 
 #include "socket.h"
 
-using namespace std;
 
 namespace PLATFORM
 {


### PR DESCRIPTION
as the topic says - basically c++11 wants us to have spaces around concatinated string constants in defines and also there is an offending std::bind which has a strange priority in c++11 now so we need to explicitly name the namespace we wanna have.