### PR TITLE
[pvr.wmc] Backport I*** changes to Helix branch

### DIFF
--- a/addons/pvr.wmc/addon/changelog.txt
+++ b/addons/pvr.wmc/addon/changelog.txt
@@ -1,3 +1,7 @@
+0.3.109
+- tidy up display of PVR data for Kodi (connection string, backend drive space total/used)
+- add support for accepting HDHR streaming URLs for channels
+
 0.3.108
 - Updated Language files from Transifex
 

--- a/addons/pvr.wmc/addon/changelog.txt
+++ b/addons/pvr.wmc/addon/changelog.txt
@@ -1,3 +1,6 @@
+0.3.110
+- fix stuttering when using new ServerWMC streams of completed WTV recordings
+
 0.3.109
 - tidy up display of PVR data for Kodi (connection string, backend drive space total/used)
 - add support for accepting HDHR streaming URLs for channels

--- a/addons/pvr.wmc/src/client.cpp
+++ b/addons/pvr.wmc/src/client.cpp
@@ -354,15 +354,17 @@ extern "C" {
 
 	const char *GetConnectionString(void)
 	{
-		static CStdString strConnectionString = "connected";
+		static CStdString strConnectionString;
+		strConnectionString.Format("%s:%u", g_strServerName, g_port);
 		return strConnectionString.c_str();
 	}
 
 	PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
 	{
-		*iTotal = 1024 * 1024 * 1024;
-		*iUsed  = 0;
-		return PVR_ERROR_NO_ERROR;
+		if (_wmc)
+			return _wmc->GetDriveSpace(iTotal, iUsed);
+
+		return PVR_ERROR_SERVER_ERROR;
 	}
 
 	PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)

--- a/addons/pvr.wmc/src/clientversion.h
+++ b/addons/pvr.wmc/src/clientversion.h
@@ -23,5 +23,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.3.109";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
+	return "0.3.110";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
 }

--- a/addons/pvr.wmc/src/clientversion.h
+++ b/addons/pvr.wmc/src/clientversion.h
@@ -23,5 +23,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.3.107";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
+	return "0.3.109";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
 }

--- a/addons/pvr.wmc/src/pvr2wmc.cpp
+++ b/addons/pvr.wmc/src/pvr2wmc.cpp
@@ -1176,12 +1176,15 @@ long long Pvr2Wmc::ActualFileSize(int count)
 }
 
 // return the length of the current stream file
-long long Pvr2Wmc::LengthLiveStream(void) 
+long long Pvr2Wmc::LengthLiveStream(void)
 {
 	if (_insertDurationHeader)			// if true, return a fake file 2Mb length to xbmc, this makes xbmc try to determine
 		return FAKE_TS_LENGTH;			// the ts time duration giving us a chance to insert the real duration
 	if (_lastStreamSize > 0)
 		return _lastStreamSize;
+	if (_streamWTV)
+		return XBMC->GetFileLength(_streamFile);
+
 	return -1;
 }
 

--- a/addons/pvr.wmc/src/pvr2wmc.h
+++ b/addons/pvr.wmc/src/pvr2wmc.h
@@ -35,6 +35,7 @@ public:
 	virtual bool IsServerDown();
 	virtual void UnLoading();
 	const char *GetBackendVersion(void);
+	virtual PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed);
 
 	// channels
 	virtual int GetChannelsAmount(void);
@@ -80,6 +81,7 @@ public:
 	
 	bool CheckErrorOnServer();
 	void TriggerUpdates(vector<CStdString> results);
+	void ExtractDriveSpace(vector<CStdString> results);
 
 private:
 	int _serverBuild;
@@ -87,6 +89,9 @@ private:
 	CStdString Channel2String(const PVR_CHANNEL &xTmr);
 
 	Socket _socketClient;
+
+	long long _diskTotal;
+	long long _diskUsed;
 
 	int _signalStatusCount;				// call backend for signal status every N calls (because XBMC calls every 1 second!)
 	bool _discardSignalStatus;			// flag to discard signal status for channels where the backend had an error


### PR DESCRIPTION
Backport latest pvr.wmc changes for Helix point release

- fix stuttering when using new ServerWMC streams of completed WTV recordings
- tidy up display of PVR data for Kodi (connection string, backend drive space total/used)
- add support for accepting HDHR streaming URLs for channels