### PR TITLE
Fix Windows build

### DIFF
--- a/lib/platform/threads/mutex.h
+++ b/lib/platform/threads/mutex.h
@@ -266,7 +266,7 @@ namespace PLATFORM
 
         while (!bReturn)
         {
-          if ((bReturn = callback(param)))
+          if ((bReturn = callback(param)) == true)
             break;
           uint32_t iMsLeft = timeout.TimeLeft();
           if ((iTimeout != 0) && (iMsLeft == 0))


### PR DESCRIPTION
Visual Studio doesn't like implicitly comparing an assignment in a
conditional statement

@FernetMenta @margro this should fix it
