### PR TITLE
[pvr.hts] convert timeouts to milliseconds once so we don't accidentally

### DIFF
--- a/addons/pvr.hts/addon/addon.xml.in
+++ b/addons/pvr.hts/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.hts"
-  version="2.0.3"
+  version="2.0.4"
   name="Tvheadend HTSP Client"
   provider-name="Adam Sutton, Sam Stenvall, Lars Op den Kamp">
   <requires>

--- a/addons/pvr.hts/addon/changelog.txt
+++ b/addons/pvr.hts/addon/changelog.txt
@@ -1,3 +1,6 @@
+2.0.4
+- added a missing commit that somehow got lost when making v2.0.3
+
 2.0.3
 - rebrand of HTSP client identifier
 - improve the VFS slightly by doing reading and buffering on separate threads, as well as tweaking the read length

--- a/addons/pvr.hts/src/AsyncState.cpp
+++ b/addons/pvr.hts/src/AsyncState.cpp
@@ -32,7 +32,7 @@ using namespace PLATFORM;
 AsyncState::AsyncState(int timeout)
 {
   m_state   = ASYNC_NONE;
-  m_timeout = timeout * 1000;
+  m_timeout = timeout;
 }
 
 void AsyncState::SetState(eAsyncState state)

--- a/addons/pvr.hts/src/HTSPConnection.cpp
+++ b/addons/pvr.hts/src/HTSPConnection.cpp
@@ -133,7 +133,7 @@ bool CHTSPConnection::WaitForConnection ( void )
 {
   if (!m_ready) {
     tvhtrace("waiting for registration...");
-    m_regCond.Wait(m_mutex, m_ready, tvh->GetSettings().iConnectTimeout * 1000);
+    m_regCond.Wait(m_mutex, m_ready, tvh->GetSettings().iConnectTimeout);
   }
   return m_ready;
 }
@@ -214,7 +214,7 @@ bool CHTSPConnection::ReadMessage ( void )
   cnt = 0;
   while (cnt < len)
   {
-    r = m_socket->Read((char*)buf + cnt, len - cnt, tvh->GetSettings().iResponseTimeout * 1000);
+    r = m_socket->Read((char*)buf + cnt, len - cnt, tvh->GetSettings().iResponseTimeout);
     if (r < 0)
     {
       tvherror("failed to read packet (%s)",
@@ -327,7 +327,7 @@ htsmsg_t *CHTSPConnection::SendAndWait0 ( const char *method, htsmsg_t *msg, int
   }
 
   /* Wait for response */
-  msg = resp.Get(m_mutex, iResponseTimeout * 1000);
+  msg = resp.Get(m_mutex, iResponseTimeout);
   m_messages.erase(seq);
   if (!msg)
   {
@@ -506,7 +506,7 @@ void* CHTSPConnection::Process ( void )
     CStdString host = settings.strHostname;
     int port, timeout;
     port = settings.iPortHTSP;
-    timeout = settings.iConnectTimeout * 1000;
+    timeout = settings.iConnectTimeout;
 
     /* Create socket (ensure mutex protection) */
     {

--- a/addons/pvr.hts/src/HTSPDemuxer.cpp
+++ b/addons/pvr.hts/src/HTSPDemuxer.cpp
@@ -166,7 +166,7 @@ bool CHTSPDemuxer::Seek
   htsmsg_destroy(m);
 
   /* Wait for time */
-  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, tvh->GetSettings().iResponseTimeout * 1000))
+  if (!m_seekCond.Wait(m_conn.Mutex(), m_seekTime, tvh->GetSettings().iResponseTimeout))
   {
     tvherror("failed to get subscriptionSeek response");
     return false;

--- a/addons/pvr.hts/src/client.cpp
+++ b/addons/pvr.hts/src/client.cpp
@@ -137,10 +137,14 @@ ADDON_STATUS ADDON_Create(void* hdl, void* _unused(props))
   settings.iPortHTTP = g_iPortHTTP;
   settings.strUsername = g_strUsername;
   settings.strPassword = g_strPassword;
-  settings.iConnectTimeout = g_iConnectTimeout;
-  settings.iResponseTimeout = g_iResponseTimeout;
   settings.bTraceDebug = g_bTraceDebug;
   settings.bAsyncEpg = g_bAsyncEpg;
+
+  /* Timeouts are defined in seconds but we expect them to be in milliseconds. 
+     Furthermore, the value from the settings is actually the index of the 
+     selected value, which is zero-based, so we need to increment by one. */
+  settings.iConnectTimeout = (g_iConnectTimeout + 1) * 1000;
+  settings.iResponseTimeout = (g_iResponseTimeout + 1) * 1000;
 
   tvh = new CTvheadend(settings);
   tvh->Start();


### PR DESCRIPTION
pass e.g. 5 milliseconds to a wait function. Also fix an ancient bug
where the timeouts were one second less than the value specified

I screwed something up when pushing this last night and the commit got lost, which completely broke the addon.