### PR TITLE
[pvr.wmc] fixup version bump

### DIFF
--- a/addons/pvr.wmc/addon/addon.xml.in
+++ b/addons/pvr.wmc/addon/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.wmc"
-  version="0.4.2"
+  version="0.4.002"
   name="PVR WMC Client"
   provider-name="KrustyReturns and scarecrow420">
   <requires>

--- a/addons/pvr.wmc/addon/changelog.txt
+++ b/addons/pvr.wmc/addon/changelog.txt
@@ -1,4 +1,4 @@
-0.4.2
+﻿0.4.002
 - Updated Language files from Transifex
 - Minor changes to conform with C++11
 

--- a/addons/pvr.wmc/src/clientversion.h
+++ b/addons/pvr.wmc/src/clientversion.h
@@ -23,5 +23,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.4.001";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
+	return "0.4.002";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
 }


### PR DESCRIPTION
Fixes the pvr.wmc versions after transfiex updates didnt set version number in clientversion.h or follow existing 3 digit minor version padding