### PR TITLE
Fixed RPi no tuner, and recording list getting out of date

### DIFF
--- a/addons/pvr.nextpvr/addon/addon.xml.in
+++ b/addons/pvr.nextpvr/addon/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.nextpvr"
-  version="1.9.19"
+  version="1.9.20"
   name="NextPVR PVR Client"
   provider-name="Graeme Blackley">
   <requires>

--- a/addons/pvr.nextpvr/addon/changelog.txt
+++ b/addons/pvr.nextpvr/addon/changelog.txt
@@ -1,3 +1,7 @@
+v1.9.20
+- fixed issue where RPi user were unable to watch live tv due to subtle differences on that platform
+- fixed issue where recording list would get out of date and not reflect reality of backend
+
 v1.9.19
 - added support for ATSC subchannel numbers, fixing 'no tuner available' message users were getting with this type of channel
 - fixes a problem with playback of radio stations

--- a/addons/pvr.nextpvr/src/RingBuffer.cpp
+++ b/addons/pvr.nextpvr/src/RingBuffer.cpp
@@ -128,7 +128,7 @@ bool CRingBuffer::ReadData(CRingBuffer &rBuf, unsigned int size)
 /* Write data to ring buffer from buffer specified in 'buf'. Amount read in is
  * specified by 'size'.
  */
-bool CRingBuffer::WriteData(char *buf, unsigned int size)
+bool CRingBuffer::WriteData(const char *buf, unsigned int size)
 {
   if (size > m_size - m_fillCount)
   {
@@ -225,7 +225,7 @@ unsigned int CRingBuffer::getSize()
   return m_size;
 }
 
-unsigned int CRingBuffer::getReadPtr()
+unsigned int CRingBuffer::getReadPtr() const
 {
   return m_readPtr;
 }

--- a/addons/pvr.nextpvr/src/RingBuffer.h
+++ b/addons/pvr.nextpvr/src/RingBuffer.h
@@ -37,14 +37,14 @@ public:
   void Clear();
   bool ReadData(char *buf, unsigned int size);
   bool ReadData(CRingBuffer &rBuf, unsigned int size);
-  bool WriteData(char *buf, unsigned int size);
+  bool WriteData(const char *buf, unsigned int size);
   bool WriteData(CRingBuffer &rBuf, unsigned int size);
   bool SkipBytes(int skipSize);
   bool Append(CRingBuffer &rBuf);
   bool Copy(CRingBuffer &rBuf);
   char *getBuffer();
   unsigned int getSize();
-  unsigned int getReadPtr();
+  unsigned int getReadPtr() const;
   unsigned int getWritePtr();
   unsigned int getMaxReadSize();
   unsigned int getMaxWriteSize();

--- a/addons/pvr.nextpvr/src/Socket.cpp
+++ b/addons/pvr.nextpvr/src/Socket.cpp
@@ -19,6 +19,8 @@
 #include "libXBMC_addon.h"
 #include <string>
 #include "platform/os.h"
+#include "platform/util/timeutils.h"
+
 #include "client.h"
 #include "Socket.h"
 
@@ -214,8 +216,15 @@ int Socket::send ( const std::string& data )
   {
     return 0;
   }
-
-  int status = Socket::send( (const char*) data.c_str(), (const unsigned int) data.size());
+  int status = 0;
+  do 
+  {
+    status = Socket::send( (const char*) data.c_str(), (const unsigned int) data.size());    
+#if defined(TARGET_WINDOWS)
+  } while (status == SOCKET_ERROR && errno == WSAEWOULDBLOCK);
+#else
+  } while (status == SOCKET_ERROR && errno == EAGAIN);
+#endif
 
   return status;
 }
@@ -249,10 +258,15 @@ int Socket::send ( const char* data, const unsigned int len )
     _sd = INVALID_SOCKET;
     return 0;
   }
-
-  int status = ::send(_sd, data, len, 0 );
-
-  if (status == -1)
+  int status = 0;
+  do {
+    status = ::send(_sd, data, len, 0 );
+#if defined(TARGET_WINDOWS)
+  } while (status == SOCKET_ERROR && errno == WSAEWOULDBLOCK);
+#else
+  } while (status == SOCKET_ERROR && errno == EAGAIN);
+#endif
+  if (status == SOCKET_ERROR)
   {
     errormessage( getLastError(), "Socket::send");
     XBMC->Log(LOG_ERROR, "Socket::send  - failed to send data");
@@ -436,11 +450,18 @@ int Socket::receive ( char* data, const unsigned int buffersize, const unsigned 
       int lasterror = getLastError();
 #if defined(TARGET_WINDOWS)
       if ( lasterror != WSAEWOULDBLOCK)
-        errormessage( lasterror, "Socket::receive" );
 #else
-      if ( lasterror != EAGAIN && lasterror != EWOULDBLOCK )
-        errormessage( lasterror, "Socket::receive" );
+      if ( lasterror != EAGAIN )
 #endif
+      {
+        errormessage( lasterror, "Socket::receive" );
+      }
+      else
+      {
+	XBMC->Log(LOG_ERROR, "Socket::read EAGAIN");
+        usleep(50000);
+	continue;
+      }
       return status;
     }
 

--- a/addons/pvr.nextpvr/src/pvrclient-nextpvr.h
+++ b/addons/pvr.nextpvr/src/pvrclient-nextpvr.h
@@ -134,6 +134,8 @@ private:
   CStdString              m_PlaybackURL;
   LiveShiftSource        *m_pLiveShiftSource;
 
+  int64_t m_lastRecordingUpdateTime;
+
   char                    m_sid[64];
 
   int                     m_iChannelCount;  


### PR DESCRIPTION
- fixed problem where RPi users would get 'tuner no longer available' messages due to subtle socket differences on this platform
- fixed problem where recording list would get out of date