### PR TITLE
[pvr.hts] Fix dvr delete response timeout value. Must be msecs, not secs...

### DIFF
--- a/addons/pvr.hts/src/Tvheadend.cpp
+++ b/addons/pvr.hts/src/Tvheadend.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <sstream>
+#include <algorithm>
 #include "Tvheadend.h"
 
 #include "platform/util/util.h"
@@ -258,7 +259,8 @@ PVR_ERROR CTvheadend::SendDvrDelete ( uint32_t id, const char *method )
   htsmsg_add_u32(m, "id", id);
 
   /* Send and wait a bit longer than usual */
-  if ((m = m_conn.SendAndWait(method, m, 30)) == NULL)
+  if ((m = m_conn.SendAndWait(method, m,
+            std::max(30000, tvh->GetSettings().iResponseTimeout))) == NULL)
     return PVR_ERROR_SERVER_ERROR;
 
   /* Check for error */


### PR DESCRIPTION
Followup to #415. 

@jalle19: Yesterday I've learned from Kodi that deleting recordings within 30 msecs is not really working. ;-)