### PR TITLE
vnsi: exit osd window on vdr osd close

### DIFF
--- a/addons/pvr.vdr.vnsi/addon/addon.xml.in
+++ b/addons/pvr.vdr.vnsi/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.vdr.vnsi"
-  version="1.9.27"
+  version="1.9.28"
   name="VDR VNSI Client"
   provider-name="FernetMenta, Team XBMC">
   <requires>

--- a/addons/pvr.vdr.vnsi/src/VNSIAdmin.cpp
+++ b/addons/pvr.vdr.vnsi/src/VNSIAdmin.cpp
@@ -1356,6 +1356,7 @@ bool cVNSIAdmin::OnResponsePacket(cResponsePacket* resp)
         m_osdRender->DisposeTexture(wnd);
       m_bIsOsdDirty = true;
       m_osdMutex.Unlock();
+      m_window->SetFocusId(CONTROL_MENU);
     }
     else if (resp->getOpCodeID() == VNSI_OSD_MOVEWINDOW)
     {


### PR DESCRIPTION
... because lot of remotes dont have "i" maped, or its not
easy to map, so now "back" in vdr main menu exits osd window.

//cc @FernetMenta