### PR TITLE
platform posix: fix memory leak in pthread

### DIFF
--- a/lib/platform/threads/threads.h
+++ b/lib/platform/threads/threads.h
@@ -129,6 +129,8 @@ namespace PLATFORM
         bReturn = true;
       }
 
+      if (bRunning && bReturn)
+        ThreadsWait(m_thread, NULL);
       return bReturn;
     }
 


### PR DESCRIPTION
==14096== 864 bytes in 3 blocks are possibly lost in loss record 2 of 2
==14096==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==14096==    by 0x4012E54: _dl_allocate_tls (dl-tls.c:296)
==14096==    by 0x4E3FDA0: pthread_create@@GLIBC_2.2.5 (allocatestack.c:589)
==14096==    by 0x46110C: PLATFORM::CThread::CreateThread(bool)

If you create a joinable thread but forget to join it, its resources or private memory
are always kept in the process space and never reclaimed.
Always join the joinable threads.