### PR TITLE
[api change] Series recording support 

### DIFF
--- a/addons/pvr.argustv/src/client.cpp
+++ b/addons/pvr.argustv/src/client.cpp
@@ -527,7 +527,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   return g_client->DeleteTimer(timer, bForceDelete);
 }

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -913,7 +913,7 @@ PVR_ERROR cPVRClientArgusTV::GetTimers(ADDON_HANDLE handle)
       tag.strSummary[0]     = '\0';
       tag.iPriority         = 0;
       tag.iLifetime         = 0;
-      tag.bIsRepeating      = false;
+      tag.iTimerType        = PVR_TIMERTYPE_MANUAL_ONCE;
       tag.firstDay          = 0;
       tag.iWeekdays         = 0;
       tag.iEpgUid           = 0;

--- a/addons/pvr.demo/addon/PVRDemoAddonSettings.xml
+++ b/addons/pvr.demo/addon/PVRDemoAddonSettings.xml
@@ -611,31 +611,44 @@
         <channelid>1</channelid>
         <starttime>03:15</starttime>
         <endtime>04:45</endtime>
-        <state>0</state>
+        <state>1</state>
+        <type>-1</type>
         <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</summary>
     </timer>
     <timer>
         <title>Demo Timer entry #2</title>
+        <channelid>1</channelid>
+        <starttime>04:15</starttime>
+        <endtime>05:30</endtime>
+        <state>1</state>
+        <type>-2</type>
+        <summary>Manual timer</summary>
+    </timer>
+    <timer>
+        <title>Demo Timer entry #3</title>
         <channelid>2</channelid>
         <starttime>07:10</starttime>
         <endtime>09:55</endtime>
         <state>1</state>
-        <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</summary>
-    </timer>
-    <timer>
-        <title>Demo Timer entry #3</title>
-        <channelid>3</channelid>
-        <starttime>10:00</starttime>
-        <endtime>11:15</endtime>
-        <state>2</state>
+        <type>1</type>
         <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</summary>
     </timer>
     <timer>
         <title>Demo Timer entry #4</title>
+        <channelid>3</channelid>
+        <starttime>10:00</starttime>
+        <endtime>11:15</endtime>
+        <state>2</state>
+        <type>2</type>
+        <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</summary>
+    </timer>
+    <timer>
+        <title>Demo Timer entry #5</title>
         <channelid>4</channelid>
         <starttime>15:00</starttime>
         <endtime>16:45</endtime>
         <state>3</state>
+        <type>3</type>
         <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam cursus consectetur ipsum, eu tincidunt dui aliquam ac. Sed scelerisque, augue eu lacinia ultrices, libero ante ullamcorper augue, vel malesuada justo risus ac nulla. Quisque ac libero libero. Sed tincidunt, orci eu condimentum laoreet, felis odio mattis est, et lacinia metus enim in leo. Fusce faucibus tristique risus in varius. Etiam sagittis venenatis ligula nec rutrum. Etiam gravida dictum hendrerit. Sed sodales felis in sapien rutrum non malesuada nisi lobortis. Mauris iaculis ante odio. Nunc gravida erat convallis purus dignissim et ultricies orci dapibus. Aliquam erat volutpat. Vestibulum mi felis, malesuada ac tincidunt sit amet, pulvinar nec dolor. Pellentesque vehicula est vulputate mi adipiscing euismod. Donec ac mauris nulla. Nullam suscipit felis eu quam sodales ac bibendum nisi interdum. Curabitur non lectus a ante venenatis semper eget id justo. Ut facilisis, ligula pretium dictum congue, lacus dolor commodo nibh, sit amet sodales sed.</summary>
     </timer>
   </timers>

--- a/addons/pvr.demo/addon/resources/language/English/strings.po
+++ b/addons/pvr.demo/addon/resources/language/English/strings.po
@@ -1,0 +1,32 @@
+# Kodi Media Center language file
+# Addon Name: PVR Demo Client
+# Addon id: pvr.demo
+# Addon Provider: 
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Main\n"
+"Report-Msgid-Bugs-To: http://trac.xbmc.org/\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-main/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#serie record labels
+
+msgctxt "#1"
+msgid "Weekly at this time"
+msgstr ""
+
+msgctxt "#2"
+msgid "Daily at this time"
+msgstr ""
+
+msgctxt "#3"
+msgid "Every time"
+msgstr ""
+

--- a/addons/pvr.demo/src/PVRDemoData.cpp
+++ b/addons/pvr.demo/src/PVRDemoData.cpp
@@ -558,6 +558,7 @@ PVR_ERROR PVRDemoData::GetTimers(ADDON_HANDLE handle)
     xbmcTimer.startTime         = timer.startTime;
     xbmcTimer.endTime           = timer.endTime;
     xbmcTimer.state             = timer.state;
+    xbmcTimer.iTimerType        = PVR_TIMERTYPE_MANUAL_ONCE;
 
     strncpy(xbmcTimer.strTitle, timer.strTitle.c_str(), sizeof(timer.strTitle) - 1);
     strncpy(xbmcTimer.strSummary, timer.strSummary.c_str(), sizeof(timer.strSummary) - 1);

--- a/addons/pvr.demo/src/PVRDemoData.cpp
+++ b/addons/pvr.demo/src/PVRDemoData.cpp
@@ -296,6 +296,12 @@ bool PVRDemoData::LoadDemoData(void)
       time_t timeNow = time(NULL);
       struct tm* now = localtime(&timeNow);
 
+      /* type */
+      if (XMLUtils::GetInt(pTimerNode, "type", iTmp))
+        timer.iTimerType = iTmp;
+      else
+        timer.iTimerType = PVR_TIMERTYPE_EPG_ONCE;
+
       /* channel id */
       if (!XMLUtils::GetInt(pTimerNode, "channelid", iTmp))
         continue;
@@ -342,7 +348,7 @@ bool PVRDemoData::LoadDemoData(void)
         }
       }
 
-      XBMC->Log(LOG_DEBUG, "loaded timer '%s' channel '%d' start '%d' end '%d'", timer.strTitle.c_str(), timer.iChannelId, timer.startTime, timer.endTime);
+      XBMC->Log(LOG_DEBUG, "loaded timer '%s' channel '%d' start '%d' end '%d' timer type '%i'", timer.strTitle.c_str(), timer.iChannelId, timer.startTime, timer.endTime, timer.iTimerType);
       m_timers.push_back(timer);
     }
   }
@@ -558,10 +564,10 @@ PVR_ERROR PVRDemoData::GetTimers(ADDON_HANDLE handle)
     xbmcTimer.startTime         = timer.startTime;
     xbmcTimer.endTime           = timer.endTime;
     xbmcTimer.state             = timer.state;
-    xbmcTimer.iTimerType        = PVR_TIMERTYPE_MANUAL_ONCE;
+    xbmcTimer.iTimerType        = timer.iTimerType;
 
-    strncpy(xbmcTimer.strTitle, timer.strTitle.c_str(), sizeof(timer.strTitle) - 1);
-    strncpy(xbmcTimer.strSummary, timer.strSummary.c_str(), sizeof(timer.strSummary) - 1);
+    strncpy(xbmcTimer.strTitle, timer.strTitle.c_str(), sizeof(xbmcTimer.strTitle) - 1);
+    strncpy(xbmcTimer.strSummary, timer.strSummary.c_str(), sizeof(xbmcTimer.strSummary) - 1);
 
     PVR->TransferTimerEntry(handle, &xbmcTimer);
   }

--- a/addons/pvr.demo/src/PVRDemoData.h
+++ b/addons/pvr.demo/src/PVRDemoData.h
@@ -78,6 +78,7 @@ struct PVRDemoRecording
 struct PVRDemoTimer
 {
   int             iChannelId;
+  int             iTimerType;
   time_t          startTime;
   time_t          endTime;
   PVR_TIMER_STATE state;

--- a/addons/pvr.demo/src/client.cpp
+++ b/addons/pvr.demo/src/client.cpp
@@ -85,6 +85,36 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   ADDON_ReadSettings();
 
+  // Weekly at this time
+  PVR_TIMERTYPE serie1;
+  serie1.iTypeId = 1;
+  serie1.iLocalizedStringId = 1;
+  serie1.bDependsNewEpisodes = true;
+  serie1.bDependsTime = true;
+  serie1.bDependsChannel = true;
+  serie1.bReadOnly = false;
+  PVR->AddTimerType(&serie1);
+
+  // Daily at this time
+  PVR_TIMERTYPE serie2;
+  serie2.iTypeId = 2;
+  serie2.iLocalizedStringId = 2;
+  serie2.bDependsNewEpisodes = false;
+  serie2.bDependsTime = true;
+  serie2.bDependsChannel = true;
+  serie2.bReadOnly = false;
+  PVR->AddTimerType(&serie2);
+
+  // Every time
+  PVR_TIMERTYPE serie3;
+  serie3.iTypeId = 3;
+  serie3.iLocalizedStringId = 3;
+  serie3.bDependsNewEpisodes = false;
+  serie3.bDependsTime = false;
+  serie3.bDependsChannel = true;
+  serie3.bReadOnly = true;
+  PVR->AddTimerType(&serie3);
+
   m_data = new PVRDemoData;
   m_CurStatus = ADDON_STATUS_OK;
   m_bCreated = true;

--- a/addons/pvr.demo/src/client.cpp
+++ b/addons/pvr.demo/src/client.cpp
@@ -354,7 +354,7 @@ PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &recording, int las
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &recording) { return -1; }
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }

--- a/addons/pvr.dvblink/src/DVBLinkClient.cpp
+++ b/addons/pvr.dvblink/src/DVBLinkClient.cpp
@@ -267,7 +267,7 @@ PVR_ERROR DVBLinkClient::GetTimers(ADDON_HANDLE handle)
     if (!rec->GetProgram().IsRecord)
       xbmcTimer.state = PVR_TIMER_STATE_CANCELLED;
 
-    xbmcTimer.bIsRepeating = rec->GetProgram().IsRepeatRecord;
+    xbmcTimer.iTimerType = rec->GetProgram().IsRepeatRecord ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE;
 
     xbmcTimer.iEpgUid = rec->GetProgram().GetStartTime();
     
@@ -360,7 +360,7 @@ PVR_ERROR DVBLinkClient::AddTimer(const PVR_TIMER &timer)
         time_t start_time = timer.startTime;
         time_t duration = timer.endTime - timer.startTime;
         long day_mask = 0;
-        if (timer.bIsRepeating)
+        if (timer.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE)
         {
             //change day mask to DVBLink server format (Sun - first day)
             bool bcarry = (timer.iWeekdays & 0x40) == 0x40;
@@ -409,7 +409,7 @@ PVR_ERROR DVBLinkClient::DeleteTimer(const PVR_TIMER &timer)
   parse_timer_hash(timer.strDirectory, timer_id, schedule_id);
 
   bool cancel_series = true;
-  if (timer.bIsRepeating)
+  if (timer.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE)
   {
       //show dialog and ask: cancel series or just this episode
       CDialogDeleteTimer vWindow(XBMC, GUI, cancel_series);

--- a/addons/pvr.dvblink/src/client.cpp
+++ b/addons/pvr.dvblink/src/client.cpp
@@ -629,7 +629,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return PVR_ERROR_FAILED;
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   if (dvblinkclient)
     return dvblinkclient->DeleteTimer(timer);

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -330,7 +330,7 @@ PVR_ERROR Dvb::GetTimers(ADDON_HANDLE handle)
     tag.endTime           = timer->endTime;
     tag.state             = timer->state;
     tag.iPriority         = timer->iPriority;
-    tag.bIsRepeating      = timer->bRepeating;
+    tag.iTimerType        = timer->bRepeating ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE;
     tag.firstDay          = timer->iFirstDay;
     tag.iWeekdays         = timer->iWeekdays;
     tag.iEpgUid           = timer->iEpgId;

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -429,7 +429,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return DvbData->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete))
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete), bool _UNUSED(bDeleteSchedule))
 {
   if (!DvbData || !DvbData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.filmon/src/PVRFilmonData.cpp
+++ b/addons/pvr.filmon/src/PVRFilmonData.cpp
@@ -356,7 +356,7 @@ PVR_ERROR PVRFilmonData::GetTimers(ADDON_HANDLE handle) {
 				xbmcTimer.startTime = timer.startTime;
 				xbmcTimer.endTime = timer.endTime;
 				xbmcTimer.state = (PVR_TIMER_STATE) timer.state;
-				xbmcTimer.bIsRepeating = timer.bIsRepeating;
+				xbmcTimer.iTimerType = timer.bIsRepeating ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE;
 				xbmcTimer.firstDay = timer.firstDay;
 				xbmcTimer.iWeekdays = timer.iWeekdays;
 				xbmcTimer.iEpgUid = timer.iEpgUid;

--- a/addons/pvr.filmon/src/client.cpp
+++ b/addons/pvr.filmon/src/client.cpp
@@ -336,7 +336,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer) {
 	return m_data->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) {
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule) {
 	if (!m_data)
 		return PVR_ERROR_SERVER_ERROR;
 

--- a/addons/pvr.hts/src/Tvheadend.cpp
+++ b/addons/pvr.hts/src/Tvheadend.cpp
@@ -535,7 +535,7 @@ PVR_ERROR CTvheadend::GetTimers ( ADDON_HANDLE handle )
       tmr.state             = rit->second.state;
       tmr.iPriority         = rit->second.priority;
       tmr.iLifetime         = rit->second.retention;
-      tmr.bIsRepeating      = false; // unused
+      tmr.iTimerType        = PVR_TIMERTYPE_MANUAL_ONCE;
       tmr.firstDay          = 0;     // unused
       tmr.iWeekdays         = 0;     // unused
       tmr.iEpgUid           = 0;     // unused

--- a/addons/pvr.hts/src/client.cpp
+++ b/addons/pvr.hts/src/client.cpp
@@ -517,7 +517,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return tvh->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   return tvh->DeleteTimer(timer, bForceDelete);
 }

--- a/addons/pvr.iptvsimple/src/client.cpp
+++ b/addons/pvr.iptvsimple/src/client.cpp
@@ -475,7 +475,7 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return 
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(ADDON_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }

--- a/addons/pvr.mediaportal.tvserver/src/client.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/client.cpp
@@ -727,7 +727,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
     return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   if (!g_client)
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.mediaportal.tvserver/src/timers.cpp
+++ b/addons/pvr.mediaportal.tvserver/src/timers.cpp
@@ -112,7 +112,7 @@ cTimer::cTimer(const PVR_TIMER& timerinfo)
 
   SetKeepMethod(timerinfo.iLifetime);
 
-  if(timerinfo.bIsRepeating)
+  if(timerinfo.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE)
   {
     m_schedtype = RepeatFlags2SchedRecType(timerinfo.iWeekdays);
     m_series = true;
@@ -180,7 +180,7 @@ void cTimer::GetPVRtimerinfo(PVR_TIMER &tag)
   }
   tag.iPriority         = Priority();
   tag.iLifetime         = GetLifetime();
-  tag.bIsRepeating      = Repeat();
+  tag.iTimerType        = Repeat() ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE;
   tag.iWeekdays         = RepeatFlags();
   tag.iMarginStart      = m_prerecordinterval;
   tag.iMarginEnd        = m_postrecordinterval;

--- a/addons/pvr.mythtv/src/client.cpp
+++ b/addons/pvr.mythtv/src/client.cpp
@@ -919,7 +919,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   if (g_client == NULL)
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.mythtv/src/pvrclient-mythtv.cpp
+++ b/addons/pvr.mythtv/src/pvrclient-mythtv.cpp
@@ -1229,7 +1229,7 @@ PVR_ERROR PVRClientMythTV::GetTimers(ADDON_HANDLE handle)
       tag.iMarginEnd = rule.EndOffset();
       tag.iMarginStart = rule.StartOffset();
       tag.firstDay = it->second->RecordingStartTime();
-      tag.bIsRepeating = meta.isRepeating;
+      tag.iTimerType = meta.isRepeating ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE;
       tag.iWeekdays = meta.weekDays;
       if (*(meta.marker))
         rulemarker.append("(").append(meta.marker).append(")");
@@ -1240,7 +1240,7 @@ PVR_ERROR PVRClientMythTV::GetTimers(ADDON_HANDLE handle)
       tag.iMarginEnd = 0;
       tag.iMarginStart = 0;
       tag.firstDay = 0;
-      tag.bIsRepeating = false;
+      tag.iTimerType = PVR_TIMERTYPE_MANUAL_ONCE;
       tag.iWeekdays = 0;
     }
 
@@ -1423,7 +1423,7 @@ MythRecordingRule PVRClientMythTV::PVRtoMythRecordingRule(const PVR_TIMER &timer
   }
 
   // Depending of timer type, create the best rule
-  if (timer.bIsRepeating)
+  if (timer.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE)
   {
     if (timer.iWeekdays < 0x7F && timer.iWeekdays > 0)
     {
@@ -1533,7 +1533,7 @@ PVR_ERROR PVRClientMythTV::UpdateTimer(const PVR_TIMER &timer)
   {
     if (old->second->iClientChannelUid != timer.iClientChannelUid)
       diffmask |= CTTimer;
-    if (old->second->bIsRepeating != timer.bIsRepeating || old->second->iWeekdays != timer.iWeekdays)
+    if (old->second->iTimerType != timer.iTimerType || old->second->iWeekdays != timer.iWeekdays)
       diffmask |= CTTimer;
     if (old->second->startTime != timer.startTime || old->second->endTime != timer.endTime)
       diffmask |= CTTimer;

--- a/addons/pvr.nextpvr/src/client.cpp
+++ b/addons/pvr.nextpvr/src/client.cpp
@@ -535,7 +535,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
     return g_client->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   if (!g_client)
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
+++ b/addons/pvr.nextpvr/src/pvrclient-nextpvr.cpp
@@ -989,7 +989,7 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
         
         PVR_STRCPY(tag.strSummary, "summary");
 
-        tag.bIsRepeating = true;
+        tag.iTimerType = PVR_TIMERTYPE_MANUAL_SERIE;
 
         // pass timer to xbmc
         PVR->TransferTimerEntry(handle, &tag);
@@ -1012,7 +1012,7 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
       {
         memset(&tag, 0, sizeof(tag));
 
-
+        tag.iTimerType = PVR_TIMERTYPE_MANUAL_ONCE;
         tag.iClientIndex = atoi(pRecordingNode->FirstChildElement("id")->FirstChild()->Value());
         tag.iClientChannelUid = atoi(pRecordingNode->FirstChildElement("channel_id")->FirstChild()->Value());
 
@@ -1049,7 +1049,7 @@ PVR_ERROR cPVRClientNextPVR::GetTimers(ADDON_HANDLE handle)
         {
           if (strcmp(pRecordingNode->FirstChildElement("recurring")->FirstChild()->Value(), "true") == 0)
           {
-            tag.bIsRepeating = true;
+            tag.iTimerType = PVR_TIMERTYPE_MANUAL_SERIE;
           }
         }
 

--- a/addons/pvr.njoy/src/client.cpp
+++ b/addons/pvr.njoy/src/client.cpp
@@ -288,7 +288,7 @@ PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return 
 int GetTimersAmount(void) { return -1; }
 PVR_ERROR GetTimers(ADDON_HANDLE handle) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR AddTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR UpdateTimer(const PVR_TIMER &timer) { return PVR_ERROR_NOT_IMPLEMENTED; }
 void DemuxAbort(void) {}
 DemuxPacket* DemuxRead(void) { return NULL; }

--- a/addons/pvr.vdr.vnsi/src/VNSIData.cpp
+++ b/addons/pvr.vdr.vnsi/src/VNSIData.cpp
@@ -395,7 +395,7 @@ PVR_ERROR cVNSIData::GetTimerInfo(unsigned int timernumber, PVR_TIMER &tag)
   tag.endTime           = vresp->extract_U32();
   tag.firstDay          = vresp->extract_U32();
   tag.iWeekdays         = vresp->extract_U32();
-  tag.bIsRepeating      = tag.iWeekdays == 0 ? false : true;
+  tag.iTimerType        = tag.iWeekdays == 0 ? PVR_TIMERTYPE_MANUAL_ONCE : PVR_TIMERTYPE_MANUAL_SERIE;
   char *strTitle = vresp->extract_String();
   strncpy(tag.strTitle, strTitle, sizeof(tag.strTitle) - 1);
   delete[] strTitle;
@@ -446,7 +446,7 @@ bool cVNSIData::GetTimersList(ADDON_HANDLE handle)
       tag.endTime           = vresp->extract_U32();
       tag.firstDay          = vresp->extract_U32();
       tag.iWeekdays         = vresp->extract_U32();
-      tag.bIsRepeating      = tag.iWeekdays == 0 ? false : true;
+      tag.iTimerType        = tag.iWeekdays == 0 ? PVR_TIMERTYPE_MANUAL_ONCE : PVR_TIMERTYPE_MANUAL_SERIE;
       char *strTitle = vresp->extract_String();
       strncpy(tag.strTitle, strTitle, sizeof(tag.strTitle) - 1);
       tag.iMarginStart      = 0;
@@ -514,7 +514,7 @@ PVR_ERROR cVNSIData::AddTimer(const PVR_TIMER &timerinfo)
   if (!vrp.add_U32(timerinfo.iClientChannelUid)) return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(starttime))  return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(endtime))    return PVR_ERROR_UNKNOWN;
-  if (!vrp.add_U32(timerinfo.bIsRepeating ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
+  if (!vrp.add_U32((timerinfo.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE) ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(timerinfo.iWeekdays))return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(path.c_str()))      return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(""))                return PVR_ERROR_UNKNOWN;
@@ -599,7 +599,7 @@ PVR_ERROR cVNSIData::UpdateTimer(const PVR_TIMER &timerinfo)
   if (!vrp.add_U32(timerinfo.iClientChannelUid)) return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(starttime))  return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(endtime))    return PVR_ERROR_UNKNOWN;
-  if (!vrp.add_U32(timerinfo.bIsRepeating ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
+  if (!vrp.add_U32((timerinfo.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE) ? timerinfo.firstDay : 0))   return PVR_ERROR_UNKNOWN;
   if (!vrp.add_U32(timerinfo.iWeekdays))return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(timerinfo.strTitle))   return PVR_ERROR_UNKNOWN;
   if (!vrp.add_String(""))                return PVR_ERROR_UNKNOWN;

--- a/addons/pvr.vdr.vnsi/src/client.cpp
+++ b/addons/pvr.vdr.vnsi/src/client.cpp
@@ -551,7 +551,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return VNSIData->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForce)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForce, bool bDeleteSchedule)
 {
   if (!VNSIData)
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.vuplus/src/VuData.cpp
+++ b/addons/pvr.vuplus/src/VuData.cpp
@@ -1006,7 +1006,7 @@ PVR_ERROR Vu::GetTimers(ADDON_HANDLE handle)
     tag.state             = timer.state;
     tag.iPriority         = 0;     // unused
     tag.iLifetime         = 0;     // unused
-    tag.bIsRepeating      = timer.bRepeating;
+    tag.iTimerType        = timer.bRepeating ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE;
     tag.firstDay          = 0;     // unused
     tag.iWeekdays         = timer.iWeekdays;
     tag.iEpgUid           = timer.iEpgID;

--- a/addons/pvr.vuplus/src/client.cpp
+++ b/addons/pvr.vuplus/src/client.cpp
@@ -457,7 +457,7 @@ PVR_ERROR AddTimer(const PVR_TIMER &timer)
   return VuData->AddTimer(timer);
 }
 
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete)
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 {
   if (!VuData || !VuData->IsConnected())
     return PVR_ERROR_SERVER_ERROR;

--- a/addons/pvr.wmc/src/client.cpp
+++ b/addons/pvr.wmc/src/client.cpp
@@ -472,7 +472,7 @@ extern "C" {
 		return PVR_ERROR_NO_ERROR;
 	}
 
-	PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete) 
+	PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool bForceDelete, bool bDeleteSchedule)
 	{
 		if (_wmc)
 			return _wmc->DeleteTimer(timer, bForceDelete);

--- a/addons/pvr.wmc/src/pvr2wmc.cpp
+++ b/addons/pvr.wmc/src/pvr2wmc.cpp
@@ -635,7 +635,7 @@ CStdString Pvr2Wmc::Timer2String(const PVR_TIMER &xTmr)
 
 	tStr.Format("|%d|%d|%d|%d|%d|%s|%d|%d|%d|%d|%d",													// format for 11 params:
 		xTmr.iClientIndex, xTmr.iClientChannelUid, xTmr.startTime, xTmr.endTime, PVR_TIMER_STATE_NEW,		// 5 params
-		xTmr.strTitle, xTmr.iPriority,  xTmr.iMarginStart, xTmr.iMarginEnd, xTmr.bIsRepeating,				// 5 params
+		xTmr.strTitle, xTmr.iPriority,  xTmr.iMarginStart, xTmr.iMarginEnd, xTmr.iTimerType == PVR_TIMERTYPE_MANUAL_SERIE,				// 5 params
 		xTmr.iEpgUid);																						// 1 param
 
 	return tStr;
@@ -648,7 +648,7 @@ PVR_ERROR Pvr2Wmc::DeleteTimer(const PVR_TIMER &xTmr, bool bForceDelete)
 
 	bool deleteSeries = false;
 
-	if (xTmr.bIsRepeating)									// if timer is a series timer, ask if want to cancel series
+	if (xTmr.iTimerType != PVR_TIMERTYPE_MANUAL_ONCE) // if timer is a series timer, ask if want to cancel series
 	{
 		CDialogDeleteTimer vWindow(deleteSeries, xTmr.strTitle);
 		int dlogResult = vWindow.DoModal();
@@ -718,7 +718,7 @@ PVR_ERROR Pvr2Wmc::GetTimers(ADDON_HANDLE handle)
 		STRCPY(xTmr.strDirectory, v[6].c_str());			// rec directory
 		STRCPY(xTmr.strSummary, v[7].c_str());				// currently set to episode title
 		xTmr.iPriority = atoi(v[8].c_str());				// rec priority
-		xTmr.bIsRepeating = Str2Bool(v[9].c_str());			// repeating rec (set to series flag)
+		xTmr.iTimerType = Str2Bool(v[9].c_str()) ? PVR_TIMERTYPE_MANUAL_SERIE : PVR_TIMERTYPE_MANUAL_ONCE; // repeating rec (set to series flag)
 
 		xTmr.iEpgUid = atoi(v[10].c_str());					// epg ID (same as client ID, except for a 'manual' record)
 		xTmr.iMarginStart = atoi(v[11].c_str());			// rec margin at start (sec)

--- a/xbmc/libXBMC_pvr.h
+++ b/xbmc/libXBMC_pvr.h
@@ -112,6 +112,10 @@ public:
       dlsym(m_libXBMC_pvr, "PVR_add_menu_hook");
     if (PVR_add_menu_hook == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
 
+    PVR_add_timer_type = (void (*)(void* HANDLE, void* CB, PVR_TIMERTYPE *type))
+      dlsym(m_libXBMC_pvr, "PVR_add_timer_type");
+    if (PVR_add_timer_type == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
+
     PVR_recording = (void (*)(void* HANDLE, void* CB, const char *Name, const char *FileName, bool On))
       dlsym(m_libXBMC_pvr, "PVR_recording");
     if (PVR_recording == NULL) { fprintf(stderr, "Unable to assign function %s\n", dlerror()); return false; }
@@ -228,6 +232,15 @@ public:
   }
 
   /*!
+   * @brief Add an additional timer type for this add-on
+   * @param type The type to add.
+   */
+  void AddTimerType(PVR_TIMERTYPE* type)
+  {
+    return PVR_add_timer_type(m_Handle, m_Callbacks, type);
+  }
+
+  /*!
    * @brief Display a notification in XBMC that a recording started or stopped on the server
    * @param strRecordingName The name of the recording to display
    * @param strFileName The filename of the recording
@@ -308,6 +321,7 @@ protected:
   void (*PVR_transfer_timer_entry)(void*, void*, const ADDON_HANDLE, const PVR_TIMER*);
   void (*PVR_transfer_recording_entry)(void*, void*, const ADDON_HANDLE, const PVR_RECORDING*);
   void (*PVR_add_menu_hook)(void*, void*, PVR_MENUHOOK*);
+  void (*PVR_add_timer_type)(void*, void*, PVR_TIMERTYPE*);
   void (*PVR_recording)(void*, void*, const char*, const char*, bool);
   void (*PVR_trigger_channel_update)(void*, void*);
   void (*PVR_trigger_channel_groups_update)(void*, void*);

--- a/xbmc/xbmc_pvr_dll.h
+++ b/xbmc/xbmc_pvr_dll.h
@@ -345,10 +345,11 @@ extern "C"
    * Delete a timer on the backend.
    * @param timer The timer to delete.
    * @param bForceDelete Set to true to delete a timer that is currently recording a program.
+   * @param bDeleteSchedule Set to true to delete the complete repeating schedule instead of the given timer only.
    * @return PVR_ERROR_NO_ERROR if the timer has been deleted successfully.
    * @remarks Required if bSupportsTimers is set to true. Return PVR_ERROR_NOT_IMPLEMENTED if this add-on won't provide this function.
    */
-  PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete);
+  PVR_ERROR DeleteTimer(const PVR_TIMER& timer, bool bForceDelete, bool bDeleteSchedule);
 
   /*!
    * Update the timer information on the backend.

--- a/xbmc/xbmc_pvr_types.h
+++ b/xbmc/xbmc_pvr_types.h
@@ -75,10 +75,10 @@ struct DemuxPacket;
 #define PVR_STREAM_MAX_STREAMS 20
 
 /* current PVR API version */
-#define XBMC_PVR_API_VERSION "1.9.3"
+#define XBMC_PVR_API_VERSION "1.9.4"
 
 /* min. PVR API version */
-#define XBMC_PVR_MIN_API_VERSION "1.9.3"
+#define XBMC_PVR_MIN_API_VERSION "1.9.4"
 
 #ifdef __cplusplus
 extern "C" {

--- a/xbmc/xbmc_pvr_types.h
+++ b/xbmc/xbmc_pvr_types.h
@@ -118,6 +118,34 @@ extern "C" {
   } PVR_TIMER_STATE;
 
   /*!
+   * @brief PVR timer types
+   */
+  typedef enum
+  {
+    PVR_TIMERTYPE_EPG_ONCE      = -1, /*!< @brief timer type for a once time epg based timer */
+    PVR_TIMERTYPE_MANUAL_ONCE   = -2, /*!< @brief timer type for a once time manual timer  */
+    PVR_TIMERTYPE_MANUAL_SERIE  = -3, /*!< @brief timer type for a manual timer schedule */
+    PVR_TIMERTYPE_UNKNOWN       = -4, /*!< @brief timer type for a unknown timer schedule */
+  } PVR_TIMERTYPEID;
+
+  /*!
+   * @brief PVR timer weekday mask
+   */
+  typedef enum
+  {
+    BITFLAG_MONDAY    = 0x01,
+    BITFLAG_TUESDAY   = 0x02,
+    BITFLAG_WEDNESDAY = 0x04,
+    BITFLAG_THURSDAY  = 0x08,
+    BITFLAG_FRIDAY    = 0x10,
+    BITFLAG_SATURDAY  = 0x20,
+    BITFLAG_SUNDAY    = 0x40,
+    BITFLAG_WEEKDAYS  = 0x1F,
+    BITFLAG_WEEKENDS  = 0x60,
+    BITFLAG_ALL_DAYS  = 0x7F
+  } PVR_WEEKDAYMASK;
+
+  /*!
    * @brief PVR menu hook categories
    */
   typedef enum
@@ -218,6 +246,19 @@ extern "C" {
   } ATTRIBUTE_PACKED PVR_MENUHOOK;
 
   /*!
+   * @brief Extra timer types which are available in the add/edit timer dialog.
+   */
+  typedef struct PVR_TIMERTYPE
+  {
+    int              iTypeId;              /*!< @brief (required) this type's identifier, should only contain positive numbers! */
+    int              iLocalizedStringId;   /*!< @brief (required) the id of the label for this type in g_localizeStrings */
+    bool             bDependsChannel;      /*!< @brief (required) this type needs the channel field */
+    bool             bDependsTime;         /*!< @brief (required) this type needs the time fields */
+    bool             bDependsNewEpisodes;  /*!< @brief (required) this type needs the new episodes field */
+    bool             bReadOnly;            /*!< @brief (required) this type may not be edited by Kodi */
+  } ATTRIBUTE_PACKED PVR_TIMERTYPE;
+
+  /*!
    * @brief Representation of a TV or radio channel.
    */
   typedef struct PVR_CHANNEL
@@ -259,14 +300,16 @@ extern "C" {
     time_t          startTime;                                 /*!< @brief (required) start time of the recording in UTC. instant timers that are sent to the add-on by xbmc will have this value set to 0 */
     time_t          endTime;                                   /*!< @brief (required) end time of the recording in UTC */
     PVR_TIMER_STATE state;                                     /*!< @brief (required) the state of this timer */
+    int             iTimerType;                                /*!< @brief (required) the type id of this timer, see PVR_TIMERTYPEID of use id's from your own PVR_TIMERTYPE's */
+    int             iScheduleUid;                              /*!< @brief (optional) id from the schedule where this timer is belonging to */
     char            strTitle[PVR_ADDON_NAME_STRING_LENGTH];    /*!< @brief (optional) title of this timer */
     char            strDirectory[PVR_ADDON_URL_STRING_LENGTH]; /*!< @brief (optional) the directory where the recording will be stored in */
     char            strSummary[PVR_ADDON_DESC_STRING_LENGTH];  /*!< @brief (optional) the summary for this timer */
     int             iPriority;                                 /*!< @brief (optional) the priority of this timer */
     int             iLifetime;                                 /*!< @brief (optional) lifetimer of this timer in days */
-    bool            bIsRepeating;                              /*!< @brief (optional) true if this is a recurring timer */
-    time_t          firstDay;                                  /*!< @brief (optional) the first day this recording is active in case of a repeating event */
-    int             iWeekdays;                                 /*!< @brief (optional) weekday mask */
+    bool            bNewEpisodesOnly;                          /*!< @brief (optional) true if backend should only record new episodes in case of a repeating epg based timer */
+    time_t          firstDay;                                  /*!< @brief (optional) the first day this recording is active in case of a repeating manual timer */
+    int             iWeekdays;                                 /*!< @brief (optional) weekday mask in case of a manual repeating timer*/
     int             iEpgUid;                                   /*!< @brief (optional) epg event id */
     unsigned int    iMarginStart;                              /*!< @brief (optional) if set, the backend starts the recording iMarginStart minutes before startTime. */
     unsigned int    iMarginEnd;                                /*!< @brief (optional) if set, the backend ends the recording iMarginEnd minutes after endTime. */
@@ -368,7 +411,7 @@ extern "C" {
     int          (__cdecl* GetTimersAmount)(void);
     PVR_ERROR    (__cdecl* GetTimers)(ADDON_HANDLE);
     PVR_ERROR    (__cdecl* AddTimer)(const PVR_TIMER&);
-    PVR_ERROR    (__cdecl* DeleteTimer)(const PVR_TIMER&, bool);
+    PVR_ERROR    (__cdecl* DeleteTimer)(const PVR_TIMER&, bool, bool);
     PVR_ERROR    (__cdecl* UpdateTimer)(const PVR_TIMER&);
     bool         (__cdecl* OpenLiveStream)(const PVR_CHANNEL&);
     void         (__cdecl* CloseLiveStream)(void);


### PR DESCRIPTION
This is the pvr addons side of
https://github.com/xbmc/xbmc/pull/6281

Demo addon updated to make use of serie timers,
all other addons are currently not using serie timers but should behave the same as before.

i.e. the next types are replacing the timer.isrepeating flag
PVR_TIMERTYPE_MANUAL_ONCE
PVR_TIMERTYPE_MANUAL_SERIE
