### PR TITLE
platform posix: fix memory leak in pthread

### DIFF
--- a/lib/platform/posix/os-threads.h
+++ b/lib/platform/posix/os-threads.h
@@ -72,7 +72,20 @@ namespace PLATFORM
 
   typedef pthread_t thread_t;
 
-  #define ThreadsCreate(thread, func, arg)         (pthread_create(&thread, NULL, (void *(*) (void *))func, (void *)arg) == 0)
+  inline pthread_attr_t *GetDetachedThreadAttribute(void)
+  {
+    static pthread_attr_t g_threadAttr;
+    static bool bAttributeInitialised = false;
+    if (!bAttributeInitialised)
+    {
+      pthread_attr_init(&g_threadAttr);
+      pthread_attr_setdetachstate(&g_threadAttr, PTHREAD_CREATE_DETACHED);
+      bAttributeInitialised = true;
+    }
+    return &g_threadAttr;
+  }
+
+  #define ThreadsCreate(thread, func, arg)         (pthread_create(&thread, GetDetachedThreadAttribute(), (void *(*) (void *))func, (void *)arg) == 0)
   #define ThreadsWait(thread, retval)              (pthread_join(thread, retval) == 0)
 
   typedef pthread_mutex_t mutex_t;


### PR DESCRIPTION
==14096== 864 bytes in 3 blocks are possibly lost in loss record 2 of 2
==14096==    at 0x4C2CC70: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==14096==    by 0x4012E54: _dl_allocate_tls (dl-tls.c:296)
==14096==    by 0x4E3FDA0: pthread_create@@GLIBC_2.2.5 (allocatestack.c:589)
==14096==    by 0x46110C: PLATFORM::CThread::CreateThread(bool)

If you create a joinable thread but forget to join it, its resources or private memory
are always kept in the process space and never reclaimed.
Always join the joinable threads.