### PR TITLE
[pvr.hts] fix extern "C" scope in client.cpp

### DIFF
--- a/addons/pvr.hts/src/client.cpp
+++ b/addons/pvr.hts/src/client.cpp
@@ -626,7 +626,7 @@ time_t GetBufferTimeStart()
 }
 time_t GetBufferTimeEnd()
 {
-  return 0; }
+  return 0;
 }
 
 /* Live stream (VFS interface - not relevant) */
@@ -652,3 +652,5 @@ const char * GetLiveStreamURL(const PVR_CHANNEL &_unused(channel))
 {
   return "";
 }
+
+} /* extern "C" */


### PR DESCRIPTION
Introduced by https://github.com/opdenkamp/xbmc-pvr-addons/commit/7779fe88e738028cb24081411ee028c93a9d0a77