### PR TITLE
[dvbviewer] Update to 1.10.28

### DIFF
--- a/addons/pvr.dvbviewer/Makefile.am
+++ b/addons/pvr.dvbviewer/Makefile.am
@@ -16,6 +16,7 @@ include ../Makefile.include.am
 
 libdvbviewer_addon_la_SOURCES = src/client.cpp \
                                 src/DvbData.cpp \
-                                src/TimeshiftBuffer.cpp
+                                src/TimeshiftBuffer.cpp \
+                                src/RecordingReader.cpp
 libdvbviewer_addon_la_LDFLAGS = @TARGET_LDFLAGS@
 

--- a/addons/pvr.dvbviewer/addon/addon.xml.in
+++ b/addons/pvr.dvbviewer/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvbviewer"
-  version="1.10.0"
+  version="1.10.28"
   name="DVBViewer Client"
   provider-name="jdembski, A600, Manuel Mausz, Portisch">
   <requires>

--- a/addons/pvr.dvbviewer/addon/changelog.txt
+++ b/addons/pvr.dvbviewer/addon/changelog.txt
@@ -1,54 +1,51 @@
-1.10.0
+1.10.28
+[added] RecordingReader: Allows playback of ongoing recordings
+        There are still some minor quirks. e.g. In case we reach the end during
+        playback/seek we'll sleep until the next refresh. This should happen
+        once but sometimes this happens twice.
+[added] Support for putting outline before plot
+[fixed] Removed custom notification if backend is unavailable
+[fixed] A new timer has been removed and re-added again shortly after it has
+        been added the first time
 
+1.10.0
 [updated] to PVR API v1.9.4
 
 1.9.27
-
 [updated] Language files from Transifex
 
 1.9.26
-
 [updated] Language files from Transifex
 [fixed] Minor changes to conform with C++11
 
 1.9.25
-
 [added] getBackendHostname function
 
 1.9.24
-
 [fixed] mime-type for MPEG-TS
 
 1.9.23
-
 [updated] Language files from Transifex
 
 1.9.22
-
 change library name to Kodi
 
 1.9.21
-
 [fixed] deadlock when activating the addon on some darwin (osx, ios) runtimes
 
 1.9.20
-
 [updated] Language files from Transifex
 
 1.9.19
-
 [updated] Language files from Transifex
 
 1.9.18
-
 [updated] to API v1.9.2
 
 1.9.16
-
 [updated] Language files from Transifex
 
 1.9.15
-
 [updated] Speed up timeshift startup time
 [added] If available add genre to EPG
 [added] Support for grouping recordings. Grouping can be by rec. directory,
@@ -56,25 +53,21 @@ change library name to Kodi
 [fixed] Another timezone offsets fix
 
 1.9.14
-
 [updated] Require DVB Viewer Recording Service 1.26.0 or later
 [updated] Removed external XML library. Use TinyXML instead
 [added] Low performance mode for devices like the raspberry pi
 [fixed] Timers starting near 12pm could have wrong date
 
 1.9.13
-
 [updated] Language files from Transifex
 
 1.9.12
-
 [updated] Language files from Transifex
 
 1.9.11
 [added] add timeshift buffer functions
 
 1.8.10
-
 [updated] Require DVB Viewer Recording Service 1.25.0 or later
 [updated] In general use RS XML API instead of HTML/channeldat parsing
 [updated] Rewrote channel parsing. Use favourites if you want fast startups.
@@ -87,23 +80,18 @@ change library name to Kodi
 [fixed] possible crash (2x)
 
 1.8.9
-
 [updated] sync with PVR API v1.8.0
 
 1.7.9
-
 [fixed] loading favourites without groups/folders
 
 1.7.8
-
 [fixed] fix crash with Recording Service 1.25.0
 
 1.7.7
-
 [fixed] fix possible crash during timer updates
 
 1.7.6
-
 [added] Basic timeshift support.
 [added] Use channel names from favourites. This allows easy channelname changes.
 [fixed] Use 64 bit channel ids. Fall back to 32 bit if favourites.xml still contain the old ones.
@@ -111,35 +99,28 @@ change library name to Kodi
 [updated] A lot of code cleanup
 
 1.7.5
-
 [updated] Bump after PVR API version bump
 
 1.6.5
-
 [updated] Language files from Transifex
 
 1.6.4
-
 [fixed] Use utf-8 encoding to get and set the timers.
 [fixed] Channel names with more than 25 chars could crash the add-on.
 
 1.6.3
-
 [updated] Language files from Transifex
 
 1.6.2
-
 New version number by Team XBMC
 
 0.1.8
-
 [fixed] Changed the way timers are calculated. This should fix problems with scheduled and instant recordings on some machines.
 [fixed] Favourites didn't show channels if the audio track wasn't the first one.
 [fixed] Channel settings weren't saved/restored after a channel switch with the channels OSD.
 [fixed] XBMC could hang after a channel switch with the channels OSD.
 
 0.1.7
-
 [added] The Recording Service version 1.21 or higher is now required. Download the latest version from the DVBViewer members area and install it.
 [added] Display a notification if the add-on can't connect to the Recording Service. Please, check that the RS is enabled and the IP, webinterface port, username and pass are correct.
 [added] If the favourites.xml selector is empty, the favourites are loaded from the web interface.
@@ -149,7 +130,6 @@ New version number by Team XBMC
 [fixed] Channel names with more than 25 chars.
 
 0.1.5
-
 [added] Timers support.
 [added] An option to load the channels from favourites.xml instead of from channels.dat (a reset of the PVR database is required).
         It is usually located at c:\ProgramData\CMUV\DVBViewer\
@@ -161,5 +141,4 @@ New version number by Team XBMC
 [fixed] When the EPG is missing the description entry, the event entry is used instead.
 
 0.1.0
-
 First version.

--- a/addons/pvr.dvbviewer/addon/resources/language/English/strings.po
+++ b/addons/pvr.dvbviewer/addon/resources/language/English/strings.po
@@ -100,7 +100,29 @@ msgctxt "#30056"
 msgid "by series"
 msgstr ""
 
-#empty strings from id 30057 to 30099
+#empty strings from id 30057 to 30059
+
+msgctxt "#30060"
+msgid "Put outline (e.g. subtitles) before plot"
+msgstr ""
+
+msgctxt "#30061"
+msgid "Never"
+msgstr ""
+
+msgctxt "#30062"
+msgid "In EPG only"
+msgstr ""
+
+msgctxt "#30063"
+msgid "In recordings only"
+msgstr ""
+
+msgctxt "#30064"
+msgid "Always"
+msgstr ""
+
+#empty strings from id 30065 to 30099
 #sections
 
 msgctxt "#30100"
@@ -144,4 +166,8 @@ msgstr ""
 
 msgctxt "#30506"
 msgid "Unable to parse timer list"
+msgstr ""
+
+msgctxt "#30507"
+msgid "Please reset the EPG database and restart Kodi afterwards"
 msgstr ""

--- a/addons/pvr.dvbviewer/addon/resources/settings.xml
+++ b/addons/pvr.dvbviewer/addon/resources/settings.xml
@@ -14,7 +14,7 @@
   </category>
 
   <category label="30102">
-    <setting label="30050" id="grouprecordings" type="enum" lvalues="30051|30052|30053|30054|30055|30056" default="30051" />
+    <setting label="30050" id="grouprecordings" type="enum" lvalues="30051|30052|30053|30054|30055|30056" default="0" />
   </category>
 
   <category label="30101">

--- a/addons/pvr.dvbviewer/addon/resources/settings.xml
+++ b/addons/pvr.dvbviewer/addon/resources/settings.xml
@@ -13,18 +13,19 @@
     <setting label="30012" id="favouritesfile"    type="file" default="" enable="eq(-1,true)" />
   </category>
 
+  <!-- recordings -->
   <category label="30102">
     <setting label="30050" id="grouprecordings" type="enum" lvalues="30051|30052|30053|30054|30055|30056" default="0" />
   </category>
 
+  <!-- advanced -->
   <category label="30101">
     <setting label="30020" id="usetimeshift"  type="bool"   default="false" />
     <setting label="30021" id="timeshiftpath" type="folder" default="special://userdata/addon_data/pvr.dvbviewer" option="writeable" enable="eq(-1,true)" />
 
     <setting id="sep3" type="sep" />
     <setting label="30030" id="usertsp" type="bool" default="false" enable="eq(-3,false)" />
-
-    <setting id="sep4" type="sep" />
+    <setting label="30060" id="prependoutline" type="enum" lvalues="30061|30062|30063|30064" default="1" />
     <setting label="30040" id="lowperformance" type="bool" default="false" />
   </category>
 </settings>

--- a/addons/pvr.dvbviewer/project/VS2010Express/pvr.dvbviewer.vcxproj
+++ b/addons/pvr.dvbviewer/project/VS2010Express/pvr.dvbviewer.vcxproj
@@ -96,11 +96,13 @@ if errorlevel 1 exit 0 else exit %errorlevel%</Command>
     <ClCompile Include="..\..\src\client.cpp" />
     <ClCompile Include="..\..\src\DvbData.cpp" />
     <ClCompile Include="..\..\src\TimeshiftBuffer.cpp" />
+    <ClCompile Include="..\..\src\RecordingReader.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\client.h" />
     <ClInclude Include="..\..\src\DvbData.h" />
     <ClInclude Include="..\..\src\TimeshiftBuffer.h" />
+    <ClInclude Include="..\..\src\RecordingReader.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\project\VS2010Express\platform\platform.vcxproj">

--- a/addons/pvr.dvbviewer/project/VS2010Express/pvr.dvbviewer.vcxproj.filters
+++ b/addons/pvr.dvbviewer/project/VS2010Express/pvr.dvbviewer.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="..\..\src\TimeshiftBuffer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\RecordingReader.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\client.h">
@@ -33,6 +36,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\TimeshiftBuffer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\RecordingReader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -222,7 +222,7 @@ PVR_ERROR Dvb::GetEPGForChannel(ADDON_HANDLE handle,
         entry.strPlot = entry.strPlotOutline;
         entry.strPlotOutline.clear();
       }
-      else if (PrependOutline::test(PrependOutline::InEPG))
+      else if (PrependOutline::test(PrependOutline::IN_EPG))
       {
         entry.strPlot.insert(0, entry.strPlotOutline + "\n");
         entry.strPlotOutline.clear();
@@ -419,7 +419,7 @@ PVR_ERROR Dvb::GetRecordings(ADDON_HANDLE handle)
       recording.plot = recording.plotOutline;
       recording.plotOutline.clear();
     }
-    else if (PrependOutline::test(PrependOutline::InRecordings))
+    else if (PrependOutline::test(PrependOutline::IN_RECORDINGS))
     {
       recording.plot.insert(0, recording.plotOutline + "\n");
       recording.plotOutline.clear();
@@ -458,7 +458,7 @@ PVR_ERROR Dvb::GetRecordings(ADDON_HANDLE handle)
     CStdString tmp;
     switch(g_groupRecordings)
     {
-      case DvbRecording::GroupByDirectory:
+      case DvbRecording::GROUP_BY_DIRECTORY:
         XMLUtils::GetString(xRecording, "file", tmp);
         tmp.ToLower();
         for (std::vector<CStdString>::reverse_iterator recf = m_recfolders.rbegin();
@@ -472,18 +472,18 @@ PVR_ERROR Dvb::GetRecordings(ADDON_HANDLE handle)
           break;
         }
         break;
-      case DvbRecording::GroupByDate:
+      case DvbRecording::GROUP_BY_DATE:
         tmp.Format("%s/%s", startTime.substr(0, 4), startTime.substr(4, 2));
         PVR_STRCPY(tag.strDirectory, tmp.c_str());
         break;
-      case DvbRecording::GroupByFirstLetter:
+      case DvbRecording::GROUP_BY_FIRST_LETTER:
         tag.strDirectory[0] = recording.title[0];
         tag.strDirectory[1] = '\0';
         break;
-      case DvbRecording::GroupByTVChannel:
+      case DvbRecording::GROUP_BY_TV_CHANNEL:
         PVR_STRCPY(tag.strDirectory, recording.channelName.c_str());
         break;
-      case DvbRecording::GroupBySeries:
+      case DvbRecording::GROUP_BY_SERIES:
         tmp = "Unknown";
         XMLUtils::GetString(xRecording, "series", tmp);
         PVR_STRCPY(tag.strDirectory, tmp.c_str());
@@ -1165,11 +1165,11 @@ bool Dvb::UpdateBackendStatus(bool updateSettings)
       m_diskspace.used += (size - free) / 1024;
     }
 
-    if (updateSettings && g_groupRecordings != DvbRecording::GroupingDisabled)
+    if (updateSettings && g_groupRecordings != DvbRecording::GROUPING_DISABLED)
       m_recfolders.push_back(CStdString(xFolder->GetText()).ToLower());
   }
 
-  if (updateSettings && g_groupRecordings != DvbRecording::GroupingDisabled)
+  if (updateSettings && g_groupRecordings != DvbRecording::GROUPING_DISABLED)
     std::sort(m_recfolders.begin(), m_recfolders.end(), StringGreaterThan);
 
   return true;

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -1095,8 +1095,6 @@ bool Dvb::CheckBackendVersion()
   {
     XBMC->Log(LOG_ERROR, "Unable to connect to the backend service. Error: %s",
         doc.ErrorDesc());
-    XBMC->QueueNotification(QUEUE_ERROR, XBMC->GetLocalizedString(30500));
-    Sleep(10000);
     return false;
   }
 

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -221,8 +221,16 @@ PVR_ERROR Dvb::GetEPGForChannel(ADDON_HANDLE handle,
     if (xEvents)
     {
       XMLUtils::GetString(xEvents, "event", entry.strPlotOutline);
-      if (!entry.strPlotOutline.empty() && entry.strPlot.empty())
+      if (entry.strPlot.empty())
+      {
         entry.strPlot = entry.strPlotOutline;
+        entry.strPlotOutline.clear();
+      }
+      else if (PrependOutline::test(PrependOutline::InEPG))
+      {
+        entry.strPlot.insert(0, entry.strPlotOutline + "\n");
+        entry.strPlotOutline.clear();
+      }
     }
 
     XMLUtils::GetUInt(xEntry, "content", entry.genre);
@@ -411,7 +419,15 @@ PVR_ERROR Dvb::GetRecordings(ADDON_HANDLE handle)
     XMLUtils::GetString(xRecording, "info",    recording.plotOutline);
     XMLUtils::GetString(xRecording, "desc",    recording.plot);
     if (recording.plot.empty())
+    {
       recording.plot = recording.plotOutline;
+      recording.plotOutline.clear();
+    }
+    else if (PrependOutline::test(PrependOutline::InRecordings))
+    {
+      recording.plot.insert(0, recording.plotOutline + "\n");
+      recording.plotOutline.clear();
+    }
 
     recording.streamURL = BuildExtURL(streamURL, "%s.ts", recording.id.c_str());
 
@@ -1169,11 +1185,11 @@ bool Dvb::UpdateBackendStatus(bool updateSettings)
       m_diskspace.used += (size - free) / 1024;
     }
 
-    if (updateSettings && g_groupRecordings != DvbRecording::GroupDisabled)
+    if (updateSettings && g_groupRecordings != DvbRecording::GroupingDisabled)
       m_recfolders.push_back(CStdString(xFolder->GetText()).ToLower());
   }
 
-  if (updateSettings && g_groupRecordings != DvbRecording::GroupDisabled)
+  if (updateSettings && g_groupRecordings != DvbRecording::GroupingDisabled)
     std::sort(m_recfolders.begin(), m_recfolders.end(), StringGreaterThan);
 
   return true;

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -245,7 +245,7 @@ bool Dvb::GetEPGForChannel(ADDON_HANDLE handle,
     PVR->TransferEpgEntry(handle, &broadcast);
     ++iNumEPG;
 
-    XBMC->Log(LOG_DEBUG, "%s loaded EPG entry '%u:%s': start=%u, end=%u",
+    XBMC->Log(LOG_DEBUG, "%s: Loaded EPG entry '%u:%s': start=%u, end=%u",
         __FUNCTION__, broadcast.iUniqueBroadcastId, broadcast.strTitle,
         entry.startTime, entry.endTime);
   }
@@ -305,7 +305,7 @@ bool Dvb::GetChannelGroupMembers(ADDON_HANDLE handle,
 
       PVR->TransferChannelGroupMember(handle, &tag);
 
-      XBMC->Log(LOG_DEBUG, "%s add channel '%s' (%u) to group '%s'",
+      XBMC->Log(LOG_DEBUG, "%s: Add channel '%s' (%u) to group '%s'",
           __FUNCTION__, channel->name.c_str(), channel->backendNr,
           group->name.c_str());
     }
@@ -348,8 +348,8 @@ bool Dvb::AddTimer(const PVR_TIMER& timer, bool update)
 {
   // http://en.dvbviewer.tv/wiki/Recording_Service_Web_API#Add_a_timer
 
-  XBMC->Log(LOG_DEBUG, "%s iChannelUid=%u title='%s' epgid=%d",
-      __FUNCTION__, timer.iClientChannelUid, timer.strTitle, timer.iEpgUid);
+  XBMC->Log(LOG_DEBUG, "%s: channel=%u, title='%s'",
+      __FUNCTION__, timer.iClientChannelUid, timer.strTitle);
 
   time_t startTime = timer.startTime, endTime = timer.endTime;
   if (!startTime)
@@ -529,12 +529,12 @@ bool Dvb::GetRecordings(ADDON_HANDLE handle)
     PVR->TransferRecordingEntry(handle, &tag);
     ++m_recordingAmount;
 
-    XBMC->Log(LOG_DEBUG, "%s loaded Recording entry '%s': start=%u, length=%u",
+    XBMC->Log(LOG_DEBUG, "%s: Loaded recording entry '%s': start=%u, length=%u",
         __FUNCTION__, recording.title.c_str(), recording.startTime,
         recording.duration);
   }
 
-  XBMC->Log(LOG_INFO, "Loaded %u Recording Entries", m_recordingAmount);
+  XBMC->Log(LOG_INFO, "Loaded %u recording entries", m_recordingAmount);
   return true;
 }
 
@@ -560,7 +560,7 @@ unsigned int Dvb::GetRecordingsAmount()
 
 bool Dvb::OpenLiveStream(const PVR_CHANNEL& channelinfo)
 {
-  XBMC->Log(LOG_DEBUG, "%s channel=%u", __FUNCTION__, channelinfo.iUniqueId);
+  XBMC->Log(LOG_DEBUG, "%s: channel=%u", __FUNCTION__, channelinfo.iUniqueId);
 
   if (channelinfo.iUniqueId == m_currentChannel)
     return true;
@@ -583,7 +583,7 @@ CStdString& Dvb::GetLiveStreamURL(const PVR_CHANNEL& channelinfo)
 void *Dvb::Process()
 {
   int updateTimer = 0;
-  XBMC->Log(LOG_DEBUG, "%s starting", __FUNCTION__);
+  XBMC->Log(LOG_DEBUG, "%s: Running...", __FUNCTION__);
 
   while (!IsStopped())
   {
@@ -910,7 +910,7 @@ DvbTimers_t Dvb::LoadTimers()
 
     CStdString strTmp;
     if (XMLUtils::GetString(xTimer, "Descr", strTmp))
-      XBMC->Log(LOG_DEBUG, "%s Processing timer '%s'", __FUNCTION__, strTmp.c_str());
+      XBMC->Log(LOG_DEBUG, "%s: Processing timer '%s'", __FUNCTION__, strTmp.c_str());
 
     timer.strTitle = strTmp;
     timer.iChannelUid = GetChannelUid(xTimer->FirstChildElement("Channel")->Attribute("ID"));
@@ -959,11 +959,11 @@ DvbTimers_t Dvb::LoadTimers()
 
     timers.push_back(timer);
 
-    XBMC->Log(LOG_DEBUG, "%s loaded Timer entry '%s': start=%u, end=%u",
+    XBMC->Log(LOG_DEBUG, "%s: Loaded timer entry '%s': start=%u, end=%u",
         __FUNCTION__, timer.strTitle.c_str(), timer.startTime, timer.endTime);
   }
 
-  XBMC->Log(LOG_INFO, "Loaded %u Timer entries", timers.size());
+  XBMC->Log(LOG_INFO, "Loaded %u timer entries", timers.size());
   return timers;
 }
 
@@ -1015,7 +1015,7 @@ void Dvb::TimerUpdates()
   {
     if (it->iUpdateState == DVB_UPDATE_STATE_NONE)
     {
-      XBMC->Log(LOG_DEBUG, "%s Removed timer: '%s', ClientIndex: %u",
+      XBMC->Log(LOG_DEBUG, "%s: Removed timer '%s': id=%u",
           __FUNCTION__, it->strTitle.c_str(), it->iClientIndex);
       it = m_timers.erase(it);
       ++removed;
@@ -1030,7 +1030,7 @@ void Dvb::TimerUpdates()
     if (it->iUpdateState == DVB_UPDATE_STATE_NEW)
     {
       it->iClientIndex = m_newTimerIndex;
-      XBMC->Log(LOG_DEBUG, "%s New timer: '%s', ClientIndex: %u",
+      XBMC->Log(LOG_DEBUG, "%s: New timer '%s': id=%u",
           __FUNCTION__, it->strTitle.c_str(), m_newTimerIndex);
       m_timers.push_back(*it);
       ++m_newTimerIndex;
@@ -1038,7 +1038,7 @@ void Dvb::TimerUpdates()
     }
   }
 
-  XBMC->Log(LOG_DEBUG, "%s Timers update: removed=%u, untouched=%u, updated=%u, added=%u",
+  XBMC->Log(LOG_DEBUG, "%s: Timers update: removed=%u, unchanged=%u, updated=%u, added=%u",
       __FUNCTION__, removed, unchanged, updated, added);
 
   if (removed || updated || added)

--- a/addons/pvr.dvbviewer/src/DvbData.cpp
+++ b/addons/pvr.dvbviewer/src/DvbData.cpp
@@ -52,14 +52,11 @@ Dvb::Dvb()
 
   m_updateTimers = false;
   m_updateEPG    = false;
-  m_tsBuffer     = NULL;
 }
 
 Dvb::~Dvb()
 {
   StopThread();
-  if (m_tsBuffer)
-    SAFE_DELETE(m_tsBuffer);
 
   for (DvbChannels_t::iterator channel = m_channels.begin();
       channel != m_channels.end(); ++channel)
@@ -70,8 +67,7 @@ bool Dvb::Open()
 {
   CLockObject lock(m_mutex);
 
-  m_connected = CheckBackendVersion();
-  if (!m_connected)
+  if (!(m_connected = CheckBackendVersion()))
     return false;
 
   if (!UpdateBackendStatus(true))
@@ -538,28 +534,12 @@ bool Dvb::OpenLiveStream(const PVR_CHANNEL& channelinfo)
     return true;
 
   SwitchChannel(channelinfo);
-  if (!g_useTimeshift)
-    return true;
-
-  if (m_tsBuffer)
-    SAFE_DELETE(m_tsBuffer);
-
-  CStdString streamURL = GetLiveStreamURL(channelinfo);
-  XBMC->Log(LOG_INFO, "Timeshift starts; url=%s", streamURL.c_str());
-  m_tsBuffer = new TimeshiftBuffer(streamURL, g_timeshiftBufferPath);
-  return m_tsBuffer->IsValid();
+  return true;
 }
 
 void Dvb::CloseLiveStream(void)
 {
   m_currentChannel = 0;
-  if (m_tsBuffer)
-    SAFE_DELETE(m_tsBuffer);
-}
-
-TimeshiftBuffer *Dvb::GetTimeshiftBuffer()
-{
-  return m_tsBuffer;
 }
 
 CStdString& Dvb::GetLiveStreamURL(const PVR_CHANNEL& channelinfo)

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -143,12 +143,12 @@ class DvbRecording
 public:
   enum Group
   {
-    GroupDisabled = 0,
+    GroupingDisabled = 0,
     GroupByDirectory,
     GroupByDate,
     GroupByFirstLetter,
     GroupByTVChannel,
-    GroupBySeries,
+    GroupBySeries
   };
 
 public:

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -78,8 +78,8 @@ public:
   unsigned int id;
   DvbChannel *channel;
   CStdString title;
-  time_t startTime;
-  time_t endTime;
+  time_t start;
+  time_t end;
   unsigned int genre;
   CStdString plotOutline;
   CStdString plot;
@@ -112,8 +112,8 @@ public:
     bool updated = false;
     TIMER_UPDATE_MEMBER(channel);
     TIMER_UPDATE_MEMBER(title);
-    TIMER_UPDATE_MEMBER(startTime);
-    TIMER_UPDATE_MEMBER(endTime);
+    TIMER_UPDATE_MEMBER(start);
+    TIMER_UPDATE_MEMBER(end);
     TIMER_UPDATE_MEMBER(priority);
     TIMER_UPDATE_MEMBER(weekdays);
     TIMER_UPDATE_MEMBER(state);
@@ -133,8 +133,8 @@ public:
   DvbChannel *channel;
   CStdString title;
   uint64_t channelId;
-  time_t startTime;
-  time_t endTime;
+  time_t start;
+  time_t end;
   int priority;
   unsigned int weekdays;
   PVR_TIMER_STATE state;
@@ -161,7 +161,7 @@ public:
 
 public:
   CStdString id;
-  time_t startTime;
+  time_t start;
   int duration;
   unsigned int genre;
   CStdString title;

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -4,7 +4,6 @@
 #define PVR_DVBVIEWER_DVBDATA_H
 
 #include "client.h"
-#include "TimeshiftBuffer.h"
 #include "platform/util/StdString.h"
 #include "platform/threads/threads.h"
 #include <list>
@@ -209,7 +208,6 @@ public:
 
   bool OpenLiveStream(const PVR_CHANNEL& channelinfo);
   void CloseLiveStream();
-  TimeshiftBuffer *GetTimeshiftBuffer();
   CStdString& GetLiveStreamURL(const PVR_CHANNEL& channelinfo);
 
 protected:
@@ -260,7 +258,6 @@ private:
   bool m_updateTimers;
   bool m_updateEPG;
   unsigned int m_recordingAmount;
-  TimeshiftBuffer *m_tsBuffer;
 
   DvbTimers_t m_timers;
   unsigned int m_newTimerIndex;

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -184,26 +184,27 @@ public:
 
   CStdString GetBackendName();
   CStdString GetBackendVersion();
-  PVR_ERROR GetDriveSpace(long long *total, long long *used);
+  bool GetDriveSpace(long long *total, long long *used);
 
-  bool SwitchChannel(const PVR_CHANNEL& channel);
+  bool SwitchChannel(const PVR_CHANNEL& channelinfo);
   unsigned int GetCurrentClientChannel(void);
-  PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
-  PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channel, time_t iStart, time_t iEnd);
+  bool GetChannels(ADDON_HANDLE handle, bool radio);
+  bool GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL& channelinfo,
+      time_t start, time_t end);
   unsigned int GetChannelsAmount(void);
 
-  PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio);
-  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP& group);
+  bool GetChannelGroups(ADDON_HANDLE handle, bool radio);
+  bool GetChannelGroupMembers(ADDON_HANDLE handle,
+      const PVR_CHANNEL_GROUP& group);
   unsigned int GetChannelGroupsAmount(void);
 
-  PVR_ERROR GetTimers(ADDON_HANDLE handle);
-  PVR_ERROR AddTimer(const PVR_TIMER& timer);
-  PVR_ERROR UpdateTimer(const PVR_TIMER& timer);
-  PVR_ERROR DeleteTimer(const PVR_TIMER& timer);
+  bool GetTimers(ADDON_HANDLE handle);
+  bool AddTimer(const PVR_TIMER& timer, bool update = false);
+  bool DeleteTimer(const PVR_TIMER& timer);
   unsigned int GetTimersAmount(void);
 
-  PVR_ERROR GetRecordings(ADDON_HANDLE handle);
-  PVR_ERROR DeleteRecording(const PVR_RECORDING& recinfo);
+  bool GetRecordings(ADDON_HANDLE handle);
+  bool DeleteRecording(const PVR_RECORDING& recinfo);
   unsigned int GetRecordingsAmount();
 
   bool OpenLiveStream(const PVR_CHANNEL& channelinfo);
@@ -220,7 +221,6 @@ private:
   bool LoadChannels();
   DvbTimers_t LoadTimers();
   void TimerUpdates();
-  void GenerateTimer(const PVR_TIMER& timer, bool newtimer = true);
   int GetTimerId(const PVR_TIMER& timer);
 
   // helper functions

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -46,7 +46,10 @@ public:
   {}
 
 public:
-  /*!< @brief unique id passed to xbmc database. see FIXME for more details */
+  /*!< @brief unique id passed to xbmc database.
+   * starts at 1 and increases by each channel regardless of hidden state.
+   * see FIXME for more details
+   */
   unsigned int id;
   /*!< @brief backend number for generating the stream url */
   unsigned int backendNr;
@@ -80,14 +83,14 @@ public:
   {}
 
 public:
-  int iEventId;
-  CStdString strTitle;
-  unsigned int iChannelUid;
+  unsigned int id;
+  DvbChannel *channel;
+  CStdString title;
   time_t startTime;
   time_t endTime;
   unsigned int genre;
-  CStdString strPlotOutline;
-  CStdString strPlot;
+  CStdString plotOutline;
+  CStdString plot;
 };
 
 class DvbTimer
@@ -245,14 +248,16 @@ private:
   std::vector<CStdString> m_recfolders;
 
   CStdString m_url;
+
+  /* channels */
+  DvbChannels_t m_channels;
+  /* active (not hidden) channels */
+  unsigned int m_channelAmount;
   unsigned int m_currentChannel;
 
-  /* channels + active (not hidden) channels */
-  DvbChannels_t m_channels;
-  unsigned int m_channelAmount;
-
-  /* channel groups + active (not hidden) groups */
+  /* channel groups */
   DvbGroups_t m_groups;
+  /* active (not hidden) groups */
   unsigned int m_groupAmount;
 
   bool m_updateTimers;

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -140,14 +140,14 @@ public:
 class DvbRecording
 {
 public:
-  enum Group
+  enum Grouping
   {
-    GroupingDisabled = 0,
-    GroupByDirectory,
-    GroupByDate,
-    GroupByFirstLetter,
-    GroupByTVChannel,
-    GroupBySeries
+    GROUPING_DISABLED = 0,
+    GROUP_BY_DIRECTORY,
+    GROUP_BY_DATE,
+    GROUP_BY_FIRST_LETTER,
+    GROUP_BY_TV_CHANNEL,
+    GROUP_BY_SERIES
   };
 
 public:

--- a/addons/pvr.dvbviewer/src/DvbData.h
+++ b/addons/pvr.dvbviewer/src/DvbData.h
@@ -4,6 +4,7 @@
 #define PVR_DVBVIEWER_DVBDATA_H
 
 #include "client.h"
+#include "RecordingReader.h"
 #include "platform/util/StdString.h"
 #include "platform/threads/threads.h"
 #include <list>
@@ -165,7 +166,6 @@ public:
   int duration;
   unsigned int genre;
   CStdString title;
-  CStdString streamURL;
   CStdString plot;
   CStdString plotOutline;
   CStdString channelName;
@@ -210,6 +210,7 @@ public:
   bool GetRecordings(ADDON_HANDLE handle);
   bool DeleteRecording(const PVR_RECORDING& recinfo);
   unsigned int GetRecordingsAmount();
+  RecordingReader *OpenRecordedStream(const PVR_RECORDING &recinfo);
 
   bool OpenLiveStream(const PVR_CHANNEL& channelinfo);
   void CloseLiveStream();
@@ -242,6 +243,7 @@ private:
   bool m_connected;
   unsigned int m_backendVersion;
   CStdString m_url;
+  CStdString m_recordingURL;
 
   long m_timezone;
   struct { long long total, used; } m_diskspace;

--- a/addons/pvr.dvbviewer/src/RecordingReader.cpp
+++ b/addons/pvr.dvbviewer/src/RecordingReader.cpp
@@ -1,0 +1,100 @@
+#include "RecordingReader.h"
+#include "client.h"
+#include "platform/util/util.h"
+#include "platform/threads/mutex.h"
+
+#define REOPEN_INTERVAL      30
+#define REOPEN_INTERVAL_FAST 10
+
+using namespace ADDON;
+
+RecordingReader::RecordingReader(CStdString streamURL, time_t end)
+  : m_streamURL(streamURL), m_end(end), m_fastReopen(false), m_playback(false)
+{
+  m_readHandle = XBMC->OpenFile(m_streamURL, 0);
+  m_len = XBMC->GetFileLength(m_readHandle);
+  m_pos = 0;
+  m_nextReopen = time(NULL) + REOPEN_INTERVAL;
+  XBMC->Log(LOG_DEBUG, "RecordingReader: Started; url=%s, end=%u",
+      m_streamURL.c_str(), m_end);
+}
+
+RecordingReader::~RecordingReader(void)
+{
+  if (m_readHandle)
+    XBMC->CloseFile(m_readHandle);
+  XBMC->Log(LOG_DEBUG, "RecordingReader: Stopped");
+}
+
+bool RecordingReader::IsValid()
+{
+  return (m_readHandle != NULL);
+}
+
+int RecordingReader::ReadData(unsigned char *buffer, unsigned int size)
+{
+  /* check for playback of ongoing recording */
+  if (m_playback && m_end)
+  {
+    time_t now = time(NULL);
+    if (now > m_nextReopen)
+    {
+FORCE_REOPEN:
+      /* reopen stream */
+      XBMC->Log(LOG_DEBUG, "RecordingReader: Reopening stream...");
+      XBMC->CloseFile(m_readHandle);
+      m_readHandle = XBMC->OpenFile(m_streamURL, 0);
+      m_len = XBMC->GetFileLength(m_readHandle);
+      XBMC->SeekFile(m_readHandle, m_pos, SEEK_SET);
+
+      m_nextReopen = now + ((m_fastReopen) ? REOPEN_INTERVAL_FAST : REOPEN_INTERVAL);
+
+      /* recording has finished */
+      if (now > m_end)
+        m_end = 0;
+    }
+    else if (m_pos == m_len)
+    {
+      /* in case we reached the end we need to wait a little */
+      int sleep = REOPEN_INTERVAL_FAST + 5;
+      if (!m_fastReopen)
+        sleep = std::min(sleep, static_cast<int>(m_nextReopen - now + 1));
+      XBMC->Log(LOG_DEBUG, "RecordingReader: End reached. Sleeping %d secs",
+          sleep);
+      PLATFORM::CEvent::Sleep(sleep * 1000);
+      now += sleep;
+      m_fastReopen = true;
+      goto FORCE_REOPEN;
+    }
+  }
+
+  unsigned int read = XBMC->ReadFile(m_readHandle, buffer, size);
+  m_pos += read;
+  return read;
+}
+
+long long RecordingReader::Seek(long long position, int whence)
+{
+  int64_t ret = XBMC->SeekFile(m_readHandle, position, whence);
+  // for unknown reason seek sometimes doesn't return the correct position
+  // so let's sync with the underlaying implementation
+  m_pos = XBMC->GetFilePosition(m_readHandle);
+  m_len = XBMC->GetFileLength(m_readHandle);
+  return ret;
+}
+
+long long RecordingReader::Position()
+{
+  return m_pos;
+}
+
+long long RecordingReader::Length()
+{
+  return m_len;
+}
+
+void RecordingReader::Announce(const char *message)
+{
+  if (strcmp(message, "OnPlay") == 0)
+    m_playback = true;
+}

--- a/addons/pvr.dvbviewer/src/RecordingReader.h
+++ b/addons/pvr.dvbviewer/src/RecordingReader.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#ifndef PVR_DVBVIEWER_RECORDINGREADER_H
+#define PVR_DVBVIEWER_RECORDINGREADER_H
+
+#include "platform/util/StdString.h"
+
+class RecordingReader
+{
+public:
+  RecordingReader(CStdString streamURL, time_t end);
+  ~RecordingReader(void);
+  int ReadData(unsigned char *buffer, unsigned int size);
+  bool IsValid();
+  long long Seek(long long position, int whence);
+  long long Position();
+  long long Length();
+  void Announce(const char *message);
+
+private:
+  CStdString m_streamURL;
+  void *m_readHandle;
+
+  /*!< @brief end time of the recording in case this an ongoing recording */
+  time_t m_end;
+  time_t m_nextReopen;
+  bool m_fastReopen;
+
+  /*!< @brief indicates if ffmpeg playback has started
+   * In case we reach the end we need to sleep until the next reopen. However
+   * during start/seek/jump/resume ffmpeg seeks and reads till the end.
+   */
+  bool m_playback;
+  uint64_t m_pos;
+  uint64_t m_len;
+};
+
+#endif

--- a/addons/pvr.dvbviewer/src/TimeshiftBuffer.cpp
+++ b/addons/pvr.dvbviewer/src/TimeshiftBuffer.cpp
@@ -8,10 +8,10 @@
 
 using namespace ADDON;
 
-TimeshiftBuffer::TimeshiftBuffer(CStdString streamUrl, CStdString bufferPath)
+TimeshiftBuffer::TimeshiftBuffer(CStdString streamURL, CStdString bufferPath)
   : m_bufferPath(bufferPath)
 {
-  m_streamHandle = XBMC->OpenFile(streamUrl, READ_NO_CACHE);
+  m_streamHandle = XBMC->OpenFile(streamURL, READ_NO_CACHE);
   m_bufferPath += "/tsbuffer.ts";
   m_filebufferWriteHandle = XBMC->OpenFileForWrite(m_bufferPath, true);
 #ifndef TARGET_POSIX

--- a/addons/pvr.dvbviewer/src/TimeshiftBuffer.cpp
+++ b/addons/pvr.dvbviewer/src/TimeshiftBuffer.cpp
@@ -51,7 +51,7 @@ void TimeshiftBuffer::Stop()
 
 void *TimeshiftBuffer::Process()
 {
-  XBMC->Log(LOG_DEBUG, "Timeshift: thread started");
+  XBMC->Log(LOG_DEBUG, "Timeshift: Thread started");
   byte buffer[STREAM_READ_BUFFER_SIZE];
 
   while (m_start)
@@ -65,7 +65,7 @@ void *TimeshiftBuffer::Process()
     m_mutex.Unlock();
 #endif
   }
-  XBMC->Log(LOG_DEBUG, "Timeshift: thread stopped");
+  XBMC->Log(LOG_DEBUG, "Timeshift: Thread stopped");
   return NULL;
 }
 

--- a/addons/pvr.dvbviewer/src/TimeshiftBuffer.cpp
+++ b/addons/pvr.dvbviewer/src/TimeshiftBuffer.cpp
@@ -2,12 +2,16 @@
 #include "client.h"
 #include "platform/util/util.h"
 
+#define STREAM_READ_BUFFER_SIZE   32768
+#define BUFFER_READ_TIMEOUT       10000
+#define BUFFER_READ_WAITTIME      50
+
 using namespace ADDON;
 
-TimeshiftBuffer::TimeshiftBuffer(CStdString streampath, CStdString bufferpath)
-  : m_bufferPath(bufferpath)
+TimeshiftBuffer::TimeshiftBuffer(CStdString streamUrl, CStdString bufferPath)
+  : m_bufferPath(bufferPath)
 {
-  m_streamHandle = XBMC->OpenFile(streampath, READ_NO_CACHE);
+  m_streamHandle = XBMC->OpenFile(streamUrl, READ_NO_CACHE);
   m_bufferPath += "/tsbuffer.ts";
   m_filebufferWriteHandle = XBMC->OpenFileForWrite(m_bufferPath, true);
 #ifndef TARGET_POSIX
@@ -35,7 +39,9 @@ TimeshiftBuffer::~TimeshiftBuffer(void)
 
 bool TimeshiftBuffer::IsValid()
 {
-  return (m_streamHandle != NULL);
+  return (m_streamHandle != NULL
+      && m_filebufferWriteHandle != NULL
+      && m_filebufferReadHandle != NULL);
 }
 
 void TimeshiftBuffer::Stop()
@@ -65,23 +71,16 @@ void *TimeshiftBuffer::Process()
 
 long long TimeshiftBuffer::Seek(long long position, int whence)
 {
-  if (m_filebufferReadHandle)
-    return XBMC->SeekFile(m_filebufferReadHandle, position, whence);
-  return -1;
+  return XBMC->SeekFile(m_filebufferReadHandle, position, whence);
 }
 
 long long TimeshiftBuffer::Position()
 {
-  if (m_filebufferReadHandle)
-    return XBMC->GetFilePosition(m_filebufferReadHandle);
-  return -1;
+  return XBMC->GetFilePosition(m_filebufferReadHandle);
 }
 
 long long TimeshiftBuffer::Length()
 {
-  if (!m_filebufferReadHandle || !m_filebufferWriteHandle)
-    return 0;
-
   // We can't use GetFileLength here as it's value will be cached
   // by XBMC until we read or seek above it.
   // see xbm/xbmc/filesystem/HDFile.cpp CHDFile::GetLength()
@@ -102,11 +101,8 @@ long long TimeshiftBuffer::Length()
 
 int TimeshiftBuffer::ReadData(unsigned char *buffer, unsigned int size)
 {
-  if (!m_filebufferReadHandle || !m_filebufferWriteHandle)
-    return 0;
-
   /* make sure we never read above the current write position */
-  int64_t readPos  = XBMC->GetFilePosition(m_filebufferReadHandle);
+  int64_t readPos = XBMC->GetFilePosition(m_filebufferReadHandle);
   unsigned int timeWaited = 0;
   while (readPos + size > Length())
   {

--- a/addons/pvr.dvbviewer/src/TimeshiftBuffer.h
+++ b/addons/pvr.dvbviewer/src/TimeshiftBuffer.h
@@ -6,18 +6,14 @@
 #include "platform/util/StdString.h"
 #include "platform/threads/threads.h"
 
-#define STREAM_READ_BUFFER_SIZE   32768
-#define BUFFER_READ_TIMEOUT       10000
-#define BUFFER_READ_WAITTIME      50
-
 class TimeshiftBuffer
   : public PLATFORM::CThread
 {
 public:
-  TimeshiftBuffer(CStdString streamPath, CStdString bufferPath);
+  TimeshiftBuffer(CStdString streamUrl, CStdString bufferPath);
   ~TimeshiftBuffer(void);
-  int ReadData(unsigned char *buffer, unsigned int size);
   bool IsValid();
+  int ReadData(unsigned char *buffer, unsigned int size);
   long long Seek(long long position, int whence);
   long long Position();
   long long Length();

--- a/addons/pvr.dvbviewer/src/TimeshiftBuffer.h
+++ b/addons/pvr.dvbviewer/src/TimeshiftBuffer.h
@@ -10,7 +10,7 @@ class TimeshiftBuffer
   : public PLATFORM::CThread
 {
 public:
-  TimeshiftBuffer(CStdString streamUrl, CStdString bufferPath);
+  TimeshiftBuffer(CStdString streamURL, CStdString bufferPath);
   ~TimeshiftBuffer(void);
   bool IsValid();
   int ReadData(unsigned char *buffer, unsigned int size);

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -40,11 +40,11 @@ CStdString g_password             = "";
 bool       g_useFavourites        = false;
 bool       g_useFavouritesFile    = false;
 CStdString g_favouritesFile       = "";
-int        g_groupRecordings      = DvbRecording::GroupingDisabled;
+int        g_groupRecordings      = DvbRecording::GROUPING_DISABLED;
 bool       g_useTimeshift         = false;
 CStdString g_timeshiftBufferPath  = DEFAULT_TSBUFFERPATH;
 bool       g_useRTSP              = false;
-int        g_prependOutline       = PrependOutline::InEPG;
+int        g_prependOutline       = PrependOutline::IN_EPG;
 bool       g_lowPerformance       = false;
 
 ADDON_STATUS m_curStatus    = ADDON_STATUS_UNKNOWN;
@@ -81,7 +81,7 @@ void ADDON_ReadSettings(void)
     g_favouritesFile = buffer;
 
   if (!XBMC->GetSetting("grouprecordings", &g_groupRecordings))
-    g_groupRecordings = DvbRecording::GroupingDisabled;
+    g_groupRecordings = DvbRecording::GROUPING_DISABLED;
 
   if (!XBMC->GetSetting("usetimeshift", &g_useTimeshift))
     g_useTimeshift = false;
@@ -93,7 +93,7 @@ void ADDON_ReadSettings(void)
     g_useRTSP = false;
 
   if (!XBMC->GetSetting("prependoutline", &g_prependOutline))
-    g_prependOutline = PrependOutline::InEPG;
+    g_prependOutline = PrependOutline::IN_EPG;
 
   if (!XBMC->GetSetting("lowperformance", &g_lowPerformance))
     g_lowPerformance = false;
@@ -110,13 +110,13 @@ void ADDON_ReadSettings(void)
   XBMC->Log(LOG_DEBUG, "Use favourites: %s", (g_useFavourites) ? "yes" : "no");
   if (g_useFavouritesFile)
     XBMC->Log(LOG_DEBUG, "Favourites file: %s", g_favouritesFile.c_str());
-  if (g_groupRecordings != DvbRecording::GroupingDisabled)
+  if (g_groupRecordings != DvbRecording::GROUPING_DISABLED)
     XBMC->Log(LOG_DEBUG, "Group recordings: %d", g_groupRecordings);
   XBMC->Log(LOG_DEBUG, "Timeshift: %s", (g_useTimeshift) ? "enabled" : "disabled");
   if (g_useTimeshift)
     XBMC->Log(LOG_DEBUG, "Timeshift buffer path: %s", g_timeshiftBufferPath.c_str());
   XBMC->Log(LOG_DEBUG, "Use RTSP: %s", (g_useRTSP) ? "yes" : "no");
-  if (g_prependOutline != PrependOutline::Never)
+  if (g_prependOutline != PrependOutline::NEVER)
     XBMC->Log(LOG_DEBUG, "Prepend outline: %d", g_prependOutline);
   XBMC->Log(LOG_DEBUG, "Low performance mode: %s", (g_lowPerformance) ? "yes" : "no");
 }
@@ -239,7 +239,7 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
   }
   else if (sname == "grouprecordings")
   {
-    if (g_groupRecordings != *(const DvbRecording::Group *)settingValue)
+    if (g_groupRecordings != *(const DvbRecording::Grouping *)settingValue)
       return ADDON_STATUS_NEED_RESTART;
   }
   else if (sname == "timeshiftpath")

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -141,7 +141,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
     return ADDON_STATUS_PERMANENT_FAILURE;
   }
 
-  XBMC->Log(LOG_DEBUG, "%s Creating DVBViewer PVR-Client", __FUNCTION__);
+  XBMC->Log(LOG_DEBUG, "%s: Creating DVBViewer PVR-Client", __FUNCTION__);
   m_curStatus = ADDON_STATUS_UNKNOWN;
 
   ADDON_ReadSettings();
@@ -247,8 +247,9 @@ ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue)
     CStdString newValue = (const char *)settingValue;
     if (g_timeshiftBufferPath != newValue)
     {
-      XBMC->Log(LOG_DEBUG, "%s Changed Setting '%s' from '%s' to '%s'", __FUNCTION__,
-          settingName, g_timeshiftBufferPath.c_str(), newValue.c_str());
+      XBMC->Log(LOG_DEBUG, "%s: Changed setting '%s' from '%s' to '%s'",
+          __FUNCTION__, settingName, g_timeshiftBufferPath.c_str(),
+          newValue.c_str());
       g_timeshiftBufferPath = newValue;
     }
   }

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -287,7 +287,7 @@ void ADDON_FreeSettings()
 {
 }
 
-void ADDON_Announce(const char *flag, const char *sender,
+void ADDON_Announce(const char *_UNUSED(flag), const char *sender,
     const char *message, const void *_UNUSED(data))
 {
   if (recReader != NULL && strcmp(sender, "xbmc") == 0)
@@ -676,7 +676,7 @@ PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &_UNUSED(recording)
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &_UNUSED(recording)) { return -1; }
 PVR_ERROR RenameRecording(const PVR_RECORDING &_UNUSED(recording)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
-PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
+PVR_ERROR UndeleteRecording(const PVR_RECORDING& _UNUSED(recording)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }
 unsigned int GetChannelSwitchDelay(void) { return 0; }
 void PauseStream(bool _UNUSED(bPaused)) {}

--- a/addons/pvr.dvbviewer/src/client.cpp
+++ b/addons/pvr.dvbviewer/src/client.cpp
@@ -363,20 +363,37 @@ const char *GetBackendHostname(void)
   return g_hostname.c_str();
 }
 
-PVR_ERROR GetDriveSpace(long long *iTotal, long long *iUsed)
+PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
 {
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetDriveSpace(iTotal, iUsed);
+  // the RS api doesn't provide information about signal quality (yet)
+  strncpy(signalStatus.strAdapterName, "DVBViewer Recording Service",
+      sizeof(signalStatus.strAdapterName));
+  strncpy(signalStatus.strAdapterStatus, "OK",
+      sizeof(signalStatus.strAdapterStatus));
+  return PVR_ERROR_NO_ERROR;
 }
 
-PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel, time_t iStart, time_t iEnd)
+PVR_ERROR GetDriveSpace(long long *total, long long *used)
 {
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->GetDriveSpace(total, used))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
 
-  return DvbData->GetEPGForChannel(handle, channel, iStart, iEnd);
+/* channel functions */
+PVR_ERROR GetChannels(ADDON_HANDLE handle, bool radio)
+{
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->GetChannels(handle, radio))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+PVR_ERROR GetEPGForChannel(ADDON_HANDLE handle, const PVR_CHANNEL &channel,
+    time_t start, time_t end)
+{
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->GetEPGForChannel(handle, channel, start, end))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
 int GetChannelsAmount(void)
@@ -385,83 +402,6 @@ int GetChannelsAmount(void)
     return 0;
 
   return DvbData->GetChannelsAmount();
-}
-
-PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetChannels(handle, bRadio);
-}
-
-int GetRecordingsAmount(bool deleted)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetRecordingsAmount();
-}
-
-PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetRecordings(handle);
-}
-
-PVR_ERROR DeleteRecording(const PVR_RECORDING &recording)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->DeleteRecording(recording);
-}
-
-PVR_ERROR RenameRecording(const PVR_RECORDING &_UNUSED(recording))
-{
-  return PVR_ERROR_NOT_IMPLEMENTED;
-}
-
-int GetTimersAmount(void)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return 0;
-
-  return DvbData->GetTimersAmount();
-}
-
-PVR_ERROR GetTimers(ADDON_HANDLE handle)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetTimers(handle);
-}
-
-PVR_ERROR AddTimer(const PVR_TIMER &timer)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->AddTimer(timer);
-}
-
-PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete))
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->DeleteTimer(timer);
-}
-
-PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
-{
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->UpdateTimer(timer);
 }
 
 int GetCurrentClientChannel(void)
@@ -480,30 +420,63 @@ bool SwitchChannel(const PVR_CHANNEL &channel)
   return DvbData->SwitchChannel(channel);
 }
 
+/* channel group functions */
 int GetChannelGroupsAmount(void)
 {
   if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
+    return 0;
 
   return DvbData->GetChannelGroupsAmount();
 }
 
-PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio)
+PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool radio)
 {
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetChannelGroups(handle, bRadio);
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->GetChannelGroups(handle, radio))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
 PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group)
 {
-  if (!DvbData || !DvbData->IsConnected())
-    return PVR_ERROR_SERVER_ERROR;
-
-  return DvbData->GetChannelGroupMembers(handle, group);
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->GetChannelGroupMembers(handle, group))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
+/* timer functions */
+int GetTimersAmount(void)
+{
+  if (!DvbData || !DvbData->IsConnected())
+    return 0;
+
+  return DvbData->GetTimersAmount();
+}
+
+PVR_ERROR GetTimers(ADDON_HANDLE handle)
+{
+  return (DvbData && DvbData->IsConnected() && DvbData->GetTimers(handle))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+PVR_ERROR AddTimer(const PVR_TIMER &timer)
+{
+  return (DvbData && DvbData->IsConnected() && DvbData->AddTimer(timer))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+PVR_ERROR UpdateTimer(const PVR_TIMER &timer)
+{
+  return (DvbData && DvbData->IsConnected() && DvbData->AddTimer(timer, true))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+PVR_ERROR DeleteTimer(const PVR_TIMER &timer, bool _UNUSED(bForceDelete))
+{
+  return (DvbData && DvbData->IsConnected() && DvbData->DeleteTimer(timer))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+/* live stream functions */
 bool OpenLiveStream(const PVR_CHANNEL &channel)
 {
   if (!DvbData || !DvbData->IsConnected())
@@ -557,20 +530,20 @@ bool CanSeekStream(void)
   return g_useTimeshift;
 }
 
-int ReadLiveStream(unsigned char *pBuffer, unsigned int iBufferSize)
+int ReadLiveStream(unsigned char *buffer, unsigned int size)
 {
   if (!tsBuffer)
     return 0;
 
-  return tsBuffer->ReadData(pBuffer, iBufferSize);
+  return tsBuffer->ReadData(buffer, size);
 }
 
-long long SeekLiveStream(long long iPosition, int iWhence /* = SEEK_SET */)
+long long SeekLiveStream(long long position, int whence)
 {
   if (!tsBuffer)
     return -1;
 
-  return tsBuffer->Seek(iPosition, iWhence);
+  return tsBuffer->Seek(position, whence);
 }
 
 long long PositionLiveStream(void)
@@ -584,7 +557,7 @@ long long PositionLiveStream(void)
 long long LengthLiveStream(void)
 {
   if (!tsBuffer)
-    return 0;
+    return -1;
 
   return tsBuffer->Length();
 }
@@ -611,14 +584,27 @@ time_t GetPlayingTime()
   return GetBufferTimeEnd();
 }
 
-PVR_ERROR SignalStatus(PVR_SIGNAL_STATUS &signalStatus)
+/* recording stream functions */
+int GetRecordingsAmount(bool _UNUSED(deleted))
 {
-  // the RS api doesn't provide information about signal quality (yet)
-  strncpy(signalStatus.strAdapterName, "DVBViewer Recording Service",
-      sizeof(signalStatus.strAdapterName));
-  strncpy(signalStatus.strAdapterStatus, "OK",
-      sizeof(signalStatus.strAdapterStatus));
-  return PVR_ERROR_NO_ERROR;
+  if (!DvbData || !DvbData->IsConnected())
+    return PVR_ERROR_SERVER_ERROR;
+
+  return DvbData->GetRecordingsAmount();
+}
+
+PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool _UNUSED(deleted))
+{
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->GetRecordings(handle))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
+}
+
+PVR_ERROR DeleteRecording(const PVR_RECORDING &recording)
+{
+  return (DvbData && DvbData->IsConnected()
+      && DvbData->DeleteRecording(recording))
+    ? PVR_ERROR_NO_ERROR : PVR_ERROR_SERVER_ERROR;
 }
 
 /** UNUSED API FUNCTIONS */
@@ -643,6 +629,7 @@ long long LengthRecordedStream(void) { return -1; }
 PVR_ERROR SetRecordingPlayCount(const PVR_RECORDING &_UNUSED(recording), int _UNUSED(count)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR SetRecordingLastPlayedPosition(const PVR_RECORDING &_UNUSED(recording), int _UNUSED(lastplayedposition)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 int GetRecordingLastPlayedPosition(const PVR_RECORDING &_UNUSED(recording)) { return -1; }
+PVR_ERROR RenameRecording(const PVR_RECORDING &_UNUSED(recording)) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR GetRecordingEdl(const PVR_RECORDING&, PVR_EDL_ENTRY[], int*) { return PVR_ERROR_NOT_IMPLEMENTED; };
 PVR_ERROR UndeleteRecording(const PVR_RECORDING& recording) { return PVR_ERROR_NOT_IMPLEMENTED; }
 PVR_ERROR DeleteAllRecordingsFromTrash() { return PVR_ERROR_NOT_IMPLEMENTED; }

--- a/addons/pvr.dvbviewer/src/client.h
+++ b/addons/pvr.dvbviewer/src/client.h
@@ -74,9 +74,21 @@ extern int           g_groupRecordings;
 extern bool          g_useTimeshift;
 extern CStdString    g_timeshiftBufferPath;
 extern bool          g_useRTSP;
+extern int           g_prependOutline;
 extern bool          g_lowPerformance;
 
 extern ADDON::CHelper_libXBMC_addon *XBMC;
 extern CHelper_libXBMC_pvr *PVR;
+
+//TODO: convert to enum class as soon as c++11 is available
+class PrependOutline
+{
+public:
+  enum options { Never = 0, InEPG, InRecordings, Always };
+  static bool test(options flag)
+  {
+    return (g_prependOutline == flag || g_prependOutline == Always);
+  }
+};
 
 #endif

--- a/addons/pvr.dvbviewer/src/client.h
+++ b/addons/pvr.dvbviewer/src/client.h
@@ -84,10 +84,10 @@ extern CHelper_libXBMC_pvr *PVR;
 class PrependOutline
 {
 public:
-  enum options { Never = 0, InEPG, InRecordings, Always };
+  enum options { NEVER = 0, IN_EPG, IN_RECORDINGS, ALWAYS };
   static bool test(options flag)
   {
-    return (g_prependOutline == flag || g_prependOutline == Always);
+    return (g_prependOutline == flag || g_prependOutline == ALWAYS);
   }
 };
 


### PR DESCRIPTION
Changes:
* added recording reader: Allows playback of ongoing recordings. There are still some minor quirks. e.g. In case we reach the end during playback/seek we'll sleep until the next refresh. This should happen once but sometimes this happens twice.
* added support for putting outline before plot
* removed custom notification if backend is unavailable
* fixed a bug where a new timer has been removed and re-added again shortly after it has been added the first time
* more code re-factorization