### PR TITLE
[pvr.wmc] fix version in clientverison.h to match addon.xml

### DIFF
--- a/addons/pvr.wmc/src/clientversion.h
+++ b/addons/pvr.wmc/src/clientversion.h
@@ -23,5 +23,5 @@
 
 inline CStdString PVRWMC_GetClientVersion()
 {
-	return "0.4.003";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
+	return "0.5.1";	// ALSO CHANGE IN REV NUMBER in 'addon.xml.in' 
 }


### PR DESCRIPTION
recent version bumps in addon.xml file were not also made in clientversion.h

once the new build system is in id like to look at generating the clientversion.h file at build time (from the addon.xml version number) to avoid needing to bump it in 2 places but for now it's required
