### PR TITLE
Fix gui lib min version to match backword compatibility to skins

### DIFF
--- a/xbmc/libXBMC_gui.h
+++ b/xbmc/libXBMC_gui.h
@@ -39,7 +39,7 @@ typedef void* GUIHANDLE;
 #define XBMC_GUI_API_VERSION "5.8.0"
 
 /* min. ADDONGUI API version */
-#define XBMC_GUI_MIN_API_VERSION "5.8.0"
+#define XBMC_GUI_MIN_API_VERSION "5.3.0"
 
 #define ADDON_ACTION_PREVIOUS_MENU          10
 #define ADDON_ACTION_CLOSE_DIALOG           51


### PR DESCRIPTION
On gui skin I has badly corrected the backword compatibility to 5.8.0, which destroy all current skins. Due to version affiliation I created this request to match skins.
