### PR TITLE
[pvr.filmon] Fix compile error on function with missing value name

### DIFF
--- a/addons/pvr.filmon/src/client.cpp
+++ b/addons/pvr.filmon/src/client.cpp
@@ -302,7 +302,7 @@ int GetRecordingsAmount(bool deleted) {
 	return -1;
 }
 
-PVR_ERROR GetRecordings(ADDON_HANDLE, bool deleted) {
+PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool deleted) {
 	if (m_data)
 		return m_data->GetRecordings(handle);
 


### PR DESCRIPTION
Due to missing dependencies has not seen this during build test. Has forgot to set the name for the value This change fix this error.
