### PR TITLE
Fix race condition on channel GUID cache

### DIFF
--- a/addons/pvr.argustv/addon/addon.xml.in
+++ b/addons/pvr.argustv/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.argustv"
-  version="1.9.186"
+  version="1.9.187"
   name="ARGUS TV client"
   provider-name="Fred Hoogduin, Marcel Groothuis">
   <requires>

--- a/addons/pvr.argustv/addon/changelog.txt
+++ b/addons/pvr.argustv/addon/changelog.txt
@@ -1,3 +1,5 @@
+v1.9.187 (22-03-2015)
+- Fix race condition on Channel GUID cache
 v1.9.186 (15-02-2015)
 - platform fixes
 v1.9.185 (02-12-2014)

--- a/addons/pvr.argustv/src/pvrclient-argustv.cpp
+++ b/addons/pvr.argustv/src/pvrclient-argustv.cpp
@@ -418,6 +418,7 @@ int cPVRClientArgusTV::GetNumChannels()
 
 PVR_ERROR cPVRClientArgusTV::GetChannels(ADDON_HANDLE handle, bool bRadio)
 {
+  CLockObject lock(m_ChannelCacheMutex);
   Json::Value response;
   int retval = -1;
 
@@ -1123,6 +1124,7 @@ cChannel* cPVRClientArgusTV::FetchChannel(int channelid, bool LogError)
 
 cChannel* cPVRClientArgusTV::FetchChannel(std::vector<cChannel*> m_Channels, int channelid, bool LogError)
 {
+  CLockObject lock(m_ChannelCacheMutex);
   // Search for this channel in our local channel list to find the original ChannelID back:
   vector<cChannel*>::iterator it;
 

--- a/addons/pvr.argustv/src/pvrclient-argustv.h
+++ b/addons/pvr.argustv/src/pvrclient-argustv.h
@@ -123,6 +123,7 @@ private:
   time_t                  m_BackendUTCoffset;
   time_t                  m_BackendTime;
 
+  PLATFORM::CMutex        m_ChannelCacheMutex;
   std::vector<cChannel*>   m_TVChannels; // Local TV channel cache list needed for id to guid conversion
   std::vector<cChannel*>   m_RadioChannels; // Local Radio channel cache list needed for id to guid conversion
   int                     m_epg_id_offset;


### PR DESCRIPTION
Back port of PR #452 for Helix

Use mutex to fix concurrent threads accessing and clearing the channel GUID cache at the same time,
this fixes an issue when resuming from standby (discovered on OpenElec kodi)
