### PR TITLE
pvr.dvblink: version 1.9.13.1 for Helix

### DIFF
--- a/addons/pvr.dvblink/addon/addon.xml.in
+++ b/addons/pvr.dvblink/addon/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.dvblink"
-  version="1.9.12"
+  version="1.9.13.1"
   name="DVBLink PVR Client"
   provider-name="DVBLogic">
   <requires>

--- a/addons/pvr.dvblink/addon/changelog.txt
+++ b/addons/pvr.dvblink/addon/changelog.txt
@@ -1,3 +1,15 @@
+[B]Version 1.9.13.1[/B]
+Added: Extended series settings dialog
+Added: "No grouping for single recording" setting
+Fixed: Long delay when starting transcoded stream from server that does not support it
+Speed and memory use optimizations
+
+[B]Version 1.9.13[/B]
+Fixed: no timers are added from EPG of DVBLink TV Adviser product
+Added: Grouping recordings by series
+Added: Year to the episode title
+Fixed: incorrect available disk space calculations
+
 [B]Version 1.9.12[/B]
 Fixed: platform fixes
 

--- a/addons/pvr.dvblink/addon/resources/language/English/strings.po
+++ b/addons/pvr.dvblink/addon/resources/language/English/strings.po
@@ -118,7 +118,12 @@ msgctxt "#30203"
 msgid "Combine title and episode name for recordings"
 msgstr ""
 
-#empty strings from id 30204 to 32000
+msgctxt "#30204"
+msgid "Group Recordings by Series"
+msgstr ""
+
+#empty strings from id 30205 to 32000
+
 #category labels
 
 msgctxt "#32001"
@@ -181,4 +186,40 @@ msgstr ""
 
 msgctxt "#32016"
 msgid "Delete the entire series"
+msgstr ""
+
+msgctxt "#32017"
+msgid "Margin before (minutes)"
+msgstr ""
+
+msgctxt "#32018"
+msgid "Margin after (minutes)"
+msgstr ""
+
+msgctxt "#32019"
+msgid "New episodes only"
+msgstr ""
+
+msgctxt "#32020"
+msgid "Broadcast anytime"
+msgstr ""
+
+msgctxt "#32021"
+msgid "Number of episodes to keep"
+msgstr ""
+
+msgctxt "#32022"
+msgid "Default"
+msgstr ""
+
+msgctxt "#32023"
+msgid "Keep all"
+msgstr ""
+
+msgctxt "#32024"
+msgid "Playback failed. Server does not support transcoding"
+msgstr ""
+
+msgctxt "#32025"
+msgid "Do not group single recordings"
 msgstr ""

--- a/addons/pvr.dvblink/addon/resources/settings.xml
+++ b/addons/pvr.dvblink/addon/resources/settings.xml
@@ -21,5 +21,7 @@
   <category label="30200">   
 		<setting id="showinfomsg" type="bool" label="30202" default="false" />
 		<setting id="add_rec_episode_info" type="bool" label="30203" default="true" />
-</category>
+		<setting id="group_recordings_by_series" type="bool" label="30204" default="true" />
+		<setting id="no_group_for_single_record"  visible="eq(-1,true)" type="bool" label="32025" default="false" />
+  </category>
 </settings>

--- a/addons/pvr.dvblink/addon/resources/skins/skin.confluence/720p/RecordPrefs.xml
+++ b/addons/pvr.dvblink/addon/resources/skins/skin.confluence/720p/RecordPrefs.xml
@@ -12,7 +12,7 @@
       <posx>0</posx>
       <posy>0</posy>
       <width>800</width>
-      <height>300</height>
+      <height>530</height>
       <texture border="40">DialogBack.png</texture>
     </control>
     <control type="image">
@@ -54,11 +54,11 @@
       <visible>system.getbool(input.enablemouse)</visible>
     </control>
     
-    <control type="group" description ="radio buttons">
+    <control type="group" description ="record prefs">
       <posx>40</posx>
       <posy>100</posy>
       <width>720</width>
-      <height>100</height>
+      <height>360</height>
       <control type="radiobutton" id="10">
         <description>episode recording</description>
         <posx>0</posx>
@@ -92,13 +92,109 @@
         <onright>11</onright>
         <onleft>11</onleft>
         <onup>10</onup>
-        <ondown>1</ondown>
+        <ondown>12</ondown>
       </control>
-    </control>
 
+      <control type="image" id="108">
+        <description>Separator</description>
+        <posx>0</posx>
+        <posy>95</posy>
+        <height>2</height>
+        <width>720</width>
+        <aspectratio align="left" aligny="top">stretch</aspectratio>
+        <texture>separator2.png</texture>
+      </control>
+	  
+      <control type="spincontrolex" id="12">
+        <description>Record minutes before</description>
+        <posx>0</posx>
+        <posy>107</posy>
+        <height>40</height>
+        <width>720</width>
+        <label>$ADDON[pvr.dvblink 32017]</label>
+        <onright>11</onright>
+        <onleft>11</onleft>
+        <onup>11</onup>
+        <ondown>13</ondown>
+      </control>
+
+      <control type="spincontrolex" id="13">
+        <description>Record minutes after</description>
+        <posx>0</posx>
+        <posy>154</posy>
+        <height>40</height>
+        <width>720</width>
+        <label>$ADDON[pvr.dvblink 32018]</label>
+        <onright>11</onright>
+        <onleft>11</onleft>
+        <onup>12</onup>
+        <ondown>14</ondown>
+      </control>
+
+      <control type="image" id="109">
+        <description>Separator</description>
+        <posx>0</posx>
+        <posy>204</posy>
+        <height>2</height>
+        <width>720</width>
+        <aspectratio align="left" aligny="top">stretch</aspectratio>
+        <texture>separator2.png</texture>
+      </control>
+
+      <control type="radiobutton" id="14">
+        <description>new only</description>
+        <posx>0</posx>
+        <posy>216</posy>
+        <height>40</height>
+        <width>720</width>
+        <label>$ADDON[pvr.dvblink 32019]</label>
+        <font>font13</font>
+        <textcolor>grey2</textcolor>
+        <focusedcolor>white</focusedcolor>
+        <texturenofocus border="5">button-nofocus.png</texturenofocus>
+        <texturefocus border="5">button-focus2.png</texturefocus>
+        <onright>10</onright>
+        <onleft>10</onleft>
+        <onup>13</onup>
+        <ondown>15</ondown>
+      </control>
+
+      <control type="radiobutton" id="15">
+        <description>anytime</description>
+        <posx>0</posx>
+        <posy>261</posy>
+        <height>40</height>
+        <width>720</width>
+        <label>$ADDON[pvr.dvblink 32020]</label>
+        <font>font13</font>
+        <textcolor>grey2</textcolor>
+        <focusedcolor>white</focusedcolor>
+        <texturenofocus border="5">button-nofocus.png</texturenofocus>
+        <texturefocus border="5">button-focus2.png</texturefocus>
+        <onright>11</onright>
+        <onleft>11</onleft>
+        <onup>14</onup>
+        <ondown>16</ondown>
+      </control>
+
+      <control type="spincontrolex" id="16">
+        <description>number to keep</description>
+        <posx>0</posx>
+        <posy>306</posy>
+        <height>40</height>
+        <width>720</width>
+        <label>$ADDON[pvr.dvblink 32021]</label>
+        <onright>11</onright>
+        <onleft>11</onleft>
+        <onup>15</onup>
+        <ondown>1</ondown>
+      </control>	  
+	  
+	</control>
+	
     <control type="group" id="9001">
       <posx>190</posx>
-      <posy>235</posy>
+      <posy>455</posy>
       <control type="button" id="1">
         <description>Ok Button</description>
         <posx>0</posx>
@@ -111,7 +207,7 @@
         <texturefocus border="5">button-focus.png</texturefocus>
         <label>186</label>
         <font>font12_title</font>
-        <onup>11</onup>
+        <onup>16</onup>
         <onleft>2</onleft>
         <onright>2</onright>
         <ondown>10</ondown>
@@ -128,7 +224,7 @@
         <texturefocus border="5">button-focus.png</texturefocus>
         <label>222</label>
         <font>font12_title</font>
-        <onup>11</onup>
+        <onup>16</onup>
         <onleft>1</onleft>
         <onright>1</onright>
         <ondown>10</ondown>

--- a/addons/pvr.dvblink/src/DVBLinkClient.h
+++ b/addons/pvr.dvblink/src/DVBLinkClient.h
@@ -40,6 +40,7 @@
 
 #define DVBLINK_BUILD_IN_RECORDER_SOURCE_ID   "8F94B459-EFC0-4D91-9B29-EC3D72E92677"
 #define DVBLINK_RECODINGS_BY_DATA_ID   "F6F08949-2A07-4074-9E9D-423D877270BB"
+#define DVBLINK_RECODINGS_BY_SERIES_ID   "0E03FEB8-BD8F-46e7-B3EF-34F6890FB458"
 
 typedef std::map<std::string, std::string> recording_id_to_url_map_t;
 
@@ -47,7 +48,7 @@ class DVBLinkClient : public PLATFORM::CThread
 {
 public:
     DVBLinkClient(ADDON::CHelper_libXBMC_addon* xbmc, CHelper_libXBMC_pvr* pvr, CHelper_libXBMC_gui* gui, std::string clientname, std::string hostname, long port, 
-        bool showinfomsg, std::string username, std::string password, bool add_episode_to_rec_title);
+        bool showinfomsg, std::string username, std::string password, bool add_episode_to_rec_title, bool group_recordings_by_series, bool no_group_single_rec);
   ~DVBLinkClient(void);
   int GetChannelsAmount();
   PVR_ERROR GetChannels(ADDON_HANDLE handle, bool bRadio);
@@ -60,6 +61,10 @@ public:
   PVR_ERROR AddTimer(const PVR_TIMER &timer);
   PVR_ERROR DeleteTimer(const PVR_TIMER &timer);
   PVR_ERROR UpdateTimer(const PVR_TIMER &timer);
+  int GetChannelGroupsAmount(void);
+  PVR_ERROR GetChannelGroups(ADDON_HANDLE handle, bool bRadio);
+  PVR_ERROR GetChannelGroupMembers(ADDON_HANDLE handle, const PVR_CHANNEL_GROUP &group);
+
   bool GetStatus();
   bool StartStreaming(const PVR_CHANNEL &channel, dvblinkremote::StreamRequest* streamRequest, std::string& stream_url);
   bool OpenLiveStream(const PVR_CHANNEL &channel, bool use_timeshift, bool use_transcoder, int width, int height, int bitrate, std::string audiotrack);
@@ -82,6 +87,8 @@ private:
   std::string GetRecordedTVByDateObjectID(const std::string& buildInRecoderObjectID);
   int GetInternalUniqueIdFromChannelId(const std::string& channelId);
   virtual void * Process(void);
+  bool build_recording_series_map(std::map<std::string, std::string>& rec_id_to_series_name);
+  bool get_dvblink_program_id(std::string& channelId, int start_time, std::string& dvblink_program_id);
 
   std::string make_timer_hash(const std::string& timer_id, const std::string& schedule_id);
   bool parse_timer_hash(const char* timer_hash, std::string& timer_id, std::string& schedule_id);
@@ -103,10 +110,19 @@ private:
   std::string m_hostname;
   LiveStreamerBase* m_live_streamer;
   bool m_add_episode_to_rec_title;
+  bool m_group_recordings_by_series;
   bool m_showinfomsg;
   bool m_updating;
   std::string m_recordingsid;
+  std::string m_recordingsid_by_date;
+  std::string m_recordingsid_by_series;
   recording_id_to_url_map_t m_recording_id_to_url_map;
+  bool setting_margins_supported_;
+  bool favorites_supported_;
+  bool transcoding_supported_;
+  dvblinkremote::ChannelFavorites channel_favorites_;
+  std::map<std::string, int> inverse_channel_map_;
+  bool no_group_single_rec_;
 };
 
 /*!

--- a/addons/pvr.dvblink/src/DialogRecordPref.cpp
+++ b/addons/pvr.dvblink/src/DialogRecordPref.cpp
@@ -120,8 +120,6 @@ void CDialogRecordPref::PopulateKeepSpin(CAddonGUISpinControl* spin)
     spin->AddLabel("5", 5);
     spin->AddLabel("6", 6);
     spin->AddLabel("7", 7);
-    spin->AddLabel("8", 8);
-    spin->AddLabel("9", 9);
     spin->AddLabel("10", 10);
 }
 

--- a/addons/pvr.dvblink/src/DialogRecordPref.cpp
+++ b/addons/pvr.dvblink/src/DialogRecordPref.cpp
@@ -31,10 +31,21 @@ using namespace ADDON;
 
 #define RADIO_BUTTON_EPISODE			10
 #define RADIO_BUTTON_SERIES				11
+#define SPIN_MARGIN_BEFORE  			12
+#define SPIN_MARGIN_AFTER				13
+#define RADIO_BUTTON_NEW_ONLY			14
+#define RADIO_BUTTON_ANYTIME			15
+#define SPIN_REC_TO_KEEP				16
 
-CDialogRecordPref::CDialogRecordPref(CHelper_libXBMC_addon* xbmc, CHelper_libXBMC_gui* gui, bool recSeries)
+CDialogRecordPref::CDialogRecordPref(CHelper_libXBMC_addon* xbmc, CHelper_libXBMC_gui* gui)
 {
-	RecSeries = recSeries;
+	RecSeries = false;
+    newOnly = true;
+    anytime = true;
+    marginBefore = c_default_margin;
+    marginAfter = c_default_margin;
+    numberToKeep = c_keep_all_recordings;
+
     GUI = gui;
     XBMC = xbmc;
 
@@ -58,10 +69,60 @@ bool CDialogRecordPref::OnInit()
 	// init radio buttons
 	_radioRecEpisode = GUI->Control_getRadioButton(_window, RADIO_BUTTON_EPISODE);
 	_radioRecSeries = GUI->Control_getRadioButton(_window, RADIO_BUTTON_SERIES);
+    _radioNewOnly = GUI->Control_getRadioButton(_window, RADIO_BUTTON_NEW_ONLY);
+    _radioAnytime = GUI->Control_getRadioButton(_window, RADIO_BUTTON_ANYTIME);
+    _marginBefore = GUI->Control_getSpin(_window, SPIN_MARGIN_BEFORE);
+    _marginAfter = GUI->Control_getSpin(_window, SPIN_MARGIN_AFTER);
+    _marginNumberToKeep = GUI->Control_getSpin(_window, SPIN_REC_TO_KEEP);
+
 	_radioRecEpisode->SetSelected(!RecSeries);
-	_radioRecSeries->SetSelected(RecSeries);  
+	_radioRecSeries->SetSelected(RecSeries);
+
+    PopulateMarginSpin(_marginBefore);
+    _marginBefore->SetValue(marginBefore);
+
+    PopulateMarginSpin(_marginAfter);
+    _marginAfter->SetValue(marginAfter);
+
+    PopulateKeepSpin(_marginNumberToKeep);
+    _marginNumberToKeep->SetValue(numberToKeep);
+
+    _radioNewOnly->SetSelected(newOnly);
+    _radioAnytime->SetSelected(anytime);
+
+    HideShowSeriesControls(RecSeries);
 
   return true;
+}
+
+void CDialogRecordPref::PopulateMarginSpin(CAddonGUISpinControl* spin)
+{
+    spin->AddLabel(XBMC->GetLocalizedString(32022), c_default_margin);
+    spin->AddLabel("0", 0);
+    spin->AddLabel("1", 1);
+    spin->AddLabel("2", 2);
+    spin->AddLabel("3", 3);
+    spin->AddLabel("4", 4);
+    spin->AddLabel("5", 5);
+    spin->AddLabel("10", 10);
+    spin->AddLabel("15", 15);
+    spin->AddLabel("30", 30);
+    spin->AddLabel("60", 60);
+}
+
+void CDialogRecordPref::PopulateKeepSpin(CAddonGUISpinControl* spin)
+{
+    spin->AddLabel(XBMC->GetLocalizedString(32023), c_keep_all_recordings);
+    spin->AddLabel("1", 1);
+    spin->AddLabel("2", 2);
+    spin->AddLabel("3", 3);
+    spin->AddLabel("4", 4);
+    spin->AddLabel("5", 5);
+    spin->AddLabel("6", 6);
+    spin->AddLabel("7", 7);
+    spin->AddLabel("8", 8);
+    spin->AddLabel("9", 9);
+    spin->AddLabel("10", 10);
 }
 
 bool CDialogRecordPref::OnClick(int controlId)
@@ -70,25 +131,44 @@ bool CDialogRecordPref::OnClick(int controlId)
 	{
 		case BUTTON_OK:				// save value from GUI, then FALLS THROUGH TO CANCEL
 			RecSeries = _radioRecSeries->IsSelected();
-		case BUTTON_CANCEL:
+            newOnly = _radioNewOnly->IsSelected();
+            anytime = _radioAnytime->IsSelected();
+            marginBefore = _marginBefore->GetValue();
+            marginAfter = _marginAfter->GetValue();
+            numberToKeep = _marginNumberToKeep->GetValue();
+        case BUTTON_CANCEL:
 		case BUTTON_CLOSE:
 			if (_confirmed == -1)		// if not previously confirmed, set to cancel value
 				_confirmed = 0;			
 			_window->Close();
 			GUI->Control_releaseRadioButton(_radioRecEpisode);
 			GUI->Control_releaseRadioButton(_radioRecSeries);
-			break;
+            GUI->Control_releaseRadioButton(_radioNewOnly);
+            GUI->Control_releaseRadioButton(_radioAnytime);
+            GUI->Control_releaseSpin(_marginBefore);
+            GUI->Control_releaseSpin(_marginAfter);
+            GUI->Control_releaseSpin(_marginNumberToKeep);
+            break;
 		case RADIO_BUTTON_EPISODE:
 			RecSeries = !_radioRecEpisode->IsSelected();
 			_radioRecSeries->SetSelected(RecSeries);
+            HideShowSeriesControls(RecSeries);
 			break;
 		case RADIO_BUTTON_SERIES:
 			RecSeries = _radioRecSeries->IsSelected();
 			_radioRecEpisode->SetSelected(!RecSeries);
+            HideShowSeriesControls(RecSeries);
 			break;
 	}
 
   return true;
+}
+
+void CDialogRecordPref::HideShowSeriesControls(bool bShow)
+{
+    _radioNewOnly->SetVisible(bShow);
+    _radioAnytime->SetVisible(bShow);
+    _marginNumberToKeep->SetVisible(bShow);
 }
 
 bool CDialogRecordPref::OnInitCB(GUIHANDLE cbhdl)

--- a/addons/pvr.dvblink/src/DialogRecordPref.h
+++ b/addons/pvr.dvblink/src/DialogRecordPref.h
@@ -27,7 +27,11 @@
 class CDialogRecordPref
 {
 public:
-    CDialogRecordPref(ADDON::CHelper_libXBMC_addon* xbmc, CHelper_libXBMC_gui* gui, bool recSeries);
+    static const int c_keep_all_recordings = 0;
+    static const int c_default_margin = -1;
+
+public:
+    CDialogRecordPref(ADDON::CHelper_libXBMC_addon* xbmc, CHelper_libXBMC_gui* gui);
 	virtual ~CDialogRecordPref();
 
 	bool Show();
@@ -35,11 +39,21 @@ public:
 	int DoModal();						// returns -1=> load failed, 0=>canceled, 1=>confirmed
 
   // dialog specific params
-	bool RecSeries;						// values returned
-	
+	bool RecSeries;
+    bool newOnly;
+    bool anytime;
+    int marginBefore;
+    int marginAfter;
+    int numberToKeep;
+
 private:
 	CAddonGUIRadioButton *_radioRecEpisode;
 	CAddonGUIRadioButton *_radioRecSeries;
+    CAddonGUIRadioButton *_radioNewOnly;
+    CAddonGUIRadioButton *_radioAnytime;
+    CAddonGUISpinControl *_marginBefore;
+    CAddonGUISpinControl *_marginAfter;
+    CAddonGUISpinControl *_marginNumberToKeep;
 
   // following is needed for every dialog
 private:
@@ -52,6 +66,10 @@ private:
     bool OnFocus(int controlId);
     bool OnInit();
     bool OnAction(int actionId);
+
+    void HideShowSeriesControls(bool bShow);
+    void PopulateMarginSpin(CAddonGUISpinControl* spin);
+    void PopulateKeepSpin(CAddonGUISpinControl* spin);
 
     static bool OnClickCB(GUIHANDLE cbhdl, int controlId);
     static bool OnFocusCB(GUIHANDLE cbhdl, int controlId);

--- a/addons/pvr.dvblink/src/client.h
+++ b/addons/pvr.dvblink/src/client.h
@@ -41,4 +41,5 @@
 #define DEFAULT_AUDIOTRACK          "eng"
 #define DEFAULT_USETIMESHIFT        false
 #define DEFAULT_ADDRECEPISODE2TITLE true
-
+#define DEFAULT_GROUPRECBYSERIES    true
+#define DEFAULT_NOGROUP_SINGLE_REC  false

--- a/lib/libdvblinkremote/Makefile.am
+++ b/lib/libdvblinkremote/Makefile.am
@@ -17,6 +17,8 @@ libdvblinkremote_la_SOURCES = channel.cpp \
 			recording_settings.cpp \
 			remove_playback_object_request.cpp \
 			scheduling.cpp \
+			favorites.cpp \
+			server_info.cpp \
 			stop_stream_request.cpp \
 			stream.cpp \
 			stream_request.cpp \

--- a/lib/libdvblinkremote/dvblinkremote.h
+++ b/lib/libdvblinkremote/dvblinkremote.h
@@ -187,6 +187,16 @@ namespace dvblinkremote
   const std::string DVBLINK_REMOTE_SET_RECORDING_SETTING_CMD = "set_recording_settings";
 
   /**
+  * A constant string representing the DVBLink command for retrieving channel favorites lists.
+  */
+  const std::string DVBLINK_REMOTE_GET_FAVORITES_CMD = "get_favorites";
+
+  /**
+  * A constant string representing the DVBLink command for retrieving server information.
+  */
+  const std::string DVBLINK_REMOTE_GET_SERVER_INFO_CMD = "get_server_info";
+
+  /**
     * A constant string representing a Real Time Transport Protocol stream type for Android devices.
     */
   const std::string DVBLINK_REMOTE_STREAM_TYPE_ANDROID = "rtp";
@@ -461,6 +471,22 @@ namespace dvblinkremote
       * @return            A DVBLinkRemoteStatusCode representing the status of the executed method.
       */
     virtual DVBLinkRemoteStatusCode SetRecordingSettings(const SetRecordingSettingsRequest& request) = 0;
+
+    /**
+    * Gets favorites lists.
+    * @param[in]      request   A constant GetFavoritesRequest reference representing the get favorites request criterias.
+    * @param[in,out]  response  A ChannelFavorites reference that will be populated with channel favorites.
+    * @return                   A DVBLinkRemoteStatusCode representing the status of the executed method.
+    */
+    virtual DVBLinkRemoteStatusCode GetFavorites(const GetFavoritesRequest& request, ChannelFavorites& response) = 0;
+
+    /**
+    * Gets server information - id, version and build number.
+    * @param[in]      request   A constant GetServerInfoRequest reference representing the get server info request criterias.
+    * @param[in,out]  response  A ServerInfo reference that will be populated with server information.
+    * @return                   A DVBLinkRemoteStatusCode representing the status of the executed method.
+    */
+    virtual DVBLinkRemoteStatusCode GetServerInfo(const GetServerInfoRequest& request, ServerInfo& response) = 0;
 
     /**
       * Gets a description of the last occured error.

--- a/lib/libdvblinkremote/dvblinkremotecommunication.cpp
+++ b/lib/libdvblinkremote/dvblinkremotecommunication.cpp
@@ -226,6 +226,16 @@ DVBLinkRemoteStatusCode DVBLinkRemoteCommunication::GetM3uPlaylist(const GetM3uP
   return GetData(DVBLINK_REMOTE_GET_PLAYLIST_M3U_CMD, request, response);
 }
 
+DVBLinkRemoteStatusCode DVBLinkRemoteCommunication::GetFavorites(const GetFavoritesRequest& request, ChannelFavorites& response)
+{
+    return GetData(DVBLINK_REMOTE_GET_FAVORITES_CMD, request, response);
+}
+
+DVBLinkRemoteStatusCode DVBLinkRemoteCommunication::GetServerInfo(const GetServerInfoRequest& request, ServerInfo& response)
+{
+    return GetData(DVBLINK_REMOTE_GET_SERVER_INFO_CMD, request, response);
+}
+
 std::string DVBLinkRemoteCommunication::GetUrl()
 {
   char buffer[2000];

--- a/lib/libdvblinkremote/dvblinkremoteconnection.h
+++ b/lib/libdvblinkremote/dvblinkremoteconnection.h
@@ -63,6 +63,8 @@ namespace dvblinkremote
     DVBLinkRemoteStatusCode GetStreamingCapabilities(const GetStreamingCapabilitiesRequest& request, StreamingCapabilities& response);
     DVBLinkRemoteStatusCode GetRecordingSettings(const GetRecordingSettingsRequest& request, RecordingSettings& response);
     DVBLinkRemoteStatusCode SetRecordingSettings(const SetRecordingSettingsRequest& request);
+    DVBLinkRemoteStatusCode GetFavorites(const GetFavoritesRequest& request, ChannelFavorites& response);
+    DVBLinkRemoteStatusCode GetServerInfo(const GetServerInfoRequest& request, ServerInfo& response);
     void GetLastError(std::string& err);
 
   private:

--- a/lib/libdvblinkremote/favorites.cpp
+++ b/lib/libdvblinkremote/favorites.cpp
@@ -1,0 +1,131 @@
+/***************************************************************************
+ * Copyright (C) 2012 Marcus Efraimsson.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included 
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ *
+ ***************************************************************************/
+
+#include "request.h"
+#include "response.h"
+#include "xml_object_serializer.h"
+
+using namespace dvblinkremote;
+using namespace dvblinkremoteserialization;
+
+GetFavoritesRequest::GetFavoritesRequest()
+{ }
+
+GetFavoritesRequest::~GetFavoritesRequest()
+{ }
+
+ChannelFavorite::ChannelFavorite(std::string& id, std::string& name, favorite_channel_list_t& channels) :
+id_(id), name_(name), channels_(channels)
+{
+}
+
+ChannelFavorite::~ChannelFavorite()
+{ }
+
+ChannelFavorites::ChannelFavorites()
+{
+}
+
+ChannelFavorites::ChannelFavorites(ChannelFavorites& favorites)
+{
+    favorites_ = favorites.favorites_;
+}
+
+ChannelFavoritesSerializer::GetFavoritesResponseXmlDataDeserializer::GetFavoritesResponseXmlDataDeserializer(ChannelFavoritesSerializer& parent, ChannelFavorites& favoritesList)
+    : m_parent(parent),
+    m_favoritesList(favoritesList)
+{
+
+}
+
+ChannelFavorites::~ChannelFavorites()
+{
+
+}
+
+ChannelFavoritesSerializer::GetFavoritesResponseXmlDataDeserializer::~GetFavoritesResponseXmlDataDeserializer()
+{
+
+}
+
+bool ChannelFavoritesSerializer::GetFavoritesResponseXmlDataDeserializer::VisitEnter(const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* attribute)
+{
+    if (strcmp(element.Name(), "favorite") == 0)
+    {
+        std::string id = Util::GetXmlFirstChildElementText(&element, "id");
+        std::string name = Util::GetXmlFirstChildElementText(&element, "name");
+
+        //channels
+        ChannelFavorite::favorite_channel_list_t channels;
+        const tinyxml2::XMLElement* channels_element = element.FirstChildElement("channels");
+        if (channels_element != NULL)
+        {
+            const tinyxml2::XMLElement* channel_element = channels_element->FirstChildElement();
+            while (channel_element != NULL)
+            {
+                if (strcmp(channel_element->Name(), "channel") == 0)
+                {
+                    if (channel_element->GetText() != NULL)
+                        channels.push_back(channel_element->GetText());
+                }
+                channel_element = channel_element->NextSiblingElement();
+            }
+
+        }
+
+        ChannelFavorite cf(id, name, channels);
+
+        m_favoritesList.favorites_.push_back(cf);
+
+        return false;
+    }
+
+    return true;
+}
+
+bool GetFavoritesRequestSerializer::WriteObject(std::string& serializedData, GetFavoritesRequest& objectGraph)
+{
+  tinyxml2::XMLElement* rootElement = PrepareXmlDocumentForObjectSerialization("favorites"); 
+
+  tinyxml2::XMLPrinter* printer = new tinyxml2::XMLPrinter();    
+  GetXmlDocument().Accept(printer);
+  serializedData = std::string(printer->CStr());
+  
+  return true;
+}
+
+bool ChannelFavoritesSerializer::ReadObject(ChannelFavorites& object, const std::string& xml)
+{
+    tinyxml2::XMLDocument& doc = GetXmlDocument();
+
+    if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+        tinyxml2::XMLElement* elRoot = doc.FirstChildElement("favorites");
+        GetFavoritesResponseXmlDataDeserializer* xmlDataDeserializer = new GetFavoritesResponseXmlDataDeserializer(*this, object);
+        elRoot->Accept(xmlDataDeserializer);
+        delete xmlDataDeserializer;
+
+        return true;
+    }
+
+  return false;
+}

--- a/lib/libdvblinkremote/playback_item.cpp
+++ b/lib/libdvblinkremote/playback_item.cpp
@@ -95,7 +95,8 @@ RecordedTvItem::RecordedTvItem(const std::string& objectId, const std::string& p
     ChannelName(""),
     ChannelNumber(0),
     ChannelSubNumber(0),
-    State(RecordedTvItem::RECORDED_TV_ITEM_STATE_IN_PROGRESS)
+    State(RecordedTvItem::RECORDED_TV_ITEM_STATE_IN_PROGRESS),
+    SeriesSchedule(false)
 {
 
 }
@@ -195,6 +196,21 @@ bool GetPlaybackObjectResponseSerializer::PlaybackItemXmlDataDeserializer::Visit
       if (m_parent.HasChildElement(element, "state")) 
       {
         recordedTvitem->State = (RecordedTvItem::DVBLinkRecordedTvItemState)Util::GetXmlFirstChildElementTextAsInt(&element, "state");
+      }
+
+      if (m_parent.HasChildElement(element, "schedule_id"))
+      {
+          recordedTvitem->ScheduleId = Util::GetXmlFirstChildElementText(&element, "schedule_id");
+      }
+
+      if (m_parent.HasChildElement(element, "schedule_name"))
+      {
+          recordedTvitem->ScheduleName = Util::GetXmlFirstChildElementText(&element, "schedule_name");
+      }
+
+      if (m_parent.HasChildElement(element, "schedule_series"))
+      {
+          recordedTvitem->SeriesSchedule = true;
       }
 
       item = (PlaybackItem*)recordedTvitem;

--- a/lib/libdvblinkremote/project/VS2010Express/libdvblinkremote.vcxproj
+++ b/lib/libdvblinkremote/project/VS2010Express/libdvblinkremote.vcxproj
@@ -16,6 +16,7 @@
     <ClCompile Include="..\..\dvblinkremotecommunication.cpp" />
     <ClCompile Include="..\..\dvblinkremotehttp.cpp" />
     <ClCompile Include="..\..\epg.cpp" />
+    <ClCompile Include="..\..\favorites.cpp" />
     <ClCompile Include="..\..\generic_response.cpp" />
     <ClCompile Include="..\..\item_metadata.cpp" />
     <ClCompile Include="..\..\m3u_playlist.cpp" />
@@ -28,6 +29,7 @@
     <ClCompile Include="..\..\recording_settings.cpp" />
     <ClCompile Include="..\..\remove_playback_object_request.cpp" />
     <ClCompile Include="..\..\scheduling.cpp" />
+    <ClCompile Include="..\..\server_info.cpp" />
     <ClCompile Include="..\..\stop_stream_request.cpp" />
     <ClCompile Include="..\..\stream.cpp" />
     <ClCompile Include="..\..\streaming_capabilities.cpp" />

--- a/lib/libdvblinkremote/project/VS2010Express/libdvblinkremote.vcxproj.filters
+++ b/lib/libdvblinkremote/project/VS2010Express/libdvblinkremote.vcxproj.filters
@@ -90,6 +90,12 @@
     <ClCompile Include="..\..\xml_object_serializer_factory.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\favorites.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\server_info.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\dvblinkremote.h">

--- a/lib/libdvblinkremote/request.h
+++ b/lib/libdvblinkremote/request.h
@@ -751,7 +751,7 @@ namespace dvblinkremote {
       * @see DVBLinkManualScheduleDayMask
     * @param title of schedule
       */
-    AddManualScheduleRequest(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title = "");
+      AddManualScheduleRequest(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title = "", const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -778,8 +778,9 @@ namespace dvblinkremote {
       * @param recordSeriesAnytime an optional constant boolean representing whether to 
       * record only series starting around original program start time or any of them. 
       * Default value is <tt>false</tt>.
-    */
-    AddScheduleByEpgRequest(const std::string& channelId, const std::string& programId, const bool repeat = false, const bool newOnly = false, const bool recordSeriesAnytime = false);
+      * @param recordingsToKeep defines anumbr of recordings to keep in case of series recordings (0 - keep all).
+      */
+      AddScheduleByEpgRequest(const std::string& channelId, const std::string& programId, const bool repeat = false, const bool newOnly = false, const bool recordSeriesAnytime = false, const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Destructor for cleaning up allocated memory.
@@ -1319,4 +1320,42 @@ namespace dvblinkremote {
     int m_timeMarginAfterScheduledRecordings;
     std::string m_recordingPath;
   };
+
+    /**
+    * Class for getting channel favorites requests.
+    * This is used as input parameter for the IDVBLinkRemoteConnection::GetFavorites method.
+    * @see IDVBLinkRemoteConnection::GetFavorites()
+    */
+    class GetFavoritesRequest : public Request
+    {
+    public:
+        /**
+        * Initializes a new instance of the dvblinkremote::GetFavoritesRequest class.
+        */
+        GetFavoritesRequest();
+
+        /**
+        * Destructor for cleaning up allocated memory.
+        */
+        ~GetFavoritesRequest();
+    };
+
+    /**
+    * Class for getting server information requests.
+    * This is used as input parameter for the IDVBLinkRemoteConnection::GetServerInfo method.
+    * @see IDVBLinkRemoteConnection::GetServerInfo()
+    */
+    class GetServerInfoRequest : public Request
+    {
+    public:
+        /**
+        * Initializes a new instance of the dvblinkremote::GetServerInfoRequest class.
+        */
+        GetServerInfoRequest();
+
+        /**
+        * Destructor for cleaning up allocated memory.
+        */
+        ~GetServerInfoRequest();
+    };
 }

--- a/lib/libdvblinkremote/response.h
+++ b/lib/libdvblinkremote/response.h
@@ -1059,6 +1059,22 @@ namespace dvblinkremote {
       * The state of the recored TV item.
       */
     DVBLinkRecordedTvItemState State;
+
+    /**
+    * Id of the schedule, this recorded tv item belongs to
+    */
+    std::string ScheduleId;
+
+    /**
+    * Name of the schedule, this recorded tv item belongs to
+    */
+    std::string ScheduleName;
+
+    /**
+    * Indicates if the schedule was/is part of the series recordings
+    */
+    bool SeriesSchedule;
+
   };
 
   /**
@@ -1290,4 +1306,82 @@ namespace dvblinkremote {
       */
     long AvailableSpace;
   };
+
+  class ChannelFavorite
+  {
+    public:
+        typedef std::vector<std::string> favorite_channel_list_t;
+
+    public:
+        ChannelFavorite(std::string& id, std::string& name, favorite_channel_list_t& channels);
+
+        ~ChannelFavorite();
+
+        std::string& get_id() {return id_;}
+        std::string& get_name() { return name_; }
+        favorite_channel_list_t& get_channels() { return channels_; }
+
+    private:
+        std::string id_;
+        std::string name_;
+        favorite_channel_list_t channels_;
+  };
+
+  /**
+  * Represent channel favorites which is used as output parameter for the
+  * IDVBLinkRemoteConnection::GetFavorites method.
+  * @see IDVBLinkRemoteConnection::GetFavorites()
+  */
+  class ChannelFavorites : public Response
+  {
+  public:
+      typedef std::vector<ChannelFavorite> favorites_list_t;
+
+  public:
+      /**
+      * Initializes a new instance of the dvblinkremote::ChannelFavorites class.
+      */
+      ChannelFavorites();
+
+      /**
+      * Initializes a new instance of the dvblinkremote::ChannelFavorites class by coping another
+      * dvblinkremote::ChannelFavorites instance.
+      * @param recordingSettings a dvblinkremote::ChannelFavorites reference.
+      */
+      ChannelFavorites(ChannelFavorites& favorites);
+
+      /**
+      * Destructor for cleaning up allocated memory.
+      */
+      ~ChannelFavorites();
+
+      favorites_list_t favorites_;
+  };
+
+  class ServerInfo : public Response
+  {
+  public:
+      /**
+      * Initializes a new instance of the dvblinkremote::ServerInfo class.
+      */
+      ServerInfo();
+
+      /**
+      * Initializes a new instance of the dvblinkremote::ServerInfo class by coping another
+      * dvblinkremote::ServerInfo instance.
+      * @param server_info a dvblinkremote::ServerInfo reference.
+      */
+      ServerInfo(ServerInfo& server_info);
+
+      /**
+      * Destructor for cleaning up allocated memory.
+      */
+      ~ServerInfo();
+
+      std::string install_id_;
+      std::string server_id_;
+      std::string version_;
+      std::string build_;
+  };
+
 }

--- a/lib/libdvblinkremote/scheduling.cpp
+++ b/lib/libdvblinkremote/scheduling.cpp
@@ -32,22 +32,26 @@ Schedule::Schedule()
 
 }
 
-Schedule::Schedule(const DVBLinkScheduleType scheduleType, const std::string& channelId, const int recordingsToKeep) 
+Schedule::Schedule(const DVBLinkScheduleType scheduleType, const std::string& channelId, const int recordingsToKeep, const int marginBefore, const int marginAfter)
   : m_scheduleType(scheduleType), 
     m_channelId(channelId), 
-    RecordingsToKeep(recordingsToKeep)
-{ 
+    RecordingsToKeep(recordingsToKeep),
+    MarginBefore(marginBefore),
+    MarginAfter(marginAfter)
+{
   m_id = "";
   UserParameter = "";
   ForceAdd = false;
 }
 
-Schedule::Schedule(const DVBLinkScheduleType scheduleType, const std::string& id, const std::string& channelId, const int recordingsToKeep) 
+Schedule::Schedule(const DVBLinkScheduleType scheduleType, const std::string& id, const std::string& channelId, const int recordingsToKeep, const int marginBefore, const int marginAfter)
   : m_scheduleType(scheduleType), 
     m_id(id),
     m_channelId(channelId), 
-    RecordingsToKeep(recordingsToKeep)
-{ 
+    RecordingsToKeep(recordingsToKeep),
+    MarginBefore(marginBefore),
+    MarginAfter(marginAfter)
+{
   UserParameter = "";
   ForceAdd = false;
 }
@@ -72,8 +76,8 @@ Schedule::DVBLinkScheduleType& Schedule::GetScheduleType()
   return m_scheduleType; 
 }
 
-ManualSchedule::ManualSchedule(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title)
-  : Schedule(SCHEDULE_TYPE_MANUAL, channelId), 
+ManualSchedule::ManualSchedule(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title, const int recordingsToKeep, const int marginBefore, const int marginAfter)
+    : Schedule(SCHEDULE_TYPE_MANUAL, channelId, recordingsToKeep, marginBefore, marginAfter),
     m_startTime(startTime), 
     m_duration(duration), 
     m_dayMask(dayMask), 
@@ -82,8 +86,8 @@ ManualSchedule::ManualSchedule(const std::string& channelId, const long startTim
 
 }
 
-ManualSchedule::ManualSchedule(const std::string& id, const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title)
-  : Schedule(SCHEDULE_TYPE_MANUAL, id, channelId), 
+ManualSchedule::ManualSchedule(const std::string& id, const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title, const int recordingsToKeep, const int marginBefore, const int marginAfter)
+    : Schedule(SCHEDULE_TYPE_MANUAL, id, channelId, recordingsToKeep, marginBefore, marginAfter),
     m_startTime(startTime), 
     m_duration(duration), 
     m_dayMask(dayMask), 
@@ -112,8 +116,8 @@ long ManualSchedule::GetDayMask()
   return m_dayMask; 
 }
 
-EpgSchedule::EpgSchedule(const std::string& channelId, const std::string& programId, const bool repeat, const bool newOnly, const bool recordSeriesAnytime)
-  : Schedule(SCHEDULE_TYPE_BY_EPG, channelId), 
+EpgSchedule::EpgSchedule(const std::string& channelId, const std::string& programId, const bool repeat, const bool newOnly, const bool recordSeriesAnytime, const int recordingsToKeep, const int marginBefore, const int marginAfter)
+    : Schedule(SCHEDULE_TYPE_BY_EPG, channelId, recordingsToKeep, marginBefore, marginAfter),
     m_programId(programId), 
     Repeat(repeat), 
     NewOnly(newOnly), 
@@ -122,8 +126,9 @@ EpgSchedule::EpgSchedule(const std::string& channelId, const std::string& progra
 
 }
 
-EpgSchedule::EpgSchedule(const std::string& id, const std::string& channelId, const std::string& programId, const bool repeat, const bool newOnly, const bool recordSeriesAnytime)
-  : Schedule(SCHEDULE_TYPE_BY_EPG, id, channelId), 
+EpgSchedule::EpgSchedule(const std::string& id, const std::string& channelId, const std::string& programId, const bool repeat, const bool newOnly, 
+    const bool recordSeriesAnytime, const int recordingsToKeep, const int marginBefore, const int marginAfter)
+    : Schedule(SCHEDULE_TYPE_BY_EPG, id, channelId, recordingsToKeep, marginBefore, marginAfter),
     m_programId(programId), 
     Repeat(repeat), 
     NewOnly(newOnly), 
@@ -153,8 +158,8 @@ AddScheduleRequest::~AddScheduleRequest()
 }
 
 
-AddManualScheduleRequest::AddManualScheduleRequest(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title)
-  : ManualSchedule(channelId, startTime, duration, dayMask, title), AddScheduleRequest(), Schedule(Schedule::SCHEDULE_TYPE_MANUAL, channelId)
+AddManualScheduleRequest::AddManualScheduleRequest(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title, const int recordingsToKeep, const int marginBefore, const int marginAfter)
+    : ManualSchedule(channelId, startTime, duration, dayMask, title, recordingsToKeep, marginBefore, marginAfter), AddScheduleRequest(), Schedule(Schedule::SCHEDULE_TYPE_MANUAL, channelId, recordingsToKeep, marginBefore, marginAfter)
 {
 
 }
@@ -164,8 +169,9 @@ AddManualScheduleRequest::~AddManualScheduleRequest()
 
 }
 
-AddScheduleByEpgRequest::AddScheduleByEpgRequest(const std::string& channelId, const std::string& programId, const bool repeat, const bool newOnly, const bool recordSeriesAnytime)
-  : EpgSchedule(channelId, programId, repeat, newOnly, recordSeriesAnytime), AddScheduleRequest(), Schedule(Schedule::SCHEDULE_TYPE_BY_EPG, channelId)
+AddScheduleByEpgRequest::AddScheduleByEpgRequest(const std::string& channelId, const std::string& programId, const bool repeat, const bool newOnly, 
+    const bool recordSeriesAnytime, const int recordingsToKeep, const int marginBefore, const int marginAfter)
+    : EpgSchedule(channelId, programId, repeat, newOnly, recordSeriesAnytime, recordingsToKeep, marginBefore, marginAfter), AddScheduleRequest(), Schedule(Schedule::SCHEDULE_TYPE_BY_EPG, channelId, recordingsToKeep, marginBefore, marginAfter)
 {
 
 }
@@ -186,6 +192,9 @@ bool AddScheduleRequestSerializer::WriteObject(std::string& serializedData, AddS
   if (objectGraph.ForceAdd) {
     rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "force_add", objectGraph.ForceAdd));
   }
+
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "margine_before", objectGraph.MarginBefore));
+  rootElement->InsertEndChild(Util::CreateXmlElementWithText(&GetXmlDocument(), "margine_after", objectGraph.MarginAfter));
 
   if (objectGraph.GetScheduleType() == objectGraph.SCHEDULE_TYPE_MANUAL) {
     AddManualScheduleRequest& addManualScheduleRequest = (AddManualScheduleRequest&)objectGraph;

--- a/lib/libdvblinkremote/scheduling.h
+++ b/lib/libdvblinkremote/scheduling.h
@@ -49,8 +49,10 @@ namespace dvblinkremote {
       * @param channelId a constant string reference representing the channel identifier.
       * @param recordingsToKeep an optional constant integer representing how many recordings to 
       * keep for a repeated recording. Default value is <tt>0</tt>, i.e. keep all recordings.
+      * @param marginBefore a constant int, specifying a margin in minutes before recording starts (-1 - use default)
+      * @param marginAfter a constant int, specifying a margin in minutes after recording ends (-1 - use default)
       */
-    Schedule(const DVBLinkScheduleType scheduleType, const std::string& channelId, const int recordingsToKeep = 0);
+    Schedule(const DVBLinkScheduleType scheduleType, const std::string& channelId, const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Initializes a new instance of the dvblinkremote::Schedule class.
@@ -60,8 +62,10 @@ namespace dvblinkremote {
       * @param channelId a constant string reference representing the channel identifier.
       * @param recordingsToKeep an optional constant integer representing how many recordings to 
       * keep for a repeated recording. Default value is <tt>0</tt>, i.e. keep all recordings.
+      * @param marginBefore a constant int, specifying a margin in minutes before recording starts (-1 - use default)
+      * @param marginAfter a constant int, specifying a margin in minutes after recording ends (-1 - use default)
       */
-    Schedule(const DVBLinkScheduleType scheduleType, const std::string& id, const std::string& channelId, const int recordingsToKeep = 0);
+    Schedule(const DVBLinkScheduleType scheduleType, const std::string& id, const std::string& channelId, const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Pure virtual destructor for cleaning up allocated memory.
@@ -96,6 +100,16 @@ namespace dvblinkremote {
       * \remark Possible values (1, 2, 3, 4, 5, 6, 7, 10; 0 - keep all)
       */
     int RecordingsToKeep;
+
+    /**
+    * Indicates margin in minutes before recording starts (-1 - use default margin)
+    */
+    int MarginBefore;
+
+    /**
+    * Indicates margin in minutes after recording ends (-1 - use default margin)
+    */
+    int MarginAfter;
 
     /**
       * Gets the type for the schedule .
@@ -159,7 +173,7 @@ namespace dvblinkremote {
       * @see DVBLinkManualScheduleDayMask
       * @param title of schedule
       */
-    ManualSchedule(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title = "");
+    ManualSchedule(const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title = "", const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Initializes a new instance of the dvblinkremote::ManualSchedule class.
@@ -172,7 +186,7 @@ namespace dvblinkremote {
       * @see DVBLinkManualScheduleDayMask
       * @param title of schedule
       */
-    ManualSchedule(const std::string& id, const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title = "");
+    ManualSchedule(const std::string& id, const std::string& channelId, const long startTime, const long duration, const long dayMask, const std::string& title = "", const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Pure virtual destructor for cleaning up allocated memory.
@@ -236,8 +250,9 @@ namespace dvblinkremote {
       * @param recordSeriesAnytime an optional constant boolean representing whether to 
       * record only series starting around original program start time or any of them. 
       * Default value is <tt>false</tt>.
-    */
-    EpgSchedule(const std::string& channelId, const std::string& programId, const bool repeat = false, const bool newOnly = false, const bool recordSeriesAnytime = false);
+      * @param recordingsToKeep defines a number of recordings to keep in case of series recordings (0 - keep all).
+      */
+      EpgSchedule(const std::string& channelId, const std::string& programId, const bool repeat = false, const bool newOnly = false, const bool recordSeriesAnytime = false, const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Initializes a new instance of the dvblinkremote::EpgSchedule class.
@@ -251,8 +266,9 @@ namespace dvblinkremote {
       * @param recordSeriesAnytime an optional constant boolean representing whether to 
       * record only series starting around original program start time or any of them. 
       * Default value is <tt>false</tt>.
-    */
-    EpgSchedule(const std::string& id, const std::string& channelId, const std::string& programId, const bool repeat = false, const bool newOnly = false, const bool recordSeriesAnytime = false);
+      * @param recordingsToKeep defines a number of recordings to keep in case of series recordings (0 - keep all).
+      */
+      EpgSchedule(const std::string& id, const std::string& channelId, const std::string& programId, const bool repeat = false, const bool newOnly = false, const bool recordSeriesAnytime = false, const int recordingsToKeep = 0, const int marginBefore = -1, const int marginAfter = -1);
 
     /**
       * Pure virtual destructor for cleaning up allocated memory.

--- a/lib/libdvblinkremote/server_info.cpp
+++ b/lib/libdvblinkremote/server_info.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ * Copyright (C) 2012 Marcus Efraimsson.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the "Software"), 
+ * to deal in the Software without restriction, including without limitation 
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+ * and/or sell copies of the Software, and to permit persons to whom the 
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included 
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ *
+ ***************************************************************************/
+
+#include "request.h"
+#include "response.h"
+#include "xml_object_serializer.h"
+
+using namespace dvblinkremote;
+using namespace dvblinkremoteserialization;
+
+GetServerInfoRequest::GetServerInfoRequest()
+{ }
+
+GetServerInfoRequest::~GetServerInfoRequest()
+{ }
+
+ServerInfo::ServerInfo()
+{ }
+
+ServerInfo::ServerInfo(ServerInfo& server_info)
+{
+    install_id_ = server_info.install_id_;
+    server_id_ = server_info.server_id_;
+    build_ = server_info.build_;
+    version_ = server_info.version_;
+}
+
+ServerInfo::~ServerInfo()
+{ }
+
+bool GetServerInfoRequestSerializer::WriteObject(std::string& serializedData, GetServerInfoRequest& objectGraph)
+{
+  tinyxml2::XMLElement* rootElement = PrepareXmlDocumentForObjectSerialization("server_info"); 
+
+  tinyxml2::XMLPrinter* printer = new tinyxml2::XMLPrinter();    
+  GetXmlDocument().Accept(printer);
+  serializedData = std::string(printer->CStr());
+  
+  return true;
+}
+
+bool ServerInfoSerializer::ReadObject(ServerInfo& object, const std::string& xml)
+{
+  tinyxml2::XMLDocument& doc = GetXmlDocument();
+    
+  if (doc.Parse(xml.c_str()) == tinyxml2::XML_NO_ERROR) {
+    tinyxml2::XMLElement* elRoot = doc.FirstChildElement("server_info");
+    object.install_id_ = Util::GetXmlFirstChildElementText(elRoot, "install_id");
+    object.server_id_ = Util::GetXmlFirstChildElementText(elRoot, "server_id");
+    object.version_ = Util::GetXmlFirstChildElementText(elRoot, "version");
+    object.build_ = Util::GetXmlFirstChildElementText(elRoot, "build");
+    return true;
+  }
+
+  return false;
+}

--- a/lib/libdvblinkremote/xml_object_serializer.h
+++ b/lib/libdvblinkremote/xml_object_serializer.h
@@ -359,6 +359,47 @@ namespace dvblinkremoteserialization {
     bool WriteObject(std::string& serializedData, SetRecordingSettingsRequest& objectGraph);
   };
 
+  class GetFavoritesRequestSerializer : public XmlObjectSerializer<GetFavoritesRequest>
+  {
+  public:
+      GetFavoritesRequestSerializer() : XmlObjectSerializer<GetFavoritesRequest>() { }
+      bool WriteObject(std::string& serializedData, GetFavoritesRequest& objectGraph);
+  };
+
+  class ChannelFavoritesSerializer : public XmlObjectSerializer<ChannelFavorites>
+  {
+  public:
+      ChannelFavoritesSerializer() : XmlObjectSerializer<ChannelFavorites>() { }
+      bool ReadObject(ChannelFavorites& object, const std::string& xml);
+
+  private:
+      class GetFavoritesResponseXmlDataDeserializer : public tinyxml2::XMLVisitor
+      {
+      private:
+          ChannelFavoritesSerializer& m_parent;
+          ChannelFavorites& m_favoritesList;
+
+      public:
+          GetFavoritesResponseXmlDataDeserializer(ChannelFavoritesSerializer& parent, ChannelFavorites& favoritesList);
+          ~GetFavoritesResponseXmlDataDeserializer();
+          bool VisitEnter(const tinyxml2::XMLElement& element, const tinyxml2::XMLAttribute* attribute);
+      };
+  };
+
+  class GetServerInfoRequestSerializer : public XmlObjectSerializer<GetServerInfoRequest>
+  {
+  public:
+      GetServerInfoRequestSerializer() : XmlObjectSerializer<GetServerInfoRequest>() { }
+      bool WriteObject(std::string& serializedData, GetServerInfoRequest& objectGraph);
+  };
+
+  class ServerInfoSerializer : public XmlObjectSerializer<ServerInfo>
+  {
+  public:
+      ServerInfoSerializer() : XmlObjectSerializer<ServerInfo>() { }
+      bool ReadObject(ServerInfo& object, const std::string& xml);
+  };
+
   class ItemMetadataSerializer
   {
   public:

--- a/lib/libdvblinkremote/xml_object_serializer_factory.cpp
+++ b/lib/libdvblinkremote/xml_object_serializer_factory.cpp
@@ -106,6 +106,14 @@ bool XmlObjectSerializerFactory::Serialize(const std::string& dvbLinkCommand, co
     requestSerializer = (XmlObjectSerializer<Request>*)new SetRecordingSettingsRequestSerializer();
     result = ((SetRecordingSettingsRequestSerializer*)requestSerializer)->WriteObject(serializedData, (SetRecordingSettingsRequest&)request);
   }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_GET_SERVER_INFO_CMD) {
+      requestSerializer = (XmlObjectSerializer<Request>*)new GetServerInfoRequestSerializer();
+      result = ((GetServerInfoRequestSerializer*)requestSerializer)->WriteObject(serializedData, (GetServerInfoRequest&)request);
+  }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_GET_FAVORITES_CMD) {
+      requestSerializer = (XmlObjectSerializer<Request>*)new GetFavoritesRequestSerializer();
+      result = ((GetFavoritesRequestSerializer*)requestSerializer)->WriteObject(serializedData, (GetFavoritesRequest&)request);
+  }
   else {
     result = false;
   }
@@ -159,7 +167,15 @@ bool XmlObjectSerializerFactory::Deserialize(const std::string& dvbLinkCommand, 
     responseSerializer = (XmlObjectSerializer<Response>*)new RecordingSettingsSerializer();
     result = ((RecordingSettingsSerializer*)responseSerializer)->ReadObject((RecordingSettings&)response, serializedData);
   }
-  else if (dvbLinkCommand == DVBLINK_REMOTE_ADD_SCHEDULE_CMD || 
+  else if (dvbLinkCommand == DVBLINK_REMOTE_GET_FAVORITES_CMD) {
+      responseSerializer = (XmlObjectSerializer<Response>*)new ChannelFavoritesSerializer();
+      result = ((ChannelFavoritesSerializer*)responseSerializer)->ReadObject((ChannelFavorites&)response, serializedData);
+  }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_GET_SERVER_INFO_CMD) {
+      responseSerializer = (XmlObjectSerializer<Response>*)new ServerInfoSerializer();
+      result = ((ServerInfoSerializer*)responseSerializer)->ReadObject((ServerInfo&)response, serializedData);
+  }
+  else if (dvbLinkCommand == DVBLINK_REMOTE_ADD_SCHEDULE_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_UPDATE_SCHEDULE_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_REMOVE_SCHEDULE_CMD ||
            dvbLinkCommand == DVBLINK_REMOTE_REMOVE_RECORDING_CMD || 


### PR DESCRIPTION
Version 1.9.13.1
Added: Extended series settings dialog
Added: "No grouping for single recording" setting
Fixed: Long delay when starting transcoded stream from server that does not support it
Speed and memory use optimizations

Version 1.9.13
Fixed: no timers are added from EPG of DVBLink TV Adviser product
Added: Grouping recordings by series
Added: Year to the episode title
Fixed: incorrect available disk space calculations
