### PR TITLE
Fix xbmc-pvr-addons VPATH build

### DIFF
--- a/addons/Makefile.include.am
+++ b/addons/Makefile.include.am
@@ -6,10 +6,10 @@ INCLUDES        = -I. -I$(abs_top_srcdir)/xbmc -I$(abs_top_srcdir)/lib @HOST_INC
 WARNINGS        = -Wall -Wextra -Wno-missing-field-initializers -Woverloaded-virtual -Wno-parentheses
 DEFINES         = @ARCH_DEFINES@ -DUSE_DEMUX -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS
 AM_CXXFLAGS     = -g -O2 -fPIC $(WARNINGS) $(DEFINES) @HOST_CXXFLAGS@
-LIB             = @abs_top_srcdir@/addons/$(ADDONNAME)/addon/@BINPREFIX@$(ADDONBINNAME)@BIN_EXT@
+LIB             = @abs_top_builddir@/addons/$(ADDONNAME)/addon/@BINPREFIX@$(ADDONBINNAME)@BIN_EXT@
 
 clean:
-	-rm -r -f $(LIB) @BINPREFIX@$(ADDONBINNAME)@BIN_EXT@ @abs_top_srcdir@/addons/$(ADDONNAME).@OS@-@ARCHITECTURE@.zip @abs_top_srcdir@/addons/.build/$(ADDONNAME) *.so *.lo *.o *.la *.a *.P *~
+	-rm -r -f $(LIB) @BINPREFIX@$(ADDONBINNAME)@BIN_EXT@ @abs_top_builddir@/addons/$(ADDONNAME).@OS@-@ARCHITECTURE@.zip @abs_top_builddir@/addons/.build/$(ADDONNAME) *.so *.lo *.o *.la *.a *.P *~
 if IS_INTREE_BUILD
 	rm -rf ../../../addons/$(ADDONNAME)
 endif
@@ -25,9 +25,9 @@ $(LIB): @BUILD_TYPE@
 	cp -f @BINPREFIX@$(ADDONBINNAME)@BIN_EXT@ $(LIB)
 
 zip: $(LIB)
-	mkdir -p @abs_top_srcdir@/addons/.build
-	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon @abs_top_srcdir@/addons/.build/$(ADDONNAME)
-	cd @abs_top_srcdir@/addons/.build ; zip -0 -x $(ADDONNAME)/addon.xml.in -r @abs_top_srcdir@/addons/$(ADDONNAME)-@OS@-@ARCHITECTURE@.zip $(ADDONNAME)
+	mkdir -p @abs_top_builddir@/addons/.build
+	cp -r -f @abs_top_srcdir@/addons/$(ADDONNAME)/addon @abs_top_builddir@/addons/.build/$(ADDONNAME)
+	cd @abs_top_builddir@/addons/.build ; zip -0 -x $(ADDONNAME)/addon.xml.in -r @abs_top_builddir@/addons/$(ADDONNAME)-@OS@-@ARCHITECTURE@.zip $(ADDONNAME)
 
 install: @BUILD_TYPE@
 if IS_INTREE_BUILD

--- a/addons/pvr.argustv/Makefile.am
+++ b/addons/pvr.argustv/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.argustv
 LIBNAME         = libargustv-addon
 lib_LTLIBRARIES = libargustv-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/jsoncpp/libjsoncpp.la
+LIBS            = @abs_top_builddir@/lib/jsoncpp/libjsoncpp.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc -Isrc/lib/filesystem -I@abs_top_srcdir@/lib/jsoncpp/include
+INCLUDES+=-I@abs_srcdir@/src -I@abs_srcdir@/src/lib/filesystem -I@abs_top_srcdir@/lib/jsoncpp/include
 
 libargustv_addon_la_SOURCES = src/activerecording.cpp \
                                    src/channel.cpp \

--- a/addons/pvr.demo/Makefile.am
+++ b/addons/pvr.demo/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.demo
 LIBNAME         = libpvrdemo-addon
 lib_LTLIBRARIES = libpvrdemo-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/addons/pvr.dvblink/Makefile.am
+++ b/addons/pvr.dvblink/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.dvblink
 LIBNAME         = libdvblink-addon
 lib_LTLIBRARIES = libdvblink-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/libdvblinkremote/libdvblinkremote.la
+LIBS            = @abs_top_builddir@/lib/libdvblinkremote/libdvblinkremote.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc
+INCLUDES+=-I@abs_srcdir@/src
 
 libdvblink_addon_la_SOURCES = src/client.cpp \
                               src/base64.cpp \

--- a/addons/pvr.dvbviewer/Makefile.am
+++ b/addons/pvr.dvbviewer/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.dvbviewer
 LIBNAME         = libdvbviewer-addon
 lib_LTLIBRARIES = libdvbviewer-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/addons/pvr.hts/Makefile.am
+++ b/addons/pvr.hts/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.hts
 LIBNAME         = libtvheadend-addon
 lib_LTLIBRARIES = libtvheadend-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/libhts/libhts.la -ldl
+LIBS            = @abs_top_builddir@/lib/libhts/libhts.la -ldl
 
 include ../Makefile.include.am
 

--- a/addons/pvr.mediaportal.tvserver/Makefile.am
+++ b/addons/pvr.mediaportal.tvserver/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.mediaportal.tvserver
 LIBNAME         = libmediaportal-addon
 lib_LTLIBRARIES = libmediaportal-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc
+INCLUDES+=-I@abs_srcdir@/src
 
 libmediaportal_addon_la_SOURCES = src/Cards.cpp \
                                   src/channels.cpp \

--- a/addons/pvr.mythtv/Makefile.am
+++ b/addons/pvr.mythtv/Makefile.am
@@ -10,14 +10,14 @@ ADDONNAME       = pvr.mythtv
 LIBNAME         = libmythtv-addon
 lib_LTLIBRARIES = libmythtv-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/cppmyth/cppmyth/libcppmyth.la
+LIBS            = @abs_top_builddir@/lib/cppmyth/cppmyth/libcppmyth.la
 
 AM_CPPFLAGS = -I@abs_top_srcdir@/lib/cppmyth/cppmyth/src
 
 include ../Makefile.include.am
 
 if HAVE_VERSION_SCRIPT
-libmythtv_addon_la_LDFLAGS = -Wl,--version-script=src/addon.map \
+libmythtv_addon_la_LDFLAGS = -Wl,--version-script=@abs_srcdir@/src/addon.map \
                                   @TARGET_LDFLAGS@
 else
 libmythtv_addon_la_LDFLAGS = @TARGET_LDFLAGS@

--- a/addons/pvr.nextpvr/Makefile.am
+++ b/addons/pvr.nextpvr/Makefile.am
@@ -10,11 +10,11 @@ ADDONNAME       = pvr.nextpvr
 LIBNAME         = libnextpvr-addon
 lib_LTLIBRARIES = libnextpvr-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 
-INCLUDES+=-Isrc
+INCLUDES+=-I@abs_srcdir@/src
 
 libnextpvr_addon_la_SOURCES = src/client.cpp \
                                   src/pvrclient-nextpvr.cpp \

--- a/addons/pvr.njoy/Makefile.am
+++ b/addons/pvr.njoy/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.njoy
 LIBNAME         = libpvrnjoy-addon
 lib_LTLIBRARIES = libpvrnjoy-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/addons/pvr.vuplus/Makefile.am
+++ b/addons/pvr.vuplus/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.vuplus
 LIBNAME         = libvuplus-addon
 lib_LTLIBRARIES = libvuplus-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/addons/pvr.wmc/Makefile.am
+++ b/addons/pvr.wmc/Makefile.am
@@ -10,7 +10,7 @@ ADDONNAME       = pvr.wmc
 LIBNAME         = libpvrwmc-addon
 lib_LTLIBRARIES = libpvrwmc-addon.la
 
-LIBS            = @abs_top_srcdir@/lib/tinyxml/libtinyxml.la
+LIBS            = @abs_top_builddir@/lib/tinyxml/libtinyxml.la
 
 include ../Makefile.include.am
 

--- a/lib/cppmyth/cppmyth/Makefile.am
+++ b/lib/cppmyth/cppmyth/Makefile.am
@@ -2,7 +2,7 @@ noinst_LTLIBRARIES = libcppmyth.la
 #lib_LTLIBRARIES    = libcppmyth.la
 
 AM_CPPFLAGS = -fPIC -Wall -Wextra \
-	-I@abs_srcdir@/src
+	-I@abs_builddir@/src
 
 libcppmyth_la_SOURCES = \
 	src/private/mythdto/mythdto.cpp \

--- a/lib/jsoncpp/Makefile.am
+++ b/lib/jsoncpp/Makefile.am
@@ -4,7 +4,7 @@ libjsoncpp_la_SOURCES = src/lib_json/json_reader.cpp \
                         src/lib_json/json_value.cpp \
                         src/lib_json/json_writer.cpp
 
-INCLUDES=-Iinclude/
+INCLUDES=-I@abs_srcdir@/include/
 
 $(LIB): libjsoncpp.la
 	cp -f .libs/libjsoncpp.a .

--- a/lib/libdvblinkremote/Makefile.am
+++ b/lib/libdvblinkremote/Makefile.am
@@ -26,9 +26,9 @@ libdvblinkremote_la_SOURCES = channel.cpp \
 			util.cpp \
 			xml_object_serializer_factory.cpp
 
-LIBS= @abs_top_srcdir@/lib/tinyxml2/libtinyxml2.la
+LDADD = @abs_top_builddir@/lib/tinyxml2/libtinyxml2.la
  
-INCLUDES=-I..
+INCLUDES=-I@abs_srcdir@/..
 
 $(LIB): libdvblinkremote.la
 	cp -f .libs/libdvblinkremote.a .


### PR DESCRIPTION
Since at leats Yocto 1.8 (fido) builds packages in VPATH, to avoid to many own hacks a project should support VPATH builds.
